### PR TITLE
Scaffold all 5 test types in sunpeak test init

### DIFF
--- a/packages/sunpeak/bin/commands/test-init.mjs
+++ b/packages/sunpeak/bin/commands/test-init.mjs
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { execSync } from 'child_process';
-import { join } from 'path';
+import { join, dirname } from 'path';
 import * as p from '@clack/prompts';
 
 /**
@@ -30,6 +30,13 @@ export const defaultDeps = {
  * - Non-JS projects: self-contained tests/sunpeak/ directory
  * - JS/TS projects: root-level config + test files
  * - sunpeak projects: migrate to defineConfig()
+ *
+ * Scaffolds all 5 test types:
+ * 1. E2E tests — Playwright-based inspector tests (mcp fixture)
+ * 2. Visual regression — Screenshot comparison via mcp.screenshot()
+ * 3. Live tests — Test against real ChatGPT/Claude hosts
+ * 4. Evals — Multi-model tool calling reliability tests
+ * 5. Unit tests — Direct tool handler tests (JS/TS projects only)
  */
 export async function testInit(args = [], deps = defaultDeps) {
   const d = { ...defaultDeps, ...deps };
@@ -230,8 +237,7 @@ function scaffoldEvals(evalsDir, { server, isSunpeak, d: deps } = {}) {
 
   d.writeFileSync(
     join(evalsDir, 'example.eval.ts'),
-    `import { expect } from 'vitest';
-import { defineEval } from 'sunpeak/eval';
+    `import { defineEval } from 'sunpeak/eval';
 
 /**
  * Example eval — tests whether LLMs call your tools correctly.
@@ -267,6 +273,199 @@ export default defineEval({
   );
 
   d.log.success(`Created ${evalsDir}/ with eval config and example.`);
+}
+
+/**
+ * Scaffold a visual regression test file.
+ * @param {string} filePath - Full path to the visual test file
+ * @param {object} d - Dependencies
+ */
+function scaffoldVisualTest(filePath, d) {
+  if (d.existsSync(filePath)) {
+    d.log.info('Visual test already exists. Skipping.');
+    return;
+  }
+
+  d.writeFileSync(
+    filePath,
+    `import { test, expect } from 'sunpeak/test';
+
+/**
+ * Visual regression tests — compare screenshots against saved baselines.
+ *
+ * Screenshots only run with: sunpeak test --visual
+ * Update baselines with:     sunpeak test --visual --update
+ *
+ * During normal \`sunpeak test\` runs, screenshot() calls are silently
+ * skipped so these tests still pass without baselines.
+ *
+ * Uncomment the tests below and replace 'your-tool' with your tool name.
+ */
+
+// test('tool renders correctly in light mode', async ({ mcp }) => {
+//   const result = await mcp.callTool('your-tool', { key: 'value' }, { theme: 'light' });
+//   expect(result).not.toBeError();
+//
+//   // Wait for UI to render, then screenshot:
+//   // const app = result.app();
+//   // await expect(app.getByText('Expected text')).toBeVisible();
+//   // await mcp.screenshot('tool-light');
+// });
+
+// test('tool renders correctly in dark mode', async ({ mcp }) => {
+//   const result = await mcp.callTool('your-tool', { key: 'value' }, { theme: 'dark' });
+//   expect(result).not.toBeError();
+//
+//   // const app = result.app();
+//   // await expect(app.getByText('Expected text')).toBeVisible();
+//   // await mcp.screenshot('tool-dark');
+// });
+
+// Full-page screenshot (captures the inspector chrome too):
+// test('full page renders correctly', async ({ mcp }) => {
+//   const result = await mcp.callTool('your-tool', {}, { theme: 'light' });
+//   const app = result.app();
+//   await expect(app.getByText('Expected text')).toBeVisible();
+//   await mcp.screenshot('tool-page', { target: 'page', maxDiffPixelRatio: 0.02 });
+// });
+`
+  );
+  d.log.success(`Created ${filePath}`);
+}
+
+/**
+ * Scaffold live test boilerplate (test against real ChatGPT/Claude).
+ * @param {string} liveDir - Directory to create live test files in
+ * @param {{ isSunpeak?: boolean, d: object }} options
+ */
+function scaffoldLiveTests(liveDir, { isSunpeak, d } = {}) {
+  if (d.existsSync(join(liveDir, 'playwright.config.ts'))) {
+    d.log.info('Live test config already exists. Skipping live test scaffold.');
+    return;
+  }
+
+  d.mkdirSync(liveDir, { recursive: true });
+
+  // Live test playwright config
+  const liveConfigPreamble = `import { defineLiveConfig } from 'sunpeak/test/live/config';
+
+/**
+ * Live tests run against real AI hosts (ChatGPT, Claude).
+ *
+ * Prerequisites:
+ * 1. Your MCP server must be accessible via a public URL (e.g., ngrok tunnel)
+ * 2. The server must be registered as an MCP action in the host
+ * 3. Run: sunpeak test --live
+ *
+ * On first run, a browser window opens for you to log in to the host.
+ * The session is saved for subsequent runs (typically lasts a few hours).`;
+
+  const liveConfigExport = `export default defineLiveConfig({
+  // hosts: ['chatgpt'],           // Which hosts to test against
+  // colorScheme: 'light',         // Default color scheme
+  // viewport: { width: 1280, height: 720 },
+  devOverlay: false,
+});
+`;
+
+  const configContent = isSunpeak
+    ? `${liveConfigPreamble}
+ */
+${liveConfigExport}`
+    : `${liveConfigPreamble}
+ *
+ * NOTE: defineLiveConfig() starts a local sunpeak dev server as its backend.
+ * If your MCP server is not a sunpeak project, you may need to customize the
+ * webServer option in the Playwright config below to start your own server,
+ * or remove webServer entirely if your server is already running.
+ */
+${liveConfigExport}`;
+
+  d.writeFileSync(join(liveDir, 'playwright.config.ts'), configContent);
+
+  // Live test example
+  d.writeFileSync(
+    join(liveDir, 'example.test.ts'),
+    `import { test, expect } from 'sunpeak/test/live';
+
+/**
+ * Live tests invoke tools through real AI hosts (ChatGPT, Claude).
+ *
+ * The \`live\` fixture provides:
+ * - live.invoke(toolName) — invoke a tool and get the app locator
+ * - live.setColorScheme('dark', app) — switch theme while app is visible
+ * - live.page — the underlying Playwright page
+ *
+ * Run with: sunpeak test --live
+ *
+ * These tests are excluded from normal \`sunpeak test\` runs because
+ * they require host accounts and cost API credits.
+ */
+
+// Uncomment and replace 'your-tool' with the tool name as it appears in the host.
+// test('tool renders in the host', async ({ live }) => {
+//   const app = await live.invoke('your-tool');
+//
+//   await expect(app.getByText('Expected text')).toBeVisible({ timeout: 15_000 });
+//
+//   // Test dark mode:
+//   await live.setColorScheme('dark', app);
+//   await expect(app.getByText('Expected text')).toBeVisible();
+// });
+`
+  );
+
+  d.log.success(`Created ${liveDir}/ with live test config and example.`);
+}
+
+/**
+ * Scaffold a unit test example for JS/TS projects.
+ * @param {string} filePath - Full path to the unit test file
+ * @param {object} d - Dependencies
+ */
+function scaffoldUnitTest(filePath, d) {
+  if (d.existsSync(filePath)) {
+    d.log.info('Unit test already exists. Skipping.');
+    return;
+  }
+
+  d.mkdirSync(dirname(filePath), { recursive: true });
+
+  d.writeFileSync(
+    filePath,
+    `import { describe, it, expect } from 'vitest';
+
+/**
+ * Unit tests for your MCP tool handlers.
+ *
+ * Import your tool handler directly and test its input/output
+ * without starting the MCP server or inspector.
+ *
+ * Run with: sunpeak test --unit
+ *
+ * To set up vitest, add it to your devDependencies:
+ *   npm install -D vitest
+ *
+ * Uncomment and customize the tests below for your tools.
+ */
+
+// import handler, { tool, schema } from '../../src/tools/your-tool';
+// const extra = {} as Parameters<typeof handler>[1];
+
+// describe('your tool', () => {
+//   it('returns expected output', async () => {
+//     const result = await handler({ key: 'value' }, extra);
+//     expect(result.structuredContent).toBeDefined();
+//   });
+//
+//   it('exports correct tool config', () => {
+//     expect(tool.title).toBe('Your Tool');
+//     expect(tool.annotations?.readOnlyHint).toBe(true);
+//   });
+// });
+`
+  );
+  d.log.success(`Created ${filePath}`);
 }
 
 async function initExternalProject(cliServer, d) {
@@ -332,7 +531,7 @@ ${serverBlock}
     ) + '\n'
   );
 
-  // smoke test — runnable out of the box, verifies the server is reachable
+  // 1. E2E test — smoke test, verifies the server is reachable
   d.writeFileSync(
     join(testDir, 'smoke.test.ts'),
     `import { test, expect } from 'sunpeak/test';
@@ -354,16 +553,25 @@ test('server is reachable and inspector loads', async ({ mcp }) => {
 `
   );
 
-  // Scaffold eval boilerplate
+  // 2. Visual regression test
+  scaffoldVisualTest(join(testDir, 'visual.test.ts'), d);
+
+  // 3. Live tests
+  scaffoldLiveTests(join(testDir, 'live'), { isSunpeak: false, d });
+
+  // 4. Eval boilerplate
   scaffoldEvals(join(testDir, 'evals'), { server, d });
 
-  d.log.success('Created tests/sunpeak/ with config and starter test.');
+  d.log.success('Created tests/sunpeak/ with all test types.');
   d.log.step('Next steps:');
   d.log.message('  cd tests/sunpeak');
   d.log.message('  npm install');
   d.log.message('  npx playwright install chromium');
-  d.log.message('  npx sunpeak test');
-  d.log.message('  npx sunpeak test --eval  (after configuring models in evals/eval.config.ts)');
+  d.log.message('');
+  d.log.message('  npx sunpeak test              # E2E tests');
+  d.log.message('  npx sunpeak test --visual      # Visual regression (generates baselines on first run)');
+  d.log.message('  npx sunpeak test --live         # Live tests against real hosts (requires login)');
+  d.log.message('  npx sunpeak test --eval         # Multi-model evals (configure models in evals/eval.config.ts)');
 }
 
 async function initJsProject(cliServer, d) {
@@ -390,11 +598,11 @@ ${serverBlock}
     d.log.success('Created playwright.config.ts');
   }
 
-  // Create test directory and smoke test
-  const testDir = join(cwd, 'tests', 'e2e');
-  d.mkdirSync(testDir, { recursive: true });
+  // 1. E2E test — smoke test
+  const e2eDir = join(cwd, 'tests', 'e2e');
+  d.mkdirSync(e2eDir, { recursive: true });
 
-  const testPath = join(testDir, 'smoke.test.ts');
+  const testPath = join(e2eDir, 'smoke.test.ts');
   if (!d.existsSync(testPath)) {
     d.writeFileSync(
       testPath,
@@ -418,15 +626,27 @@ test('server is reachable and inspector loads', async ({ mcp }) => {
     d.log.success('Created tests/e2e/smoke.test.ts');
   }
 
-  // Scaffold eval boilerplate
-  const evalsDir = join(cwd, 'tests', 'evals');
-  scaffoldEvals(evalsDir, { server, d });
+  // 2. Visual regression test
+  scaffoldVisualTest(join(e2eDir, 'visual.test.ts'), d);
+
+  // 3. Live tests
+  scaffoldLiveTests(join(cwd, 'tests', 'live'), { isSunpeak: false, d });
+
+  // 4. Eval boilerplate
+  scaffoldEvals(join(cwd, 'tests', 'evals'), { server, d });
+
+  // 5. Unit test
+  scaffoldUnitTest(join(cwd, 'tests', 'unit', 'example.test.ts'), d);
 
   d.log.step('Next steps:');
-  d.log.message('  npm install -D sunpeak @playwright/test');
+  d.log.message('  npm install -D sunpeak @playwright/test vitest');
   d.log.message('  npx playwright install chromium');
-  d.log.message('  npx sunpeak test');
-  d.log.message('  npx sunpeak test --eval  (after configuring models in tests/evals/eval.config.ts)');
+  d.log.message('');
+  d.log.message('  npx sunpeak test              # E2E tests');
+  d.log.message('  npx sunpeak test --unit        # Unit tests (vitest)');
+  d.log.message('  npx sunpeak test --visual      # Visual regression');
+  d.log.message('  npx sunpeak test --live         # Live tests against real hosts');
+  d.log.message('  npx sunpeak test --eval         # Multi-model evals');
 }
 
 async function initSunpeakProject(d) {
@@ -439,6 +659,11 @@ async function initSunpeakProject(d) {
     const content = d.readFileSync(configPath, 'utf-8');
     if (content.includes('sunpeak/test/config')) {
       d.log.info('Config already uses sunpeak/test/config. Nothing to do.');
+    } else {
+      d.log.warn('playwright.config.ts exists but does not use sunpeak/test/config.');
+      d.log.message('  To migrate, replace your config with:');
+      d.log.message("    import { defineConfig } from 'sunpeak/test/config';");
+      d.log.message('    export default defineConfig();');
     }
   } else {
     d.writeFileSync(
@@ -451,15 +676,32 @@ export default defineConfig();
     d.log.success('Updated playwright.config.ts to use defineConfig()');
   }
 
-  // Scaffold eval boilerplate
-  const evalsDir = join(cwd, 'tests', 'evals');
-  scaffoldEvals(evalsDir, { isSunpeak: true, d });
+  // Scaffold missing test types
 
-  d.log.step('Migrate test files:');
+  // 1. Visual regression test
+  const e2eDir = join(cwd, 'tests', 'e2e');
+  d.mkdirSync(e2eDir, { recursive: true });
+  scaffoldVisualTest(join(e2eDir, 'visual.test.ts'), d);
+
+  // 2. Live tests
+  scaffoldLiveTests(join(cwd, 'tests', 'live'), { isSunpeak: true, d });
+
+  // 3. Eval boilerplate
+  scaffoldEvals(join(cwd, 'tests', 'evals'), { isSunpeak: true, d });
+
+  // 4. Unit test
+  scaffoldUnitTest(join(cwd, 'tests', 'unit', 'example.test.ts'), d);
+
+  d.log.step('Scaffolded test types:');
+  d.log.message('  tests/e2e/visual.test.ts    — Visual regression (sunpeak test --visual)');
+  d.log.message('  tests/live/                 — Live host tests (sunpeak test --live)');
+  d.log.message('  tests/evals/                — Multi-model evals (sunpeak test --eval)');
+  d.log.message('  tests/unit/example.test.ts  — Unit tests (sunpeak test --unit)');
+  d.log.message('');
+  d.log.message('  Migrate existing e2e tests:');
   d.log.message('  Replace: import { test, expect } from "@playwright/test"');
   d.log.message('  With:    import { test, expect } from "sunpeak/test"');
   d.log.message('');
   d.log.message('  Use the `mcp` fixture instead of raw page navigation.');
   d.log.message('  See sunpeak docs for migration examples.');
-  d.log.message('  Run: sunpeak test --eval  (after configuring models in tests/evals/eval.config.ts)');
 }

--- a/packages/sunpeak/scripts/validate.mjs
+++ b/packages/sunpeak/scripts/validate.mjs
@@ -254,6 +254,242 @@ function validateDocs() {
 // ============================================================================
 
 /**
+ * Validate `sunpeak test init` across all 3 project types.
+ *
+ * For each type (external, JS, sunpeak), scaffolds into a temp directory
+ * and verifies:
+ * - All expected files are created
+ * - File contents contain expected imports/exports
+ * - Idempotency: running twice doesn't crash or overwrite
+ * - Server config flows through to generated files
+ */
+function runTestInitSmokeTest() {
+  const tmpBase = join(REPO_ROOT, '.tmp-validate-test-init');
+
+  if (existsSync(tmpBase)) {
+    rmSync(tmpBase, { recursive: true });
+  }
+  mkdirSync(tmpBase, { recursive: true });
+
+  try {
+    const allOutput = [];
+
+    // ── External project (empty dir, no package.json) ──
+    {
+      const dir = join(tmpBase, 'external');
+      mkdirSync(dir, { recursive: true });
+
+      const result = runCommandCapture(
+        `node ${SUNPEAK_BIN} test init --server http://localhost:8000/mcp`,
+        dir,
+        { CI: '1' }
+      );
+      allOutput.push(`--- external: init ---\n${result.output}`);
+      if (!result.ok) return { ok: false, step: 'test-init external', output: allOutput.join('\n') };
+
+      const testDir = join(dir, 'tests', 'sunpeak');
+      const expected = [
+        'package.json',
+        'playwright.config.ts',
+        'tsconfig.json',
+        'smoke.test.ts',
+        'visual.test.ts',
+        'live/playwright.config.ts',
+        'live/example.test.ts',
+        'evals/eval.config.ts',
+        'evals/example.eval.ts',
+        'evals/.env.example',
+      ];
+
+      for (const file of expected) {
+        const fullPath = join(testDir, file);
+        if (!existsSync(fullPath)) {
+          return { ok: false, step: `test-init external: missing ${file}`, output: allOutput.join('\n') };
+        }
+      }
+
+      // Verify server URL flows through
+      const configContent = readFileSync(join(testDir, 'playwright.config.ts'), 'utf-8');
+      if (!configContent.includes('http://localhost:8000/mcp')) {
+        return { ok: false, step: 'test-init external: server URL missing from playwright.config.ts', output: allOutput.join('\n') };
+      }
+
+      const evalConfig = readFileSync(join(testDir, 'evals/eval.config.ts'), 'utf-8');
+      if (!evalConfig.includes('http://localhost:8000/mcp')) {
+        return { ok: false, step: 'test-init external: server URL missing from eval.config.ts', output: allOutput.join('\n') };
+      }
+
+      // Verify live config has the NOTE for non-sunpeak projects
+      const liveConfig = readFileSync(join(testDir, 'live/playwright.config.ts'), 'utf-8');
+      if (!liveConfig.includes('NOTE:')) {
+        return { ok: false, step: 'test-init external: live config missing NOTE for non-sunpeak', output: allOutput.join('\n') };
+      }
+
+      // Idempotency: second run should not crash
+      const result2 = runCommandCapture(
+        `node ${SUNPEAK_BIN} test init --server http://localhost:8000/mcp`,
+        dir,
+        { CI: '1' }
+      );
+      allOutput.push(`--- external: idempotency ---\n${result2.output}`);
+      if (!result2.ok) return { ok: false, step: 'test-init external: idempotency', output: allOutput.join('\n') };
+    }
+
+    // ── JS project (package.json without sunpeak) ──
+    {
+      const dir = join(tmpBase, 'js');
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({
+        name: 'test-js-project',
+        dependencies: { express: '*' },
+      }, null, 2) + '\n');
+
+      const result = runCommandCapture(
+        `node ${SUNPEAK_BIN} test init --server http://localhost:9000/mcp`,
+        dir,
+        { CI: '1' }
+      );
+      allOutput.push(`--- js: init ---\n${result.output}`);
+      if (!result.ok) return { ok: false, step: 'test-init js', output: allOutput.join('\n') };
+
+      const expected = [
+        'playwright.config.ts',
+        'tests/e2e/smoke.test.ts',
+        'tests/e2e/visual.test.ts',
+        'tests/live/playwright.config.ts',
+        'tests/live/example.test.ts',
+        'tests/evals/eval.config.ts',
+        'tests/evals/example.eval.ts',
+        'tests/evals/.env.example',
+        'tests/unit/example.test.ts',
+      ];
+
+      for (const file of expected) {
+        if (!existsSync(join(dir, file))) {
+          return { ok: false, step: `test-init js: missing ${file}`, output: allOutput.join('\n') };
+        }
+      }
+
+      // Verify correct imports in scaffolded files
+      const smokeContent = readFileSync(join(dir, 'tests/e2e/smoke.test.ts'), 'utf-8');
+      if (!smokeContent.includes("from 'sunpeak/test'")) {
+        return { ok: false, step: 'test-init js: smoke test missing sunpeak/test import', output: allOutput.join('\n') };
+      }
+
+      const visualContent = readFileSync(join(dir, 'tests/e2e/visual.test.ts'), 'utf-8');
+      if (!visualContent.includes("from 'sunpeak/test'") || !visualContent.includes('mcp.screenshot')) {
+        return { ok: false, step: 'test-init js: visual test missing expected content', output: allOutput.join('\n') };
+      }
+
+      const liveTest = readFileSync(join(dir, 'tests/live/example.test.ts'), 'utf-8');
+      if (!liveTest.includes("from 'sunpeak/test/live'") || !liveTest.includes('live.invoke')) {
+        return { ok: false, step: 'test-init js: live test missing expected content', output: allOutput.join('\n') };
+      }
+
+      const unitTest = readFileSync(join(dir, 'tests/unit/example.test.ts'), 'utf-8');
+      if (!unitTest.includes("from 'vitest'")) {
+        return { ok: false, step: 'test-init js: unit test missing vitest import', output: allOutput.join('\n') };
+      }
+
+      const evalExample = readFileSync(join(dir, 'tests/evals/example.eval.ts'), 'utf-8');
+      if (!evalExample.includes("from 'sunpeak/eval'") || !evalExample.includes('defineEval')) {
+        return { ok: false, step: 'test-init js: eval test missing expected content', output: allOutput.join('\n') };
+      }
+
+      // JS project live config should have the NOTE
+      const liveConfig = readFileSync(join(dir, 'tests/live/playwright.config.ts'), 'utf-8');
+      if (!liveConfig.includes('NOTE:')) {
+        return { ok: false, step: 'test-init js: live config missing NOTE', output: allOutput.join('\n') };
+      }
+
+      // Verify server URL in main config
+      const mainConfig = readFileSync(join(dir, 'playwright.config.ts'), 'utf-8');
+      if (!mainConfig.includes('http://localhost:9000/mcp')) {
+        return { ok: false, step: 'test-init js: server URL missing from config', output: allOutput.join('\n') };
+      }
+    }
+
+    // ── sunpeak project (package.json with sunpeak dep) ──
+    {
+      const dir = join(tmpBase, 'sunpeak-app');
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({
+        name: 'my-app',
+        dependencies: { sunpeak: '*' },
+      }, null, 2) + '\n');
+
+      const result = runCommandCapture(
+        `node ${SUNPEAK_BIN} test init`,
+        dir,
+        { CI: '1' }
+      );
+      allOutput.push(`--- sunpeak: init ---\n${result.output}`);
+      if (!result.ok) return { ok: false, step: 'test-init sunpeak', output: allOutput.join('\n') };
+
+      const expected = [
+        'playwright.config.ts',
+        'tests/e2e/visual.test.ts',
+        'tests/live/playwright.config.ts',
+        'tests/live/example.test.ts',
+        'tests/evals/eval.config.ts',
+        'tests/evals/example.eval.ts',
+        'tests/evals/.env.example',
+        'tests/unit/example.test.ts',
+      ];
+
+      for (const file of expected) {
+        if (!existsSync(join(dir, file))) {
+          return { ok: false, step: `test-init sunpeak: missing ${file}`, output: allOutput.join('\n') };
+        }
+      }
+
+      // Verify playwright.config uses defineConfig() (no server arg)
+      const config = readFileSync(join(dir, 'playwright.config.ts'), 'utf-8');
+      if (!config.includes('defineConfig()')) {
+        return { ok: false, step: 'test-init sunpeak: config should use defineConfig()', output: allOutput.join('\n') };
+      }
+
+      // sunpeak project live config should NOT have the NOTE
+      const liveConfig = readFileSync(join(dir, 'tests/live/playwright.config.ts'), 'utf-8');
+      if (liveConfig.includes('NOTE:')) {
+        return { ok: false, step: 'test-init sunpeak: live config should NOT have NOTE', output: allOutput.join('\n') };
+      }
+
+      // Eval config should have sunpeak-specific comment
+      const evalConfig = readFileSync(join(dir, 'tests/evals/eval.config.ts'), 'utf-8');
+      if (!evalConfig.includes('Omit server for sunpeak projects')) {
+        return { ok: false, step: 'test-init sunpeak: eval config missing sunpeak comment', output: allOutput.join('\n') };
+      }
+    }
+
+    // ── Command-based server (external project) ──
+    {
+      const dir = join(tmpBase, 'command-server');
+      mkdirSync(dir, { recursive: true });
+
+      const result = runCommandCapture(
+        `node ${SUNPEAK_BIN} test init --server "python src/server.py"`,
+        dir,
+        { CI: '1' }
+      );
+      allOutput.push(`--- command-server: init ---\n${result.output}`);
+      if (!result.ok) return { ok: false, step: 'test-init command-server', output: allOutput.join('\n') };
+
+      const config = readFileSync(join(dir, 'tests/sunpeak/playwright.config.ts'), 'utf-8');
+      if (!config.includes("command: 'python'") || !config.includes("'src/server.py'")) {
+        return { ok: false, step: 'test-init command-server: config missing parsed command/args', output: allOutput.join('\n') };
+      }
+    }
+
+    return { ok: true, step: null, output: allOutput.join('\n') };
+  } finally {
+    if (existsSync(tmpBase)) {
+      rmSync(tmpBase, { recursive: true });
+    }
+  }
+}
+
+/**
  * Scaffold smoke test — validates the `sunpeak new` CLI path.
  * Runs captured (no stdio inherit) so it can run in parallel.
  */
@@ -889,11 +1125,13 @@ try {
   printSection('PARALLEL: SCAFFOLD + EXAMPLES');
 
   const parallelStart = Date.now();
-  console.log(`Running scaffold smoke test + ${resources.length} examples in parallel...\n`);
+  console.log(`Running scaffold smoke test + test init + ${resources.length} examples in parallel...\n`);
 
-  const [scaffoldResult, ...exampleResults] = await Promise.all([
-    // Scaffold smoke test
+  const [scaffoldResult, testInitResult, ...exampleResults] = await Promise.all([
+    // Scaffold smoke test (sunpeak new)
     new Promise(resolve => resolve(runScaffoldSmokeTest())),
+    // Test init smoke test (sunpeak test init)
+    new Promise(resolve => resolve(runTestInitSmokeTest())),
     // All examples in parallel
     ...resources.map((resource, index) =>
       new Promise(resolve => resolve(testExample(resource, index)))
@@ -902,11 +1140,20 @@ try {
 
   // Report scaffold result
   if (scaffoldResult.ok) {
-    printSuccess('scaffold smoke test');
+    printSuccess('scaffold smoke test (sunpeak new)');
   } else {
     console.error(`\n${colors.red}✗ scaffold smoke test failed at: ${scaffoldResult.step}${colors.reset}`);
     console.error(`${colors.dim}${scaffoldResult.output.split('\n').slice(-30).join('\n')}${colors.reset}`);
     throw new Error(`Scaffold smoke test failed at: ${scaffoldResult.step}`);
+  }
+
+  // Report test init result
+  if (testInitResult.ok) {
+    printSuccess('test init smoke test (sunpeak test init)');
+  } else {
+    console.error(`\n${colors.red}✗ test init smoke test failed at: ${testInitResult.step}${colors.reset}`);
+    console.error(`${colors.dim}${testInitResult.output.split('\n').slice(-30).join('\n')}${colors.reset}`);
+    throw new Error(`Test init smoke test failed at: ${testInitResult.step}`);
   }
 
   // Report example results

--- a/packages/sunpeak/src/cli/commands.test.ts
+++ b/packages/sunpeak/src/cli/commands.test.ts
@@ -645,6 +645,35 @@ describe('CLI Commands', () => {
       );
     });
 
+    it('should warn when sunpeak project has non-sunpeak playwright config', async () => {
+      const { testInit } = await importTestInit();
+      const logWarnMock = vi.fn();
+      const logMessageMock = vi.fn();
+
+      await testInit(
+        [],
+        createTestInitDeps({
+          existsSync: (path: string) =>
+            path.includes('package.json') || path.includes('playwright.config.ts'),
+          readFileSync: (path: string) => {
+            if (path.includes('package.json')) {
+              return JSON.stringify({ dependencies: { sunpeak: '*' } });
+            }
+            // Config exists but uses raw @playwright/test, not sunpeak
+            return "import { defineConfig } from '@playwright/test';";
+          },
+          log: { ...noopLog, warn: logWarnMock, message: logMessageMock },
+        })
+      );
+
+      expect(logWarnMock).toHaveBeenCalledWith(
+        expect.stringContaining('does not use sunpeak/test/config')
+      );
+      expect(logMessageMock).toHaveBeenCalledWith(
+        expect.stringContaining('defineConfig')
+      );
+    });
+
     it('should detect JS project type and use CLI server arg', async () => {
       const { testInit } = await importTestInit();
       const writeFileSync = vi.fn();
@@ -663,6 +692,237 @@ describe('CLI Commands', () => {
         expect.stringContaining('playwright.config.ts'),
         expect.stringContaining('http://localhost:9000/mcp')
       );
+    });
+
+    /** Extract written file content. Pass enough trailing path to be unique. */
+    function getWrittenContent(
+      mock: ReturnType<typeof vi.fn>,
+      pathSuffix: string
+    ): string | undefined {
+      const call = mock.mock.calls.find((c: [string, string]) =>
+        (c[0] as string).endsWith(pathSuffix)
+      );
+      return call ? (call[1] as string) : undefined;
+    }
+
+    it('should scaffold e2e, visual, live, and eval tests for external projects', async () => {
+      const { testInit } = await importTestInit();
+      const writeFileSync = vi.fn();
+      const mkdirSync = vi.fn();
+
+      await testInit(
+        ['--server', 'http://localhost:8000/mcp'],
+        createTestInitDeps({
+          writeFileSync,
+          mkdirSync,
+        })
+      );
+
+      const writtenPaths = writeFileSync.mock.calls.map((c: [string, string]) => c[0]);
+
+      // All expected files
+      expect(writtenPaths).toContainEqual(expect.stringContaining('smoke.test.ts'));
+      expect(writtenPaths).toContainEqual(expect.stringContaining('visual.test.ts'));
+      expect(writtenPaths).toContainEqual(expect.stringContaining('live/playwright.config.ts'));
+      expect(writtenPaths).toContainEqual(expect.stringContaining('live/example.test.ts'));
+      expect(writtenPaths).toContainEqual(expect.stringContaining('evals/eval.config.ts'));
+      expect(writtenPaths).toContainEqual(expect.stringContaining('evals/example.eval.ts'));
+      expect(writtenPaths).toContainEqual(expect.stringContaining('package.json'));
+      expect(writtenPaths).toContainEqual(expect.stringContaining('tsconfig.json'));
+
+      // No unit tests for external projects (server is in another language)
+      expect(writtenPaths).not.toContainEqual(expect.stringContaining('unit/'));
+
+      // Server URL flows through to root config (not live/playwright.config.ts)
+      const config = getWrittenContent(writeFileSync, 'sunpeak/playwright.config.ts');
+      expect(config).toContain('http://localhost:8000/mcp');
+      expect(config).toContain("from 'sunpeak/test/config'");
+
+      // Eval config has server URL
+      const evalConfig = getWrittenContent(writeFileSync, 'evals/eval.config.ts');
+      expect(evalConfig).toContain('http://localhost:8000/mcp');
+
+      // Live config has NOTE for non-sunpeak projects
+      const liveConfig = getWrittenContent(writeFileSync, 'live/playwright.config.ts');
+      expect(liveConfig).toContain('NOTE:');
+      expect(liveConfig).toContain("from 'sunpeak/test/live/config'");
+    });
+
+    it('should scaffold all 5 test types for JS projects with correct imports', async () => {
+      const { testInit } = await importTestInit();
+      const writeFileSync = vi.fn();
+
+      await testInit(
+        ['--server', 'http://localhost:8000/mcp'],
+        createTestInitDeps({
+          existsSync: (path: string) => path.includes('package.json') || false,
+          readFileSync: () => JSON.stringify({ dependencies: { express: '*' } }),
+          writeFileSync,
+        })
+      );
+
+      const writtenPaths = writeFileSync.mock.calls.map((c: [string, string]) => c[0]);
+
+      // All 5 test types
+      expect(writtenPaths).toContainEqual(expect.stringContaining('e2e/smoke.test.ts'));
+      expect(writtenPaths).toContainEqual(expect.stringContaining('e2e/visual.test.ts'));
+      expect(writtenPaths).toContainEqual(expect.stringContaining('live/playwright.config.ts'));
+      expect(writtenPaths).toContainEqual(expect.stringContaining('live/example.test.ts'));
+      expect(writtenPaths).toContainEqual(expect.stringContaining('evals/eval.config.ts'));
+      expect(writtenPaths).toContainEqual(expect.stringContaining('unit/example.test.ts'));
+
+      // Verify correct imports
+      const smoke = getWrittenContent(writeFileSync, 'e2e/smoke.test.ts');
+      expect(smoke).toContain("from 'sunpeak/test'");
+
+      const visual = getWrittenContent(writeFileSync, 'e2e/visual.test.ts');
+      expect(visual).toContain("from 'sunpeak/test'");
+      expect(visual).toContain('mcp.screenshot');
+
+      const liveTest = getWrittenContent(writeFileSync, 'live/example.test.ts');
+      expect(liveTest).toContain("from 'sunpeak/test/live'");
+      expect(liveTest).toContain('live.invoke');
+
+      const unit = getWrittenContent(writeFileSync, 'unit/example.test.ts');
+      expect(unit).toContain("from 'vitest'");
+
+      const evalTest = getWrittenContent(writeFileSync, 'evals/example.eval.ts');
+      expect(evalTest).toContain("from 'sunpeak/eval'");
+      expect(evalTest).toContain('defineEval');
+    });
+
+    it('should scaffold all test types for sunpeak projects without NOTE in live config', async () => {
+      const { testInit } = await importTestInit();
+      const writeFileSync = vi.fn();
+
+      await testInit(
+        [],
+        createTestInitDeps({
+          existsSync: (path: string) => path.includes('package.json') || false,
+          readFileSync: (path: string) => {
+            if (path.includes('package.json')) {
+              return JSON.stringify({ dependencies: { sunpeak: '*' } });
+            }
+            return '{}';
+          },
+          writeFileSync,
+        })
+      );
+
+      const writtenPaths = writeFileSync.mock.calls.map((c: [string, string]) => c[0]);
+
+      // All test types
+      expect(writtenPaths).toContainEqual(expect.stringContaining('playwright.config.ts'));
+      expect(writtenPaths).toContainEqual(expect.stringContaining('visual.test.ts'));
+      expect(writtenPaths).toContainEqual(expect.stringContaining('live/playwright.config.ts'));
+      expect(writtenPaths).toContainEqual(expect.stringContaining('evals/eval.config.ts'));
+      expect(writtenPaths).toContainEqual(expect.stringContaining('unit/example.test.ts'));
+
+      // Config uses defineConfig() with no args (root config, not live/)
+      const config = getWrittenContent(writeFileSync, 'project/playwright.config.ts');
+      expect(config).toContain('defineConfig()');
+
+      // Live config should NOT have NOTE (this IS a sunpeak project)
+      const liveConfig = getWrittenContent(writeFileSync, 'live/playwright.config.ts');
+      expect(liveConfig).not.toContain('NOTE:');
+
+      // Eval config has sunpeak-specific comment
+      const evalConfig = getWrittenContent(writeFileSync, 'evals/eval.config.ts');
+      expect(evalConfig).toContain('Omit server for sunpeak projects');
+    });
+
+    it('should skip existing files without overwriting', async () => {
+      const { testInit } = await importTestInit();
+      const writeFileSync = vi.fn();
+
+      await testInit(
+        ['--server', 'http://localhost:8000/mcp'],
+        createTestInitDeps({
+          existsSync: (path: string) => {
+            if (path.includes('package.json')) return true;
+            if (path.includes('visual.test.ts')) return true;
+            if (path.includes('live/playwright.config.ts')) return true;
+            if (path.includes('unit/example.test.ts')) return true;
+            return false;
+          },
+          readFileSync: () => JSON.stringify({ dependencies: { express: '*' } }),
+          writeFileSync,
+        })
+      );
+
+      const writtenPaths = writeFileSync.mock.calls.map((c: [string, string]) => c[0]);
+
+      // Should NOT have written visual, live config, or unit test (they already exist)
+      expect(writtenPaths).not.toContainEqual(expect.stringContaining('visual.test.ts'));
+      expect(writtenPaths).not.toContainEqual(expect.stringContaining('live/playwright.config.ts'));
+      expect(writtenPaths).not.toContainEqual(expect.stringContaining('live/example.test.ts'));
+      expect(writtenPaths).not.toContainEqual(expect.stringContaining('unit/example.test.ts'));
+
+      // Should still have written smoke test and evals (they don't exist in the mock)
+      expect(writtenPaths).toContainEqual(expect.stringContaining('smoke.test.ts'));
+      expect(writtenPaths).toContainEqual(expect.stringContaining('evals/eval.config.ts'));
+    });
+
+    it('should parse command-based server into command and args', async () => {
+      const { testInit } = await importTestInit();
+      const writeFileSync = vi.fn();
+
+      await testInit(['--server', 'python src/server.py'], createTestInitDeps({ writeFileSync }));
+
+      const config = getWrittenContent(writeFileSync, 'sunpeak/playwright.config.ts');
+      expect(config).toContain("command: 'python'");
+      expect(config).toContain("'src/server.py'");
+    });
+
+    it('should not scaffold test bodies that would fail on missing tools', async () => {
+      const { testInit } = await importTestInit();
+      const writeFileSync = vi.fn();
+
+      await testInit(
+        ['--server', 'http://localhost:8000/mcp'],
+        createTestInitDeps({
+          existsSync: (path: string) => path.includes('package.json') || false,
+          readFileSync: () => JSON.stringify({ dependencies: { express: '*' } }),
+          writeFileSync,
+        })
+      );
+
+      // Visual test: all callTool/screenshot lines should be commented
+      const visual = getWrittenContent(writeFileSync, 'visual.test.ts');
+      expect(visual).toBeDefined();
+      // Should not have uncommented callTool (which would crash on 'your-tool')
+      const uncommentedLines = visual!
+        .split('\n')
+        .filter(
+          (l) =>
+            !l.trim().startsWith('//') && !l.trim().startsWith('*') && !l.trim().startsWith('/**')
+        );
+      expect(uncommentedLines.join('\n')).not.toContain('callTool');
+      expect(uncommentedLines.join('\n')).not.toContain('screenshot');
+
+      // Live test: invoke should be commented
+      const liveTest = getWrittenContent(writeFileSync, 'live/example.test.ts');
+      expect(liveTest).toBeDefined();
+      const liveUncommented = liveTest!
+        .split('\n')
+        .filter(
+          (l) =>
+            !l.trim().startsWith('//') && !l.trim().startsWith('*') && !l.trim().startsWith('/**')
+        );
+      expect(liveUncommented.join('\n')).not.toContain('live.invoke');
+
+      // Unit test: handler import and test bodies should be commented
+      const unit = getWrittenContent(writeFileSync, 'unit/example.test.ts');
+      expect(unit).toBeDefined();
+      const unitUncommented = unit!
+        .split('\n')
+        .filter(
+          (l) =>
+            !l.trim().startsWith('//') && !l.trim().startsWith('*') && !l.trim().startsWith('/**')
+        );
+      // The vitest import is OK uncommented, but actual test logic should be commented
+      expect(unitUncommented.join('\n')).not.toContain('handler');
+      expect(unitUncommented.join('\n')).not.toContain('expect(tool');
     });
   });
 


### PR DESCRIPTION
## Summary

- `sunpeak test init` now scaffolds all 5 test types: e2e (smoke test), visual regression (screenshot comparisons), live (real host testing), evals (multi-model tool calling), and unit tests (vitest). Previously only e2e and evals were scaffolded.
- All scaffolded test files have fully commented test bodies so they don't crash on placeholder tool names out of the box.
- Works language-agnostically: empty directories get a self-contained `tests/sunpeak/` package, JS/TS projects get root-level config, sunpeak projects get missing test types added.
- Non-sunpeak live test configs include a NOTE explaining that `defineLiveConfig()` assumes a sunpeak dev server backend.
- Sunpeak projects with a non-sunpeak playwright config now get a migration warning instead of silent no-op.
- Removed unused `import { expect } from 'vitest'` from the eval example template.
- Integration tests in `validate.mjs` exercise all 4 project scenarios (external, JS, sunpeak, command-based server) in temp directories with file existence, content, and idempotency checks.
- Unit tests verify file contents, correct imports, NOTE presence/absence, server URL propagation, and that no uncommented tool calls exist in scaffold templates.

## Test plan

- [x] `pnpm --filter sunpeak test` (332 tests pass)
- [x] `pnpm --filter sunpeak lint`
- [x] `pnpm --filter sunpeak typecheck`
- [x] `pnpm --filter sunpeak validate` (128.5s, all phases pass including new test-init smoke test)
- [x] Manual testing in real temp directories for all 3 project types + command-based server + idempotency