### PR TITLE
Improve new-user UX for testing framework onboarding

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -129,6 +129,7 @@
           {
             "group": "Overview",
             "pages": [
+              "testing/getting-started",
               "testing/overview"
             ]
           },

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,14 +1,19 @@
 ---
 title: "Quickstart"
-description: "Create your first MCP App with sunpeak."
-keywords: ["MCP Apps", "ChatGPT Apps", "MCP app framework", "ChatGPT app framework", "create MCP app", "getting started"]
+description: "Create your first MCP App or test an existing MCP server with sunpeak."
+keywords: ["MCP Apps", "ChatGPT Apps", "MCP app framework", "ChatGPT app framework", "create MCP app", "getting started", "MCP testing", "test MCP server"]
 ---
 
-## New projects
+<CardGroup cols={2}>
+  <Card title="Test an existing MCP server" icon="flask" href="/testing/getting-started">
+    Add automated testing to any MCP server (Python, Go, TypeScript, Rust, or any language). No project changes required.
+  </Card>
+  <Card title="Build a new MCP App" icon="hammer" href="#new-projects">
+    Create a new MCP App project with interactive UIs, tools, and testing built in. Follow the steps below.
+  </Card>
+</CardGroup>
 
-<Tip>
-Already have an MCP server? Skip the project scaffold and use `sunpeak inspect --server <url>` to test it immediately. See [sunpeak inspect](/testing/cli/inspect).
-</Tip>
+## New projects
 
 <Steps>
   <Step title="Install sunpeak">

