### PR TITLE
Split create-sunpeak-app skill into runtime and testing skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,8 +235,9 @@ When sunpeak package APIs change (new hooks, new features, deprecations, etc.), 
 
 1. **`docs/`** — Mintlify docs pages (hook docs, MCP Apps SDK docs, cross-references)
 2. **READMEs** — `README.md` files throughout the monorepo (`packages/sunpeak/README.md`, root `README.md`, template `README.md`)
-3. **`skills/create-sunpeak-app/SKILL.md`** — Agent skill reference with hook tables, code examples, and usage patterns
-4. **This file**
+3. **`skills/create-sunpeak-app/SKILL.md`** — Agent skill for building MCP Apps (hooks, patterns, simulations)
+4. **`skills/test-mcp-server/SKILL.md`** — Agent skill for testing MCP servers (e2e, visual, live, evals)
+5. **This file**
 
 ## Upgrading Dependencies
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -24,10 +24,10 @@ This documentation is available via MCP at https://sunpeak.ai/docs/mcp, use it i
 </Tip>
 
 <Tip>
-Install the `create-sunpeak-app` coding agent skill for built-in knowledge of sunpeak patterns, hooks, simulations, and testing conventions:
+Install the sunpeak coding agent skills for built-in knowledge of patterns, hooks, simulations, and testing:
 
 ```bash
-npx skills add Sunpeak-AI/sunpeak@create-sunpeak-app
+npx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@test-mcp-server
 ```
 </Tip>
 

--- a/examples/albums-example/README.md
+++ b/examples/albums-example/README.md
@@ -150,12 +150,12 @@ Only the resource file (`.tsx`) is required to generate a production build and s
 
 Then create a tool file in `src/tools/` and simulation file(s) in `tests/simulations/` to preview your resource in `sunpeak dev`.
 
-## Coding Agent Skill
+## Coding Agent Skills
 
-Install the `create-sunpeak-app` skill to give your coding agent built-in knowledge of sunpeak patterns, hooks, simulation files, and testing conventions:
+Install the sunpeak skills to give your coding agent built-in knowledge of sunpeak patterns, hooks, and testing:
 
 ```bash
-npx skills add Sunpeak-AI/sunpeak@create-sunpeak-app
+npx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@test-mcp-server
 ```
 
 ## Troubleshooting

--- a/examples/albums-example/package.json
+++ b/examples/albums-example/package.json
@@ -17,7 +17,7 @@
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",
     "embla-carousel-wheel-gestures": "^8.1.0",
-    "sunpeak": "^0.19.6",
+    "sunpeak": "^0.19.7",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"
   },

--- a/examples/carousel-example/README.md
+++ b/examples/carousel-example/README.md
@@ -150,12 +150,12 @@ Only the resource file (`.tsx`) is required to generate a production build and s
 
 Then create a tool file in `src/tools/` and simulation file(s) in `tests/simulations/` to preview your resource in `sunpeak dev`.
 
-## Coding Agent Skill
+## Coding Agent Skills
 
-Install the `create-sunpeak-app` skill to give your coding agent built-in knowledge of sunpeak patterns, hooks, simulation files, and testing conventions:
+Install the sunpeak skills to give your coding agent built-in knowledge of sunpeak patterns, hooks, and testing:
 
 ```bash
-npx skills add Sunpeak-AI/sunpeak@create-sunpeak-app
+npx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@test-mcp-server
 ```
 
 ## Troubleshooting

--- a/examples/carousel-example/package.json
+++ b/examples/carousel-example/package.json
@@ -17,7 +17,7 @@
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",
     "embla-carousel-wheel-gestures": "^8.1.0",
-    "sunpeak": "^0.19.6",
+    "sunpeak": "^0.19.7",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"
   },

--- a/examples/map-example/README.md
+++ b/examples/map-example/README.md
@@ -150,12 +150,12 @@ Only the resource file (`.tsx`) is required to generate a production build and s
 
 Then create a tool file in `src/tools/` and simulation file(s) in `tests/simulations/` to preview your resource in `sunpeak dev`.
 
-## Coding Agent Skill
+## Coding Agent Skills
 
-Install the `create-sunpeak-app` skill to give your coding agent built-in knowledge of sunpeak patterns, hooks, simulation files, and testing conventions:
+Install the sunpeak skills to give your coding agent built-in knowledge of sunpeak patterns, hooks, and testing:
 
 ```bash
-npx skills add Sunpeak-AI/sunpeak@create-sunpeak-app
+npx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@test-mcp-server
 ```
 
 ## Troubleshooting

--- a/examples/map-example/package.json
+++ b/examples/map-example/package.json
@@ -17,7 +17,7 @@
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",
     "mapbox-gl": "^3.21.0",
-    "sunpeak": "^0.19.6",
+    "sunpeak": "^0.19.7",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"
   },

--- a/examples/review-example/README.md
+++ b/examples/review-example/README.md
@@ -150,12 +150,12 @@ Only the resource file (`.tsx`) is required to generate a production build and s
 
 Then create a tool file in `src/tools/` and simulation file(s) in `tests/simulations/` to preview your resource in `sunpeak dev`.
 
-## Coding Agent Skill
+## Coding Agent Skills
 
-Install the `create-sunpeak-app` skill to give your coding agent built-in knowledge of sunpeak patterns, hooks, simulation files, and testing conventions:
+Install the sunpeak skills to give your coding agent built-in knowledge of sunpeak patterns, hooks, and testing:
 
 ```bash
-npx skills add Sunpeak-AI/sunpeak@create-sunpeak-app
+npx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@test-mcp-server
 ```
 
 ## Troubleshooting

--- a/examples/review-example/package.json
+++ b/examples/review-example/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
-    "sunpeak": "^0.19.6",
+    "sunpeak": "^0.19.7",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"
   },

--- a/packages/sunpeak/README.md
+++ b/packages/sunpeak/README.md
@@ -127,12 +127,12 @@ sunpeak new
 | `sunpeak start`                  | Start production MCP server                 |
 | `sunpeak upgrade`                | Upgrade sunpeak to latest version           |
 
-## Coding Agent Skill
+## Coding Agent Skills
 
-Install the `create-sunpeak-app` skill to give your coding agent (Claude Code, Cursor, etc.) built-in knowledge of sunpeak patterns, hooks, simulation files, and testing conventions:
+Install the sunpeak skills to give your coding agent (Claude Code, Cursor, etc.) built-in knowledge of sunpeak patterns, hooks, and testing:
 
 ```bash
-npx skills add Sunpeak-AI/sunpeak@create-sunpeak-app
+npx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@test-mcp-server
 ```
 
 ## Troubleshooting

--- a/packages/sunpeak/bin/commands/new.mjs
+++ b/packages/sunpeak/bin/commands/new.mjs
@@ -282,20 +282,20 @@ export async function init(projectName, resourcesArg, deps = defaultDeps) {
     s.stop(`Install failed. You can try running "${pm} install" manually.`);
   }
 