--- a/docs/testing/getting-started.mdx
+++ b/docs/testing/getting-started.mdx
@@ -1,0 +1,217 @@
+---
+title: "Getting Started"
+description: "Add automated testing to any MCP server in under five minutes."
+keywords: ["MCP testing", "MCP server testing", "test MCP server", "Python MCP testing", "Go MCP testing", "getting started"]
+---
+
+## Prerequisites
+
+- **Node.js 20+** is required, even if your MCP server is written in Python, Go, or another language. The testing framework runs on Node.js and Playwright.
+- Your MCP server running locally (HTTP or stdio)
+
+## 1. Install sunpeak
+
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm add -g sunpeak
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm install -g sunpeak
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn global add sunpeak
+    ```
+  </Tab>
+</Tabs>
+
+## 2. Try the inspector
+
+Before writing tests, try the inspector to verify sunpeak can connect to your server:
+
+<Tabs>
+  <Tab title="HTTP server">
+    ```bash
+    sunpeak inspect --server http://localhost:8000/mcp
+    ```
+  </Tab>
+  <Tab title="Python (stdio)">
+    ```bash
+    sunpeak inspect --server "python server.py"
+
+    # With uv:
+    sunpeak inspect --server "uv run python server.py"
+    ```
+  </Tab>
+  <Tab title="Go (stdio)">
+    ```bash
+    sunpeak inspect --server "go run ./cmd/server"
+    ```
+  </Tab>
+  <Tab title="Node.js (stdio)">
+    ```bash
+    sunpeak inspect --server "node server.js"
+    ```
+  </Tab>
+</Tabs>
+
+This opens the inspector at `http://localhost:3000`, where you can call your tools and see them rendered in simulated ChatGPT and Claude runtimes. Browse your tools, switch hosts and themes, and verify everything connects.
+
+## 3. Scaffold test infrastructure
+
+Once the inspector works, scaffold automated tests:
+
+```bash
+sunpeak test init --server http://localhost:8000/mcp
+```
+
+Or with a stdio command:
+
+```bash
+sunpeak test init --server "python server.py"
+```
+
+This creates test files for all four testing levels. For non-JS projects, everything goes into a self-contained `tests/sunpeak/` directory with its own `package.json`.
+
+Install dependencies:
+
+<Tabs>
+  <Tab title="Non-JS project">
+    ```bash
+    cd tests/sunpeak
+    npm install
+    npx playwright install chromium
+    ```
+  </Tab>
+  <Tab title="JS/TS project">
+    ```bash
+    npm add -D sunpeak @playwright/test vitest
+    npx playwright install chromium
+    ```
+  </Tab>
+</Tabs>
+
+## 4. Run the smoke test
+
+```bash
+sunpeak test
+```
+
+The scaffolded smoke test verifies that the inspector can connect to your server and load. You should see one passing test.
+
+## 5. Write your first real test
+
+Open the scaffolded smoke test (`smoke.test.ts`) and add a test for one of your tools. Replace `your-tool` with an actual tool name from your server:
+
+```typescript
+import { test, expect } from 'sunpeak/test';
+
+test('server is reachable and inspector loads', async ({ mcp }) => {
+  await expect(mcp.page.locator('#root')).not.toBeEmpty();
+});
+
+test('my tool returns a result', async ({ mcp }) => {
+  const result = await mcp.callTool('your-tool', { key: 'value' });
+  expect(result).not.toBeError();
+});
+
+// If your tool renders a UI, you can interact with it:
+test('my tool renders a UI', async ({ mcp }) => {
+  const result = await mcp.callTool('your-tool', { key: 'value' });
+  const app = result.app();
+  await expect(app.getByText('Expected text')).toBeVisible();
+});
+```
+
+The `mcp` fixture handles all the plumbing: starting the inspector, connecting to your server, navigating to the tool, and traversing the double-iframe sandbox. Each test runs automatically against both ChatGPT and Claude hosts.
+
+<Tip>
+  Run `sunpeak inspect --server <url>` to browse your tools interactively and find the right tool names and arguments to use in tests.
+</Tip>
+
+## 6. Add more test levels
+
+The scaffolded files include templates for all four testing levels:
+
+| Level | File | Command | Cost |
+|-------|------|---------|------|
+| **E2E** | `smoke.test.ts` | `sunpeak test` | Free |
+| **Visual** | `visual.test.ts` | `sunpeak test --visual` | Free |
+| **Live** | `live/example.test.ts` | `sunpeak test --live` | Host credits |
+| **Evals** | `evals/example.eval.ts` | `sunpeak test --eval` | API keys |
+
+Start with E2E tests (free, fast, local). Add visual regression when you want to catch CSS regressions. Add live tests and evals when you need production host validation and multi-model reliability testing.
+
+## Language-specific tips
+
+<AccordionGroup>
+  <Accordion title="Python">
+    For stdio servers, pass the full command including any virtual environment activation:
+
+    ```typescript
+    // playwright.config.ts
+    import { defineConfig } from 'sunpeak/test/config';
+    export default defineConfig({
+      server: {
+        // Option 1: uv (recommended)
+        command: 'uv', args: ['run', 'python', 'server.py'],
+
+        // Option 2: venv absolute path
+        // command: '.venv/bin/python', args: ['server.py'],
+
+        // Option 3: HTTP server (no shell needed)
+        // url: 'http://localhost:8000/mcp',
+      },
+    });
+    ```
+
+    HTTP servers (FastAPI, Flask) are the simplest option because you start them separately and sunpeak just connects to the URL.
+  </Accordion>
+
+  <Accordion title="Go">
+    ```typescript
+    import { defineConfig } from 'sunpeak/test/config';
+    export default defineConfig({
+      server: {
+        command: 'go', args: ['run', './cmd/server'],
+
+        // Or connect to a running HTTP server:
+        // url: 'http://localhost:8000/mcp',
+      },
+    });
+    ```
+  </Accordion>
+
+  <Accordion title="Rust">
+    ```typescript
+    import { defineConfig } from 'sunpeak/test/config';
+    export default defineConfig({
+      server: {
+        command: 'cargo', args: ['run', '--release'],
+        // url: 'http://localhost:8000/mcp',
+      },
+    });
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card horizontal title="E2E Testing" icon="flask" href="/testing/e2e">
+    Write Playwright tests against simulated hosts.
+  </Card>
+  <Card horizontal title="Visual Regression" icon="image" href="/testing/visual">
+    Screenshot comparison across themes and hosts.
+  </Card>
+  <Card horizontal title="Live Testing" icon="globe" href="/testing/live">
+    Test against real ChatGPT and Claude.
+  </Card>
+  <Card horizontal title="Evals" icon="chart-bar" href="/testing/evals">
+    Multi-model tool calling reliability.
+  </Card>
+</CardGroup>

--- a/docs/testing/overview.mdx
+++ b/docs/testing/overview.mdx
@@ -88,11 +88,13 @@ For existing MCP servers (not built with sunpeak), run `sunpeak test init` to ge
 sunpeak test init
 ```
 