-  // Offer to install the sunpeak skill (only in interactive mode)
+  // Offer to install the sunpeak skills (only in interactive mode)
   if (resourcesArg === undefined) {
     const installSkill = await d.confirm({
-      message: 'Install the sunpeak skill? (helps your coding agent build your app)',
+      message: 'Install the sunpeak skills? (helps your coding agent build and test your app)',
       initialValue: true,
     });
     if (!clack.isCancel(installSkill) && installSkill) {
       try {
-        d.execSync('npx skills add Sunpeak-AI/sunpeak@create-sunpeak-app', {
+        d.execSync('npx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@test-mcp-server', {
           cwd: targetDir,
           stdio: 'inherit',
         });
       } catch {
-        d.console.log('Skill install skipped. You can install later with: npx skills add Sunpeak-AI/sunpeak@create-sunpeak-app');
+        d.console.log('Skill install skipped. You can install later with: npx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@test-mcp-server');
       }
     }
   }

--- a/packages/sunpeak/bin/commands/test-init.mjs
+++ b/packages/sunpeak/bin/commands/test-init.mjs
@@ -1,6 +1,27 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { execSync } from 'child_process';
 import { join } from 'path';
 import * as p from '@clack/prompts';
+
+/**
+ * Default dependencies (real implementations).
+ * Override in tests via the `deps` parameter.
+ */
+export const defaultDeps = {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  execSync,
+  cwd: () => process.cwd(),
+  intro: p.intro,
+  outro: p.outro,
+  confirm: p.confirm,
+  isCancel: p.isCancel,
+  select: p.select,
+  text: p.text,
+  log: p.log,
+};
 
 /**
  * sunpeak test init — Scaffold test infrastructure for MCP servers.
@@ -10,8 +31,10 @@ import * as p from '@clack/prompts';
  * - JS/TS projects: root-level config + test files
  * - sunpeak projects: migrate to defineConfig()
  */
-export async function testInit(args = []) {
-  p.intro('Setting up sunpeak tests');
+export async function testInit(args = [], deps = defaultDeps) {
+  const d = { ...defaultDeps, ...deps };
+
+  d.intro('Setting up sunpeak tests');
 
   // Parse --server flag from CLI args
   const serverIdx = args.indexOf('--server');
@@ -20,26 +43,42 @@ export async function testInit(args = []) {
       ? args[serverIdx + 1]
       : undefined;
 
-  const projectType = detectProjectType();
+  const projectType = detectProjectType(d);
 
   if (projectType === 'sunpeak') {
-    await initSunpeakProject();
+    await initSunpeakProject(d);
   } else if (projectType === 'js') {
-    await initJsProject(cliServer);
+    await initJsProject(cliServer, d);
   } else {
-    await initExternalProject(cliServer);
+    await initExternalProject(cliServer, d);
   }
 
-  p.outro('Done!');
+  // Offer to install the testing skill
+  const installSkill = await d.confirm({
+    message: 'Install the test-mcp-server skill? (helps your coding agent write tests)',
+    initialValue: true,
+  });
+  if (!d.isCancel(installSkill) && installSkill) {
+    try {
+      d.execSync('npx skills add Sunpeak-AI/sunpeak@test-mcp-server', {
+        cwd: d.cwd(),
+        stdio: 'inherit',
+      });
+    } catch {
+      d.log.info('Skill install skipped. Install later: npx skills add Sunpeak-AI/sunpeak@test-mcp-server');
+    }
+  }
+
+  d.outro('Done!');
 }
 
-function detectProjectType() {
-  const cwd = process.cwd();
+function detectProjectType(d) {
+  const cwd = d.cwd();
   const pkgPath = join(cwd, 'package.json');
 
-  if (existsSync(pkgPath)) {
+  if (d.existsSync(pkgPath)) {
     try {
-      const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+      const pkg = JSON.parse(d.readFileSync(pkgPath, 'utf-8'));
       const deps = { ...pkg.dependencies, ...pkg.devDependencies };
       if ('sunpeak' in deps) return 'sunpeak';
       return 'js';
@@ -52,7 +91,7 @@ function detectProjectType() {
   return 'external';
 }
 
-async function getServerConfig(cliServer) {
+async function getServerConfig(cliServer, d) {
   // If provided via --server flag, detect type automatically
   if (cliServer) {
     if (cliServer.startsWith('http://') || cliServer.startsWith('https://')) {
@@ -61,7 +100,7 @@ async function getServerConfig(cliServer) {
     return { type: 'command', value: cliServer };
   }
 
-  const serverType = await p.select({
+  const serverType = await d.select({
     message: 'How does your MCP server start?',
     options: [
       { value: 'command', label: 'Command (e.g., python server.py)' },
@@ -70,23 +109,23 @@ async function getServerConfig(cliServer) {
     ],
   });
 
-  if (p.isCancel(serverType)) process.exit(0);
+  if (d.isCancel(serverType)) process.exit(0);
 
   if (serverType === 'command') {
-    const command = await p.text({
+    const command = await d.text({
       message: 'Server start command:',
       placeholder: 'python src/server.py',
     });
-    if (p.isCancel(command)) process.exit(0);
+    if (d.isCancel(command)) process.exit(0);
     return { type: 'command', value: command };
   }
 
   if (serverType === 'url') {
-    const url = await p.text({
+    const url = await d.text({
       message: 'Server URL:',
       placeholder: 'http://localhost:8000/mcp',
     });
-    if (p.isCancel(url)) process.exit(0);
+    if (d.isCancel(url)) process.exit(0);
     return { type: 'url', value: url };
   }
 
@@ -125,15 +164,16 @@ function generateServerConfigBlock(server, relativeTo = '.') {
 /**
  * Scaffold eval boilerplate into a directory.
  * @param {string} evalsDir - Directory to create eval files in
- * @param {{ server?: object, isSunpeak?: boolean }} options
+ * @param {{ server?: object, isSunpeak?: boolean, d?: object }} options
  */
-function scaffoldEvals(evalsDir, { server, isSunpeak } = {}) {
-  if (existsSync(join(evalsDir, 'eval.config.ts'))) {
-    p.log.info('Eval config already exists. Skipping eval scaffold.');
+function scaffoldEvals(evalsDir, { server, isSunpeak, d: deps } = {}) {
+  const d = deps || defaultDeps;
+  if (d.existsSync(join(evalsDir, 'eval.config.ts'))) {
+    d.log.info('Eval config already exists. Skipping eval scaffold.');
     return;
   }
 
-  mkdirSync(evalsDir, { recursive: true });
+  d.mkdirSync(evalsDir, { recursive: true });
 
   // Generate server line for eval config
   let serverLine = '  // server: \'http://localhost:8000/mcp\',';
@@ -175,10 +215,10 @@ function scaffoldEvals(evalsDir, { server, isSunpeak } = {}) {
     "",
   ];
 
-  writeFileSync(join(evalsDir, 'eval.config.ts'), configLines.join('\n'));
+  d.writeFileSync(join(evalsDir, 'eval.config.ts'), configLines.join('\n'));
 
   // Scaffold .env template
-  writeFileSync(
+  d.writeFileSync(
     join(evalsDir, '.env.example'),
     `# Copy this file to .env and fill in your API keys.
 # .env is gitignored — never commit API keys.
@@ -188,7 +228,7 @@ function scaffoldEvals(evalsDir, { server, isSunpeak } = {}) {
 `
   );
 
-  writeFileSync(
+  d.writeFileSync(
     join(evalsDir, 'example.eval.ts'),
     `import { expect } from 'vitest';
 import { defineEval } from 'sunpeak/eval';
@@ -226,24 +266,24 @@ export default defineEval({
 `
   );
 
-  p.log.success(`Created ${evalsDir}/ with eval config and example.`);
+  d.log.success(`Created ${evalsDir}/ with eval config and example.`);
 }
 
-async function initExternalProject(cliServer) {
-  p.log.info('Detected non-JS project. Creating self-contained test directory.');
+async function initExternalProject(cliServer, d) {
+  d.log.info('Detected non-JS project. Creating self-contained test directory.');
 
-  const server = await getServerConfig(cliServer);
-  const testDir = join(process.cwd(), 'tests', 'sunpeak');
+  const server = await getServerConfig(cliServer, d);
+  const testDir = join(d.cwd(), 'tests', 'sunpeak');
 
-  if (existsSync(testDir)) {
-    p.log.warn('tests/sunpeak/ already exists. Skipping scaffold.');
+  if (d.existsSync(testDir)) {
+    d.log.warn('tests/sunpeak/ already exists. Skipping scaffold.');
     return;
   }
 
-  mkdirSync(testDir, { recursive: true });
+  d.mkdirSync(testDir, { recursive: true });
 
   // package.json
-  writeFileSync(
+  d.writeFileSync(
     join(testDir, 'package.json'),
     JSON.stringify(
       {
@@ -264,7 +304,7 @@ async function initExternalProject(cliServer) {
 
   // sunpeak.config.ts (used as playwright config)
   const serverBlock = generateServerConfigBlock(server, '../..');
-  writeFileSync(
+  d.writeFileSync(
     join(testDir, 'playwright.config.ts'),
     `import { defineConfig } from 'sunpeak/test/config';
 
@@ -275,7 +315,7 @@ ${serverBlock}
   );
 
   // tsconfig.json
-  writeFileSync(
+  d.writeFileSync(
     join(testDir, 'tsconfig.json'),
     JSON.stringify(
       {
@@ -293,7 +333,7 @@ ${serverBlock}
   );
 
   // smoke test — runnable out of the box, verifies the server is reachable
-  writeFileSync(
+  d.writeFileSync(
     join(testDir, 'smoke.test.ts'),
     `import { test, expect } from 'sunpeak/test';
 
@@ -315,30 +355,30 @@ test('server is reachable and inspector loads', async ({ mcp }) => {
   );
 
   // Scaffold eval boilerplate
-  scaffoldEvals(join(testDir, 'evals'), { server });
+  scaffoldEvals(join(testDir, 'evals'), { server, d });
 
-  p.log.success('Created tests/sunpeak/ with config and starter test.');
-  p.log.step('Next steps:');
-  p.log.message('  cd tests/sunpeak');
-  p.log.message('  npm install');
-  p.log.message('  npx playwright install chromium');
-  p.log.message('  npx sunpeak test');
-  p.log.message('  npx sunpeak test --eval  (after configuring models in evals/eval.config.ts)');
+  d.log.success('Created tests/sunpeak/ with config and starter test.');
+  d.log.step('Next steps:');
+  d.log.message('  cd tests/sunpeak');
+  d.log.message('  npm install');
+  d.log.message('  npx playwright install chromium');
+  d.log.message('  npx sunpeak test');
+  d.log.message('  npx sunpeak test --eval  (after configuring models in evals/eval.config.ts)');
 }
 
-async function initJsProject(cliServer) {
-  p.log.info('Detected JS/TS project. Adding test config at project root.');
+async function initJsProject(cliServer, d) {
+  d.log.info('Detected JS/TS project. Adding test config at project root.');
 
-  const server = await getServerConfig(cliServer);
-  const cwd = process.cwd();
+  const server = await getServerConfig(cliServer, d);
+  const cwd = d.cwd();
 
   // Create playwright.config.ts
   const configPath = join(cwd, 'playwright.config.ts');
-  if (existsSync(configPath)) {
-    p.log.warn('playwright.config.ts already exists. Skipping config creation.');
+  if (d.existsSync(configPath)) {
+    d.log.warn('playwright.config.ts already exists. Skipping config creation.');
   } else {
     const serverBlock = generateServerConfigBlock(server);
-    writeFileSync(
+    d.writeFileSync(
       configPath,
       `import { defineConfig } from 'sunpeak/test/config';
 
@@ -347,16 +387,16 @@ ${serverBlock}
 });
 `
     );
-    p.log.success('Created playwright.config.ts');
+    d.log.success('Created playwright.config.ts');
   }
 
   // Create test directory and smoke test
   const testDir = join(cwd, 'tests', 'e2e');
-  mkdirSync(testDir, { recursive: true });
+  d.mkdirSync(testDir, { recursive: true });
 
   const testPath = join(testDir, 'smoke.test.ts');
-  if (!existsSync(testPath)) {
-    writeFileSync(
+  if (!d.existsSync(testPath)) {
+    d.writeFileSync(
       testPath,
       `import { test, expect } from 'sunpeak/test';
 
@@ -375,51 +415,51 @@ test('server is reachable and inspector loads', async ({ mcp }) => {
 // });
 `
     );
-    p.log.success('Created tests/e2e/smoke.test.ts');
+    d.log.success('Created tests/e2e/smoke.test.ts');
   }
 
   // Scaffold eval boilerplate
   const evalsDir = join(cwd, 'tests', 'evals');
-  scaffoldEvals(evalsDir, { server });
+  scaffoldEvals(evalsDir, { server, d });
 
-  p.log.step('Next steps:');
-  p.log.message('  npm install -D sunpeak @playwright/test');
-  p.log.message('  npx playwright install chromium');
-  p.log.message('  npx sunpeak test');
-  p.log.message('  npx sunpeak test --eval  (after configuring models in tests/evals/eval.config.ts)');
+  d.log.step('Next steps:');
+  d.log.message('  npm install -D sunpeak @playwright/test');
+  d.log.message('  npx playwright install chromium');
+  d.log.message('  npx sunpeak test');
+  d.log.message('  npx sunpeak test --eval  (after configuring models in tests/evals/eval.config.ts)');
 }
 
-async function initSunpeakProject() {
-  p.log.info('Detected sunpeak project. Updating config to use defineConfig().');
+async function initSunpeakProject(d) {
+  d.log.info('Detected sunpeak project. Updating config to use defineConfig().');
 
-  const cwd = process.cwd();
+  const cwd = d.cwd();
   const configPath = join(cwd, 'playwright.config.ts');
 
-  if (existsSync(configPath)) {
-    const content = readFileSync(configPath, 'utf-8');
+  if (d.existsSync(configPath)) {
+    const content = d.readFileSync(configPath, 'utf-8');
     if (content.includes('sunpeak/test/config')) {
-      p.log.info('Config already uses sunpeak/test/config. Nothing to do.');
+      d.log.info('Config already uses sunpeak/test/config. Nothing to do.');
     }
   } else {
-    writeFileSync(
+    d.writeFileSync(
       configPath,
       `import { defineConfig } from 'sunpeak/test/config';
 
 export default defineConfig();
 `
     );
-    p.log.success('Updated playwright.config.ts to use defineConfig()');
+    d.log.success('Updated playwright.config.ts to use defineConfig()');
   }
 
   // Scaffold eval boilerplate
   const evalsDir = join(cwd, 'tests', 'evals');
-  scaffoldEvals(evalsDir, { isSunpeak: true });
+  scaffoldEvals(evalsDir, { isSunpeak: true, d });
 
-  p.log.step('Migrate test files:');
-  p.log.message('  Replace: import { test, expect } from "@playwright/test"');
-  p.log.message('  With:    import { test, expect } from "sunpeak/test"');
-  p.log.message('');
-  p.log.message('  Use the `mcp` fixture instead of raw page navigation.');
-  p.log.message('  See sunpeak docs for migration examples.');
-  p.log.message('  Run: sunpeak test --eval  (after configuring models in tests/evals/eval.config.ts)');
+  d.log.step('Migrate test files:');
+  d.log.message('  Replace: import { test, expect } from "@playwright/test"');
+  d.log.message('  With:    import { test, expect } from "sunpeak/test"');
+  d.log.message('');
+  d.log.message('  Use the `mcp` fixture instead of raw page navigation.');
+  d.log.message('  See sunpeak docs for migration examples.');
+  d.log.message('  Run: sunpeak test --eval  (after configuring models in tests/evals/eval.config.ts)');
 }

--- a/packages/sunpeak/src/cli/commands.test.ts
+++ b/packages/sunpeak/src/cli/commands.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, vi } from 'vitest';
 // Helper functions to import CLI modules dynamically
 const importUpgrade = () => import('../../bin/commands/upgrade.mjs');
 const importNew = () => import('../../bin/commands/new.mjs');
+const importTestInit = () => import('../../bin/commands/test-init.mjs');
 
 // Mock console for all tests
 const createMockConsole = () => ({
@@ -123,6 +124,41 @@ describe('CLI Commands', () => {
       // Should have prompted and then failed on existing directory
       expect(mockConsole.error).toHaveBeenCalledWith(
         'Error: Directory "prompted-name" already exists'
+      );
+    });
+
+    it('should install both skills when user confirms in interactive mode', async () => {
+      const { init } = await importNew();
+      const mockConsole = createMockConsole();
+      const mockProcess = createMockProcess();
+      const execSyncMock = vi.fn();
+
+      await init('my-project', undefined, {
+        discoverResources: () => ['carousel'],
+        detectPackageManager: () => 'npm',
+        selectResources: vi.fn().mockResolvedValue(['carousel']),
+        existsSync: () => false,
+        mkdirSync: vi.fn(),
+        cpSync: vi.fn(),
+        readFileSync: () => JSON.stringify({ version: '1.0.0', name: 'test' }),
+        writeFileSync: vi.fn(),
+        renameSync: vi.fn(),
+        execSync: execSyncMock,
+        execAsync: noopExecAsync,
+        confirm: vi.fn().mockResolvedValue(true),
+        cwd: () => '/test',
+        templateDir: '/template',
+        rootPkgPath: '/root/package.json',
+        console: mockConsole,
+        process: mockProcess,
+        intro: noopIntro,
+        outro: noopOutro,
+        spinner: noopSpinner,
+      });
+
+      expect(execSyncMock).toHaveBeenCalledWith(
+        'npx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@test-mcp-server',
+        expect.objectContaining({ cwd: '/test/my-project', stdio: 'inherit' })
       );
     });
 
@@ -484,6 +520,149 @@ describe('CLI Commands', () => {
       expect(compareVersions('1.0.0', '1.0.1')).toBe(-1);
       expect(compareVersions('1.2.3', '1.2.4')).toBe(-1);
       expect(compareVersions('2.0.0', '1.9.9')).toBe(1);
+    });
+  });
+
+  describe('test init command', () => {
+    const noopLog = {
+      info: vi.fn(),
+      success: vi.fn(),
+      step: vi.fn(),
+      message: vi.fn(),
+      warn: vi.fn(),
+    };
+
+    const createTestInitDeps = (overrides = {}) => ({
+      existsSync: () => false,
+      readFileSync: () => '{}',
+      writeFileSync: vi.fn(),
+      mkdirSync: vi.fn(),
+      execSync: vi.fn(),
+      cwd: () => '/test/project',
+      intro: vi.fn(),
+      outro: vi.fn(),
+      confirm: vi.fn().mockResolvedValue(false),
+      isCancel: () => false,
+      select: vi.fn().mockResolvedValue('later'),
+      text: vi.fn().mockResolvedValue(''),
+      log: noopLog,
+      ...overrides,
+    });
+
+    it('should prompt to install test-mcp-server skill', async () => {
+      const { testInit } = await importTestInit();
+      const confirmMock = vi.fn().mockResolvedValue(false);
+
+      await testInit([], createTestInitDeps({ confirm: confirmMock }));
+
+      // The skill install confirm should be called (it's the only confirm in the flow for external projects)
+      expect(confirmMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Install the test-mcp-server skill? (helps your coding agent write tests)',
+        })
+      );
+    });
+
+    it('should run npx skills add when user confirms skill install', async () => {
+      const { testInit } = await importTestInit();
+      const execSyncMock = vi.fn();
+
+      await testInit(
+        [],
+        createTestInitDeps({
+          confirm: vi.fn().mockResolvedValue(true),
+          execSync: execSyncMock,
+        })
+      );
+
+      expect(execSyncMock).toHaveBeenCalledWith(
+        'npx skills add Sunpeak-AI/sunpeak@test-mcp-server',
+        expect.objectContaining({ cwd: '/test/project', stdio: 'inherit' })
+      );
+    });
+
+    it('should not run npx skills add when user declines', async () => {
+      const { testInit } = await importTestInit();
+      const execSyncMock = vi.fn();
+
+      await testInit(
+        [],
+        createTestInitDeps({
+          confirm: vi.fn().mockResolvedValue(false),
+          execSync: execSyncMock,
+        })
+      );
+
+      expect(execSyncMock).not.toHaveBeenCalledWith(
+        'npx skills add Sunpeak-AI/sunpeak@test-mcp-server',
+        expect.anything()
+      );
+    });
+
+    it('should handle skill install failure gracefully', async () => {
+      const { testInit } = await importTestInit();
+      const logInfoMock = vi.fn();
+      const execSyncMock = vi.fn().mockImplementation(() => {
+        throw new Error('npx not found');
+      });
+
+      await testInit(
+        [],
+        createTestInitDeps({
+          confirm: vi.fn().mockResolvedValue(true),
+          execSync: execSyncMock,
+          log: { ...noopLog, info: logInfoMock },
+        })
+      );
+
+      expect(logInfoMock).toHaveBeenCalledWith(
+        'Skill install skipped. Install later: npx skills add Sunpeak-AI/sunpeak@test-mcp-server'
+      );
+    });
+
+    it('should detect sunpeak project type', async () => {
+      const { testInit } = await importTestInit();
+      const writeFileSync = vi.fn();
+
+      await testInit(
+        [],
+        createTestInitDeps({
+          existsSync: (path: string) => path.includes('package.json') || false,
+          readFileSync: (path: string) => {
+            if (path.includes('package.json')) {
+              return JSON.stringify({ dependencies: { sunpeak: '*' } });
+            }
+            return '{}';
+          },
+          writeFileSync,
+        })
+      );
+
+      // For sunpeak projects, it writes playwright.config.ts with defineConfig()
+      expect(writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('playwright.config.ts'),
+        expect.stringContaining('defineConfig()')
+      );
+    });
+
+    it('should detect JS project type and use CLI server arg', async () => {
+      const { testInit } = await importTestInit();
+      const writeFileSync = vi.fn();
+
+      await testInit(
+        ['--server', 'http://localhost:9000/mcp'],
+        createTestInitDeps({
+          existsSync: (path: string) => path.includes('package.json') || false,
+          readFileSync: () => JSON.stringify({ dependencies: { express: '*' } }),
+          writeFileSync,
+        })
+      );
+
+      // For JS projects with URL server, writes config with server URL
+      expect(writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('playwright.config.ts'),
+        expect.stringContaining('http://localhost:9000/mcp')
+      );
     });
   });
 

--- a/packages/sunpeak/template/README.md
+++ b/packages/sunpeak/template/README.md
@@ -150,12 +150,12 @@ Only the resource file (`.tsx`) is required to generate a production build and s
 
 Then create a tool file in `src/tools/` and simulation file(s) in `tests/simulations/` to preview your resource in `sunpeak dev`.
 
-## Coding Agent Skill
+## Coding Agent Skills
 
-Install the `create-sunpeak-app` skill to give your coding agent built-in knowledge of sunpeak patterns, hooks, simulation files, and testing conventions:
+Install the sunpeak skills to give your coding agent built-in knowledge of sunpeak patterns, hooks, and testing:
 
 ```bash
-npx skills add Sunpeak-AI/sunpeak@create-sunpeak-app
+npx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@test-mcp-server
 ```
 
 ## Troubleshooting

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,12 +6,6 @@ settings:
 
 importers:
 
-  .:
-    dependencies:
-      sunpeak:
-        specifier: file:/Users/abe/conductor/workspaces/sunpeak/karachi-v1/packages/sunpeak
-        version: link:packages/sunpeak
-
   packages/sunpeak:
     dependencies:
       '@ai-sdk/anthropic':

--- a/skills/create-sunpeak-app/SKILL.md
+++ b/skills/create-sunpeak-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-sunpeak-app
-description: Use when working with sunpeak, or when the user asks to "build an MCP App", "build a ChatGPT App", "add a UI to an MCP tool", "create an interactive resource for Claude Connector or ChatGPT", "build a React UI for an MCP server", or needs guidance on MCP App resources, tool-to-UI data flow, simulation files, host context, platform-specific ChatGPT/Claude features, or end-to-end testing of MCP App UIs.
+description: Use when working with sunpeak, or when the user asks to "build an MCP App", "build a ChatGPT App", "add a UI to an MCP tool", "create an interactive resource for Claude Connector or ChatGPT", "build a React UI for an MCP server", or needs guidance on MCP App resources, tool-to-UI data flow, simulation files, host context, platform-specific ChatGPT/Claude features, or production builds. For testing (e2e, visual regression, live tests, evals), see the test-mcp-server skill.
 ---
 
 # Create Sunpeak App
@@ -417,20 +417,6 @@ function MyResource() {
 
 ## Commands
 
-Testing (works with any MCP server):
-```bash
-sunpeak inspect              # Inspect any MCP server in the inspector (standalone)
-sunpeak test                 # Run unit + e2e tests
-sunpeak test --unit          # Run unit tests only (vitest)
-sunpeak test --e2e           # Run e2e tests only (Playwright)
-sunpeak test --visual        # Run e2e tests with visual regression comparison
-sunpeak test --visual --update  # Update visual regression baselines
-sunpeak test init            # Scaffold test infrastructure into a project
-sunpeak test --live          # Run live tests against real ChatGPT (requires tunnel + browser session)
-sunpeak test --eval          # Run evals against multiple LLM models (requires API keys)
-```
-
-App framework (for sunpeak projects):
 ```bash
 sunpeak new         # Scaffold a new sunpeak app project
 sunpeak dev         # Start dev server (Vite + MCP server, port 3000 web / 8000 MCP)
@@ -556,144 +542,17 @@ Use MCP standard CSS variables via Tailwind arbitrary values instead of raw colo
 
 These variables use CSS `light-dark()` so they respond to theme changes automatically. The `dark:` Tailwind variant also works via `[data-theme="dark"]`.
 
-## E2E Tests with the `mcp` Fixture
+## Testing
 
-Import `test` and `expect` from `sunpeak/test`. The `mcp` fixture handles inspector navigation, double-iframe traversal, URL construction, and host selection. Tests run automatically across ChatGPT and Claude hosts via Playwright projects.
+For all testing capabilities (e2e tests, visual regression, live tests against real ChatGPT, multi-model evals, Playwright config), install the `test-mcp-server` skill:
 
-```typescript
-import { test, expect } from 'sunpeak/test';
-
-test('renders weather card', async ({ mcp }) => {
-  const result = await mcp.callTool('show-weather');
-  const app = result.app();
-  await expect(app.locator('h1')).toHaveText('Austin');
-});
-
-test('renders in dark mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-weather', {}, { theme: 'dark' });
-  const app = result.app();
-  await expect(app.locator('h1')).toBeVisible();
-});
-
-test('loads without console errors', async ({ mcp }) => {
-  const errors: string[] = [];
-  mcp.page.on('console', (msg) => {
-    if (msg.type() === 'error') errors.push(msg.text());
-  });
-
-  const result = await mcp.callTool('show-weather', {}, { theme: 'dark' });
-  const app = result.app();
-  await expect(app.locator('h1')).toBeVisible();
-
-  const unexpectedErrors = errors.filter(
-    (e) =>
-      !e.includes('[IframeResource]') &&
-      !e.includes('mcp') &&
-      !e.includes('PostMessage') &&
-      !e.includes('connect')
-  );
-  expect(unexpectedErrors).toHaveLength(0);
-});
-
-test('prod tools empty state', async ({ mcp }) => {
-  await mcp.openTool('show-weather');
-  await expect(mcp.page.locator('text=Press Run to call the tool')).toBeVisible();
-});
-
-test('pip mode (skip on Claude)', async ({ mcp }) => {
-  test.skip(mcp.host === 'claude', 'Claude does not support PiP');
-  const result = await mcp.callTool('show-weather');
-  await mcp.setDisplayMode('pip');
-  await expect(result.app().locator('h1')).toBeVisible({ timeout: 5000 });
-});
+```bash
+npx skills add Sunpeak-AI/sunpeak@test-mcp-server
 ```
 
-### `mcp` Fixture API
+The testing skill works with any MCP server (not just sunpeak projects). Simulations (above) are part of the dev workflow and defined here. Tests consume them via the `mcp` fixture.
 
-| Method | Description |
-|--------|-------------|
-| `callTool(name, input?, options?)` | Navigate to simulation, wait for render, return `ToolResult` |
-| `openTool(name, options?)` | Navigate to tool with no mock data ("Press Run" state) |
-| `runTool()` | Click Run button, wait for resource, return `ToolResult` |
-| `setTheme(theme)` | Switch to `'light'` or `'dark'` via sidebar |
-| `setDisplayMode(mode)` | Switch to `'inline'`, `'pip'`, or `'fullscreen'` via sidebar |
-| `screenshot(name?, options?)` | Take a screenshot and compare against a baseline (only runs with `--visual`) |
-| `page` | Raw Playwright `Page` for chrome-level assertions |
-| `host` | Current host ID (`'chatgpt'` or `'claude'`) from Playwright project |
-
-### `ToolResult` API
-
-| Property/Method | Description |
-|--------|-------------|
-| `app()` | Get FrameLocator for rendered resource UI (handles double-iframe) |
-| `content` | Raw MCP content items |
-| `structuredContent` | Structured content from tool response |
-| `isError` | Whether the tool returned an error |
-
-### MCP-Native Matchers
-
-| Matcher | Description |
-|---------|-------------|
-| `expect(result).toBeError()` | Assert tool result is an error |
-| `expect(result).toHaveTextContent(str)` | Assert any content text contains string |
-| `expect(result).toHaveStructuredContent(shape)` | Assert structuredContent matches shape |
-| `expect(result).toHaveContentType(type)` | Assert content includes item of given type |
-
-### `callTool` Options
-
-| Option | Type | Description |
-|--------|------|-------------|
-| `theme` | `'light' \| 'dark'` | Color theme (default: inspector default) |
-| `displayMode` | `'inline' \| 'pip' \| 'fullscreen'` | Display mode |
-| `prodResources` | `boolean` | Use production-built resource bundles |
-
-### Visual Regression Testing
-
-Use `mcp.screenshot()` to capture and compare screenshots against saved baselines. Comparisons only run with `sunpeak test --visual`. Without it, `screenshot()` silently skips, so you can include it in regular e2e tests.
-
-```typescript
-import { test, expect } from 'sunpeak/test';
-
-test('albums renders correctly', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { theme: 'light' });
-  const app = result.app();
-  await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
-
-  await mcp.screenshot('albums-light');
-});
-```
-
-`screenshot()` options:
-
-| Option | Type | Description |
-|--------|------|-------------|
-| `target` | `'app' \| 'page'` | What to capture: `'app'` (inner iframe, default) or `'page'` (full inspector) |
-| `element` | `Locator` | Specific locator to screenshot instead of the default target |
-| `threshold` | `number` | Pixel comparison threshold (0-1) |
-| `maxDiffPixelRatio` | `number` | Maximum allowed ratio of differing pixels (0-1) |
-
-All Playwright `toHaveScreenshot` options are passed through.
-
-Configure project-wide visual defaults:
-
-```typescript
-import { defineConfig } from 'sunpeak/test/config';
-export default defineConfig({
-  visual: {
-    threshold: 0.2,
-    maxDiffPixelRatio: 0.05,
-  },
-});
-```
-
-### Playwright Config
-
-```typescript
-// playwright.config.ts
-import { defineConfig } from 'sunpeak/test/config';
-export default defineConfig();
-// Creates per-host projects (chatgpt, claude). Tests run once per host automatically.
-```
+For testing commands, see the `test-mcp-server` skill. Quick reference: `sunpeak test` (unit + e2e), `sunpeak test --visual` (visual regression), `sunpeak test --live` (real ChatGPT), `sunpeak test --eval` (multi-model evals).
 
 ## ResourceConfig Fields
 
@@ -716,152 +575,14 @@ export const resource: ResourceConfig = {
 };
 ```
 
-## Live Testing (against real ChatGPT)
-
-Live tests validate MCP Apps inside real ChatGPT. They use Playwright to open the user's browser, send messages that trigger tool calls, and assert on the rendered app iframe.
-
-### Live Test Pattern
-
-One spec file per resource. Import `test` and `expect` from `sunpeak/test/live` — the `live` fixture handles login, MCP refresh, and host-specific message formatting.
-
-```typescript
-// tests/live/weather.spec.ts
-import { test, expect } from 'sunpeak/test/live';
-
-test('weather tool renders forecast', async ({ live }) => {
-  const app = await live.invoke('show me the weather in Austin');
-  await expect(app.locator('h1')).toBeVisible();
-});
-```
-
-Config is a one-liner:
-```typescript
-// tests/live/playwright.config.ts
-import { defineLiveConfig } from 'sunpeak/test/live/config';
-export default defineLiveConfig();
-// Add hosts: defineLiveConfig({ hosts: ['chatgpt', 'claude'] })
-// Generates one Playwright project per host. Tests switch themes internally via live.setColorScheme().
-```
-
-### live Fixture API
-
-| Method | Description |
-|--------|-------------|
-| `invoke(prompt)` | Start new chat, send prompt, return app FrameLocator (one-liner) |
-| `startNewChat()` | Start a new conversation (for multi-step flows) |
-| `sendMessage(text)` | Send a message with host-appropriate formatting |
-| `sendRawMessage(text)` | Send a message without prefix |
-| `waitForAppIframe({ timeout })` | Wait for MCP app iframe to render (default 90s) |
-| `getAppIframe()` | Get FrameLocator for the app iframe |
-| `setColorScheme(scheme, appFrame?)` | Switch the host to `'light'` or `'dark'` theme. Optionally pass an app FrameLocator to wait for it to update. |
-| `page` | Raw Playwright `Page` object for advanced assertions |
-
-### Running
-
-```bash
-# Requires: tunnel running (ngrok http 8000) + logged into ChatGPT in your browser
-pnpm test:live
-
-# Or via validate pipeline
-sunpeak validate --live
-```
-
-The browser opens visibly — headless mode is blocked by chatgpt.com's bot detection.
-
-The live test runner imports your browser session, starts `sunpeak dev --prod-resources`, and refreshes the MCP server connection in ChatGPT once in globalSetup before all workers. Tests run in parallel — each test gets its own chat window.
-
-**If auth fails:** If tests report "Not logged into ChatGPT", delete `.auth/` and re-run `pnpm test:live` — a browser window will open for you to log in again.
-
-## Evals (Multi-Model Tool Calling)
-
-Evals test whether different LLMs call your tools correctly. They connect to your MCP server, discover tools via MCP protocol, and send prompts to multiple models to check tool calling behavior. Each case runs N times per model to measure reliability.
-
-### Setup
-
-```bash
-pnpm add ai @ai-sdk/openai @ai-sdk/anthropic @ai-sdk/google
-```
-
-Copy `tests/evals/.env.example` to `tests/evals/.env` and add your API keys. The `.env` file is gitignored and loaded automatically when running evals. For sunpeak projects, the dev server starts automatically.
-
-### Configuration (`tests/evals/eval.config.ts`)
-
-```typescript
-import { defineEvalConfig } from 'sunpeak/eval';
-
-// API keys are loaded automatically from tests/evals/.env (gitignored).
-
-export default defineEvalConfig({
-  // Server is auto-detected for sunpeak projects.
-  // For non-sunpeak projects: server: 'http://localhost:8000/mcp',
-
-  models: ['gpt-4o', 'gpt-4o-mini', 'o4-mini', 'claude-sonnet-4-20250514', 'gemini-2.0-flash'],
-  defaults: {
-    runs: 10,
-    maxSteps: 1,
-    temperature: 0,
-    timeout: 30_000,
-  },
-});
-```
-
-### Writing Evals (`tests/evals/*.eval.ts`)
-
-```typescript
-import { expect } from 'vitest';
-import { defineEval } from 'sunpeak/eval';
-
-export default defineEval({
-  cases: [
-    {
-      name: 'food category request',
-      prompt: 'Show me photos from my Austin pizza tour',
-      expect: {
-        tool: 'show-albums',
-        args: { search: expect.stringMatching(/pizza|austin/i) },
-      },
-    },
-    {
-      name: 'multi-step flow',
-      prompt: 'Write a post for X and LinkedIn',
-      maxSteps: 3,
-      expect: [
-        { tool: 'review-post' },
-        { tool: 'publish-post' },
-      ],
-    },
-    {
-      name: 'custom assertion',
-      prompt: 'Show me vacation photos',
-      assert: (result) => {
-        expect(result.toolCalls).toHaveLength(1);
-        expect(result.toolCalls[0].name).toBe('show-albums');
-      },
-    },
-  ],
-});
-```
-
-Three assertion levels: single tool (`expect: { tool, args }`), ordered sequence (`expect: [...]`), or custom function (`assert: (result) => { ... }`). Args use partial matching — extra keys in the actual call are allowed.
-
-### Running
-
-```bash
-sunpeak test --eval                          # All evals
-sunpeak test --eval tests/evals/albums.eval.ts  # Single file
-```
-
-Not included in the default `sunpeak test` run (costs money, like `--live`).
-
 ## Common Mistakes
 
 1. **Hooks before early returns** — All hooks must run unconditionally. Move `useMemo`/`useEffect` above any `if (...) return` blocks.
 2. **Missing `<SafeArea>`** — Always wrap content in `<SafeArea>` to respect host safe area insets.
-3. **Wrong Playwright locator** — Use `result.app().locator(...)` (from `mcp.callTool()`) for resource content. This handles the double-iframe sandbox architecture. Use `mcp.page.locator(...)` only for inspector chrome elements.
-4. **Hardcoded colors** — Use MCP standard CSS variables via Tailwind arbitrary values (`text-[var(--color-text-primary)]`, `bg-[var(--color-background-primary)]`) not raw colors.
-5. **Simulation tool mismatch** — The `"tool"` field in simulation JSON must match a tool filename in `src/tools/` (e.g. `"tool": "show-weather"` matches `src/tools/show-weather.ts`).
-6. **Mutating hook params** — Use `eslint-disable-next-line react-hooks/immutability` for `app.onteardown = ...` (class setter, not a mutation).
-7. **Forgetting text fallback** — Include `toolResult.content[]` in simulations for non-UI hosts.
+3. **Hardcoded colors** — Use MCP standard CSS variables via Tailwind arbitrary values (`text-[var(--color-text-primary)]`, `bg-[var(--color-background-primary)]`) not raw colors.
+4. **Simulation tool mismatch** — The `"tool"` field in simulation JSON must match a tool filename in `src/tools/` (e.g. `"tool": "show-weather"` matches `src/tools/show-weather.ts`).
+5. **Mutating hook params** — Use `eslint-disable-next-line react-hooks/immutability` for `app.onteardown = ...` (class setter, not a mutation).
+6. **Forgetting text fallback** — Include `toolResult.content[]` in simulations for non-UI hosts.
 
 ## Troubleshooting: App Not Rendering in ChatGPT/Claude
 
@@ -887,15 +608,9 @@ Full troubleshooting guide: https://sunpeak.ai/docs/guides/troubleshooting
 | `sunpeak/claude` | Claude host shell + Inspector re-export |
 | `sunpeak/host` | Host detection (`isChatGPT`, `isClaude`, `detectHost`) |
 | `sunpeak/host/chatgpt` | ChatGPT-specific hooks (`useUploadFile`, `useRequestModal`, `useRequestCheckout`) |
-| `sunpeak/test` | MCP-first Playwright fixtures (`test` with `mcp` fixture, `expect` with MCP-native matchers) |
-| `sunpeak/test/config` | Playwright config factory (`defineConfig` for e2e tests) |
-| `sunpeak/test/live` | Host-agnostic Playwright fixtures for live testing (`test` with `live` fixture, `expect`, `setColorScheme`) |
-| `sunpeak/test/live/config` | Live test config factory (`defineLiveConfig` with `hosts` array) |
-| `sunpeak/test/live/chatgpt` | ChatGPT-specific Playwright fixtures (`test` with `chatgpt` fixture) |
-| `sunpeak/test/live/chatgpt/config` | ChatGPT-specific Playwright config factory |
-| `sunpeak/test/inspect/config` | Inspect config factory for external MCP servers (`defineInspectConfig`) |
-| `sunpeak/eval` | Eval framework (`defineEval`, `defineEvalConfig`) for multi-model tool calling evals |
 | `sunpeak/style.css` | Main stylesheet |
+
+For testing export paths (`sunpeak/test`, `sunpeak/eval`, etc.), see the `test-mcp-server` skill.
 
 ## References
 

--- a/skills/test-mcp-server/SKILL.md
+++ b/skills/test-mcp-server/SKILL.md
@@ -1,0 +1,379 @@
+---
+name: test-mcp-server
+description: Use when testing MCP servers -- e2e tests with the sunpeak inspector, visual regression testing, live testing against real ChatGPT, multi-model evals, Playwright configuration, or scaffolding test infrastructure with "sunpeak test init". Works with any MCP server (Python, Go, TypeScript, etc.), not just sunpeak projects.
+---
+
+# Test MCP Server
+
+sunpeak includes a testing framework that works with any MCP server, regardless of language or framework. It provides four testing layers: e2e tests (inspector-based), visual regression, live tests (against real ChatGPT), and evals (multi-model tool calling).
+
+For sunpeak app projects, testing integrates automatically. For non-sunpeak MCP servers (Python, Go, Rust, etc.), `sunpeak test init` scaffolds a self-contained test directory.
+
+## Getting Started
+
+```bash
+sunpeak test init                        # Interactive setup (detects project type)
+sunpeak test init --server http://localhost:8000/mcp  # URL-based server
+sunpeak test init --server "python server.py"         # Command-based server
+```
+
+`sunpeak test init` detects three project types:
+- **sunpeak projects** -- Adds `defineConfig()` and eval boilerplate
+- **JS/TS projects** -- Adds Playwright config, smoke test, and evals at project root
+- **Non-JS projects** -- Creates a self-contained `tests/sunpeak/` directory with its own `package.json`
+
+## Getting Reference Code
+
+Clone the sunpeak repo for working test examples:
+
+```bash
+git clone --depth 1 https://github.com/Sunpeak-AI/sunpeak /tmp/sunpeak
+```
+
+Test examples live at `/tmp/sunpeak/packages/sunpeak/template/tests/`. This includes e2e tests, simulations, evals, and live tests.
+
+## Commands
+
+```bash
+sunpeak inspect              # Inspect any MCP server in the inspector (standalone)
+sunpeak test                 # Run unit + e2e tests
+sunpeak test --unit          # Run unit tests only (vitest)
+sunpeak test --e2e           # Run e2e tests only (Playwright)
+sunpeak test --visual        # Run e2e tests with visual regression comparison
+sunpeak test --visual --update  # Update visual regression baselines
+sunpeak test init            # Scaffold test infrastructure into a project
+sunpeak test --live          # Run live tests against real ChatGPT (requires tunnel + browser session)
+sunpeak test --eval          # Run evals against multiple LLM models (requires API keys)
+```
+
+Flags are additive: `--unit --e2e --live --eval` runs all four. `--update` implies `--visual`. `--eval` and `--live` are never included in the default run (they cost money).
+
+## E2E Tests with the `mcp` Fixture
+
+Import `test` and `expect` from `sunpeak/test`. The `mcp` fixture handles inspector navigation, double-iframe traversal, URL construction, and host selection. Tests run automatically across ChatGPT and Claude hosts via Playwright projects.
+
+```typescript
+import { test, expect } from 'sunpeak/test';
+
+test('renders weather card', async ({ mcp }) => {
+  const result = await mcp.callTool('show-weather');
+  const app = result.app();
+  await expect(app.locator('h1')).toHaveText('Austin');
+});
+
+test('renders in dark mode', async ({ mcp }) => {
+  const result = await mcp.callTool('show-weather', {}, { theme: 'dark' });
+  const app = result.app();
+  await expect(app.locator('h1')).toBeVisible();
+});
+
+test('loads without console errors', async ({ mcp }) => {
+  const errors: string[] = [];
+  mcp.page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text());
+  });
+
+  const result = await mcp.callTool('show-weather', {}, { theme: 'dark' });
+  const app = result.app();
+  await expect(app.locator('h1')).toBeVisible();
+
+  const unexpectedErrors = errors.filter(
+    (e) =>
+      !e.includes('[IframeResource]') &&
+      !e.includes('mcp') &&
+      !e.includes('PostMessage') &&
+      !e.includes('connect')
+  );
+  expect(unexpectedErrors).toHaveLength(0);
+});
+
+test('prod tools empty state', async ({ mcp }) => {
+  await mcp.openTool('show-weather');
+  await expect(mcp.page.locator('text=Press Run to call the tool')).toBeVisible();
+});
+
+test('pip mode (skip on Claude)', async ({ mcp }) => {
+  test.skip(mcp.host === 'claude', 'Claude does not support PiP');
+  const result = await mcp.callTool('show-weather');
+  await mcp.setDisplayMode('pip');
+  await expect(result.app().locator('h1')).toBeVisible({ timeout: 5000 });
+});
+```
+
+### `mcp` Fixture API
+
+| Method | Description |
+|--------|-------------|
+| `callTool(name, input?, options?)` | Navigate to simulation, wait for render, return `ToolResult` |
+| `openTool(name, options?)` | Navigate to tool with no mock data ("Press Run" state) |
+| `runTool()` | Click Run button, wait for resource, return `ToolResult` |
+| `setTheme(theme)` | Switch to `'light'` or `'dark'` via sidebar |
+| `setDisplayMode(mode)` | Switch to `'inline'`, `'pip'`, or `'fullscreen'` via sidebar |
+| `screenshot(name?, options?)` | Take a screenshot and compare against a baseline (only runs with `--visual`) |
+| `page` | Raw Playwright `Page` for chrome-level assertions |
+| `host` | Current host ID (`'chatgpt'` or `'claude'`) from Playwright project |
+
+### `ToolResult` API
+
+| Property/Method | Description |
+|--------|-------------|
+| `app()` | Get FrameLocator for rendered resource UI (handles double-iframe) |
+| `content` | Raw MCP content items |
+| `structuredContent` | Structured content from tool response |
+| `isError` | Whether the tool returned an error |
+
+### MCP-Native Matchers
+
+| Matcher | Description |
+|---------|-------------|
+| `expect(result).toBeError()` | Assert tool result is an error |
+| `expect(result).toHaveTextContent(str)` | Assert any content text contains string |
+| `expect(result).toHaveStructuredContent(shape)` | Assert structuredContent matches shape |
+| `expect(result).toHaveContentType(type)` | Assert content includes item of given type |
+
+### `callTool` Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `theme` | `'light' \| 'dark'` | Color theme (default: inspector default) |
+| `displayMode` | `'inline' \| 'pip' \| 'fullscreen'` | Display mode |
+| `prodResources` | `boolean` | Use production-built resource bundles |
+
+### Visual Regression Testing
+
+Use `mcp.screenshot()` to capture and compare screenshots against saved baselines. Comparisons only run with `sunpeak test --visual`. Without it, `screenshot()` silently skips, so you can include it in regular e2e tests.
+
+```typescript
+import { test, expect } from 'sunpeak/test';
+
+test('albums renders correctly', async ({ mcp }) => {
+  const result = await mcp.callTool('show-albums', {}, { theme: 'light' });
+  const app = result.app();
+  await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
+
+  await mcp.screenshot('albums-light');
+});
+```
+
+`screenshot()` options:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `target` | `'app' \| 'page'` | What to capture: `'app'` (inner iframe, default) or `'page'` (full inspector) |
+| `element` | `Locator` | Specific locator to screenshot instead of the default target |
+| `threshold` | `number` | Pixel comparison threshold (0-1) |
+| `maxDiffPixelRatio` | `number` | Maximum allowed ratio of differing pixels (0-1) |
+
+All Playwright `toHaveScreenshot` options are passed through.
+
+Configure project-wide visual defaults:
+
+```typescript
+import { defineConfig } from 'sunpeak/test/config';
+export default defineConfig({
+  visual: {
+    threshold: 0.2,
+    maxDiffPixelRatio: 0.05,
+  },
+});
+```
+
+### Playwright Config
+
+```typescript
+// playwright.config.ts
+import { defineConfig } from 'sunpeak/test/config';
+export default defineConfig();
+// Creates per-host projects (chatgpt, claude). Tests run once per host automatically.
+```
+
+For non-sunpeak MCP servers, pass a `server` option:
+
+```typescript
+import { defineConfig } from 'sunpeak/test/config';
+export default defineConfig({
+  server: {
+    url: 'http://localhost:8000/mcp',
+  },
+});
+
+// Or with a command:
+export default defineConfig({
+  server: {
+    command: 'python',
+    args: ['server.py'],
+  },
+});
+```
+
+### Locator Rules
+
+Resource content renders inside a double-iframe (outer sandbox proxy + inner app iframe). In e2e tests:
+- Use `result.app().locator(...)` (from `mcp.callTool()`) for resource content. This handles the double-iframe sandbox architecture.
+- Use `mcp.page.locator(...)` only for inspector chrome elements (header, `#root`, sidebar controls).
+
+## Simulations
+
+E2e tests consume simulation fixtures defined in `tests/simulations/*.json`. For sunpeak projects, simulations are part of the app project structure (see the `create-sunpeak-app` skill for the simulation file format). For non-sunpeak servers, `callTool` connects to the live server via the configured `server` option.
+
+## Live Testing (against real ChatGPT)
+
+Live tests validate MCP Apps inside real ChatGPT. They use Playwright to open the user's browser, send messages that trigger tool calls, and assert on the rendered app iframe.
+
+### Live Test Pattern
+
+One spec file per resource. Import `test` and `expect` from `sunpeak/test/live` -- the `live` fixture handles login, MCP refresh, and host-specific message formatting.
+
+```typescript
+// tests/live/weather.spec.ts
+import { test, expect } from 'sunpeak/test/live';
+
+test('weather tool renders forecast', async ({ live }) => {
+  const app = await live.invoke('show me the weather in Austin');
+  await expect(app.locator('h1')).toBeVisible();
+});
+```
+
+Config is a one-liner:
+```typescript
+// tests/live/playwright.config.ts
+import { defineLiveConfig } from 'sunpeak/test/live/config';
+export default defineLiveConfig();
+// Add hosts: defineLiveConfig({ hosts: ['chatgpt', 'claude'] })
+// Generates one Playwright project per host. Tests switch themes internally via live.setColorScheme().
+```
+
+### live Fixture API
+
+| Method | Description |
+|--------|-------------|
+| `invoke(prompt)` | Start new chat, send prompt, return app FrameLocator (one-liner) |
+| `startNewChat()` | Start a new conversation (for multi-step flows) |
+| `sendMessage(text)` | Send a message with host-appropriate formatting |
+| `sendRawMessage(text)` | Send a message without prefix |
+| `waitForAppIframe({ timeout })` | Wait for MCP app iframe to render (default 90s) |
+| `getAppIframe()` | Get FrameLocator for the app iframe |
+| `setColorScheme(scheme, appFrame?)` | Switch the host to `'light'` or `'dark'` theme. Optionally pass an app FrameLocator to wait for it to update. |
+| `page` | Raw Playwright `Page` object for advanced assertions |
+
+### Running
+
+```bash
+# Requires: tunnel running (ngrok http 8000) + logged into ChatGPT in your browser
+pnpm test:live
+
+# Or via validate pipeline
+sunpeak validate --live
+```
+
+The browser opens visibly -- headless mode is blocked by chatgpt.com's bot detection.
+
+The live test runner imports your browser session, starts `sunpeak dev --prod-resources`, and refreshes the MCP server connection in ChatGPT once in globalSetup before all workers. Tests run in parallel -- each test gets its own chat window.
+
+**If auth fails:** If tests report "Not logged into ChatGPT", delete `.auth/` and re-run `pnpm test:live` -- a browser window will open for you to log in again.
+
+## Evals (Multi-Model Tool Calling)
+
+Evals test whether different LLMs call your tools correctly. They connect to your MCP server, discover tools via MCP protocol, and send prompts to multiple models to check tool calling behavior. Each case runs N times per model to measure reliability.
+
+### Setup
+
+```bash
+pnpm add ai @ai-sdk/openai @ai-sdk/anthropic @ai-sdk/google
+```
+
+Copy `tests/evals/.env.example` to `tests/evals/.env` and add your API keys. The `.env` file is gitignored and loaded automatically when running evals. For sunpeak projects, the dev server starts automatically.
+
+### Configuration (`tests/evals/eval.config.ts`)
+
+```typescript
+import { defineEvalConfig } from 'sunpeak/eval';
+
+// API keys are loaded automatically from tests/evals/.env (gitignored).
+
+export default defineEvalConfig({
+  // Server is auto-detected for sunpeak projects.
+  // For non-sunpeak projects: server: 'http://localhost:8000/mcp',
+
+  models: ['gpt-4o', 'gpt-4o-mini', 'o4-mini', 'claude-sonnet-4-20250514', 'gemini-2.0-flash'],
+  defaults: {
+    runs: 10,
+    maxSteps: 1,
+    temperature: 0,
+    timeout: 30_000,
+  },
+});
+```
+
+### Writing Evals (`tests/evals/*.eval.ts`)
+
+```typescript
+import { expect } from 'vitest';
+import { defineEval } from 'sunpeak/eval';
+
+export default defineEval({
+  cases: [
+    {
+      name: 'food category request',
+      prompt: 'Show me photos from my Austin pizza tour',
+      expect: {
+        tool: 'show-albums',
+        args: { search: expect.stringMatching(/pizza|austin/i) },
+      },
+    },
+    {
+      name: 'multi-step flow',
+      prompt: 'Write a post for X and LinkedIn',
+      maxSteps: 3,
+      expect: [
+        { tool: 'review-post' },
+        { tool: 'publish-post' },
+      ],
+    },
+    {
+      name: 'custom assertion',
+      prompt: 'Show me vacation photos',
+      assert: (result) => {
+        expect(result.toolCalls).toHaveLength(1);
+        expect(result.toolCalls[0].name).toBe('show-albums');
+      },
+    },
+  ],
+});
+```
+
+Three assertion levels: single tool (`expect: { tool, args }`), ordered sequence (`expect: [...]`), or custom function (`assert: (result) => { ... }`). Args use partial matching -- extra keys in the actual call are allowed.
+
+### Running
+
+```bash
+sunpeak test --eval                          # All evals
+sunpeak test --eval tests/evals/albums.eval.ts  # Single file
+```
+
+Not included in the default `sunpeak test` run (costs money, like `--live`).
+
+## Common Mistakes
+
+1. **Wrong Playwright locator** -- Use `result.app().locator(...)` (from `mcp.callTool()`) for resource content. This handles the double-iframe sandbox architecture. Use `mcp.page.locator(...)` only for inspector chrome elements.
+2. **Simulation tool mismatch** -- The `"tool"` field in simulation JSON must match a tool filename in `src/tools/` (e.g. `"tool": "show-weather"` matches `src/tools/show-weather.ts`).
+3. **Missing console error filter** -- When testing for console errors, always filter out expected MCP handshake errors (`[IframeResource]`, `mcp`, `PostMessage`, `connect`).
+
+## Export Paths
+
+| Import | Contents |
+|--------|----------|
+| `sunpeak/test` | MCP-first Playwright fixtures (`test` with `mcp` fixture, `expect` with MCP-native matchers) |
+| `sunpeak/test/config` | Playwright config factory (`defineConfig` for e2e tests) |
+| `sunpeak/test/live` | Host-agnostic Playwright fixtures for live testing (`test` with `live` fixture, `expect`, `setColorScheme`) |
+| `sunpeak/test/live/config` | Live test config factory (`defineLiveConfig` with `hosts` array) |
+| `sunpeak/test/live/chatgpt` | ChatGPT-specific Playwright fixtures (`test` with `chatgpt` fixture) |
+| `sunpeak/test/live/chatgpt/config` | ChatGPT-specific Playwright config factory |
+| `sunpeak/test/inspect/config` | Inspect config factory for external MCP servers (`defineInspectConfig`) |
+| `sunpeak/eval` | Eval framework (`defineEval`, `defineEvalConfig`) for multi-model tool calling evals |
+
+## References
+
+- [sunpeak Documentation](https://sunpeak.ai/docs)
+- [MCP Apps Documentation](https://sunpeak.ai/docs/mcp-apps/introduction)
+- [MCP Apps SDK](https://github.com/modelcontextprotocol/ext-apps)


### PR DESCRIPTION
## Summary

- Creates a new `test-mcp-server` skill covering all testing layers (e2e, visual regression, live tests, evals, Playwright config) as a standalone skill that works with any MCP server
- Strips testing sections from `create-sunpeak-app` and adds cross-references to the new testing skill
- `sunpeak new` now installs both skills during interactive setup; `sunpeak test init` prompts to install the testing skill
- Refactors `test-init.mjs` to support dependency injection (consistent with `new.mjs` pattern) and adds unit tests for the skill installation prompt
- Updates all READMEs, docs/index.mdx, and CLAUDE.md to reference both skills

## Test plan

- [x] `pnpm validate` passes (lint, typecheck, build, 325 unit tests, 22 e2e tests, examples, visual regression, production server, inspect mode, dev server)
- [x] Integration-tested `sunpeak new` and `sunpeak test init` skill prompts via DI
- [x] Verified both skills are self-contained with no dangling cross-references