-This creates:
-- `tests/e2e/` with example Playwright specs and config
-- `tests/simulations/` with example simulation JSON fixtures
+For JS/TS projects, this creates files at the project root:
+- `tests/e2e/` with smoke and visual regression test specs
 - `tests/evals/` with eval config, `.env.example`, and example eval specs
 - `tests/live/` with live test config and example specs
+- `tests/unit/` with unit test example
+
+For non-JS projects (Python, Go, Rust, etc.), everything goes into a self-contained `tests/sunpeak/` directory with its own `package.json`.
 
 For sunpeak framework projects, `sunpeak new` scaffolds all of this automatically.
 

--- a/packages/sunpeak/bin/commands/test-init.mjs
+++ b/packages/sunpeak/bin/commands/test-init.mjs
@@ -212,11 +212,23 @@ async function getServerConfig(cliServer, d) {
 
 function generateServerConfigBlock(server, relativeTo = '.') {
   if (server.type === 'later') {
-    return `  // TODO: Configure your MCP server connection
-  // server: {
-  //   command: 'python',
-  //   args: ['server.py'],
-  // },`;
+    return `  // TODO: Configure your MCP server connection before running tests.
+  // Uncomment one of the options below:
+  //
+  // HTTP server (Python FastAPI, Go, etc.):
+  // server: { url: 'http://localhost:8000/mcp' },
+  //
+  // Python (uv):
+  // server: { command: 'uv', args: ['run', 'python', 'server.py'] },
+  //
+  // Python (venv):
+  // server: { command: '.venv/bin/python', args: ['server.py'] },
+  //
+  // Go:
+  // server: { command: 'go', args: ['run', './cmd/server'] },
+  //
+  // Node.js:
+  // server: { command: 'node', args: ['server.js'] },`;
   }
   if (server.type === 'url') {
     return `  server: {
@@ -631,7 +643,12 @@ test('server is reachable and inspector loads', async ({ mcp }) => {
   scaffoldEvals(join(testDir, 'evals'), { server, d });
 
   d.log.success('Created tests/sunpeak/ with all test types.');
+  if (server.type === 'later') {
+    d.log.warn('Server not configured. Edit tests/sunpeak/playwright.config.ts before running tests.');
+  }
   d.log.step('Next steps:');
+  d.log.message('  Requires: Node.js 20+');
+  d.log.message('');
   const pm = d.detectPackageManager();
   d.log.message('  cd tests/sunpeak');
   d.log.message(`  ${pm} install`);
@@ -707,6 +724,9 @@ test('server is reachable and inspector loads', async ({ mcp }) => {
   // 5. Unit test
   scaffoldUnitTest(join(cwd, 'tests', 'unit', 'example.test.ts'), d);
 
+  if (server.type === 'later') {
+    d.log.warn('Server not configured. Edit playwright.config.ts before running tests.');
+  }
   const pkgMgr = d.detectPackageManager();
   d.log.step('Next steps:');
   d.log.message(`  ${pkgMgr} add -D sunpeak @playwright/test vitest`);

--- a/packages/sunpeak/src/cli/commands.test.ts
+++ b/packages/sunpeak/src/cli/commands.test.ts
@@ -929,6 +929,73 @@ describe('CLI Commands', () => {
       expect(unitUncommented.join('\n')).not.toContain('handler');
       expect(unitUncommented.join('\n')).not.toContain('expect(tool');
     });
+
+    it('should include multi-language hints in "configure later" config', async () => {
+      const { testInit } = await importTestInit();
+      const writeFileSync = vi.fn();
+
+      await testInit([], createTestInitDeps({ writeFileSync }));
+
+      const config = getWrittenContent(writeFileSync, 'sunpeak/playwright.config.ts');
+      expect(config).toBeDefined();
+      // Should contain TODO and language-specific examples
+      expect(config).toContain('TODO: Configure your MCP server');
+      expect(config).toContain('Python (uv)');
+      expect(config).toContain('Python (venv)');
+      expect(config).toContain('Go:');
+      expect(config).toContain('Node.js:');
+      expect(config).toContain('HTTP server');
+    });
+
+    it('should warn when server is "configure later" for external projects', async () => {
+      const { testInit } = await importTestInit();
+      const logWarnMock = vi.fn();
+
+      await testInit(
+        [],
+        createTestInitDeps({
+          log: { ...noopLog, warn: logWarnMock },
+        })
+      );
+
+      expect(logWarnMock).toHaveBeenCalledWith(
+        expect.stringContaining('Server not configured')
+      );
+    });
+
+    it('should warn when server is "configure later" for JS projects', async () => {
+      const { testInit } = await importTestInit();
+      const logWarnMock = vi.fn();
+
+      await testInit(
+        [],
+        createTestInitDeps({
+          existsSync: (path: string) => path.includes('package.json') || false,
+          readFileSync: () => JSON.stringify({ dependencies: { express: '*' } }),
+          log: { ...noopLog, warn: logWarnMock },
+        })
+      );
+
+      expect(logWarnMock).toHaveBeenCalledWith(
+        expect.stringContaining('Server not configured')
+      );
+    });
+
+    it('should show Node.js requirement in external project next steps', async () => {
+      const { testInit } = await importTestInit();
+      const logMessageMock = vi.fn();
+
+      await testInit(
+        ['--server', 'http://localhost:8000/mcp'],
+        createTestInitDeps({
+          log: { ...noopLog, message: logMessageMock },
+        })
+      );
+
+      expect(logMessageMock).toHaveBeenCalledWith(
+        expect.stringContaining('Node.js 20+')
+      );
+    });
   });
 
   describe('version command', () => {
@@ -967,6 +1034,28 @@ describe('CLI Commands', () => {
       const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
 
       expect(output).toBe(pkg.version);
+    });
+  });
+
+  describe('docs navigation', () => {
+    it('testing/getting-started should be in docs.json and the file should exist', async () => {
+      const { readFileSync, existsSync } = await import('fs');
+      const { join } = await import('path');
+
+      // Check docs.json includes the page
+      const docsJsonPath = join(process.cwd(), '../../docs/docs.json');
+      const docsJson = JSON.parse(readFileSync(docsJsonPath, 'utf-8'));
+      const testingTab = docsJson.navigation.tabs.find(
+        (t: { tab: string }) => t.tab === 'MCP Testing Framework'
+      );
+      const overviewGroup = testingTab.groups.find(
+        (g: { group: string }) => g.group === 'Overview'
+      );
+      expect(overviewGroup.pages).toContain('testing/getting-started');
+
+      // Check the file exists
+      const filePath = join(process.cwd(), '../../docs/testing/getting-started.mdx');
+      expect(existsSync(filePath)).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

- Add `docs/testing/getting-started.mdx` with a complete walkthrough for testing existing MCP servers (install, inspect, scaffold, first test, language-specific tips for Python/Go/Rust)
- Replace the buried quickstart tip with a prominent card fork so testing-focused users see their path immediately
- Add multi-language config hints (Python/uv/venv, Go, Rust, Node.js) to the "configure later" scaffolded config in `test init`
- Warn users when server is unconfigured after `test init`, and show Node.js 20+ requirement for non-JS projects
- Fix docs/code mismatch: `overview.mdx` incorrectly claimed `test init` creates `tests/simulations/`, and didn't mention the `tests/sunpeak/` layout for non-JS projects
- Add 5 new tests covering the config hints, warnings, Node.js requirement, and docs navigation

Also updates the marketing site (`sunpeak-site`) separately: CTA links point to the new getting-started page, Rust added to all language lists, and stale "simulations" claims removed from the `test init` description.