### PR TITLE
Improve testing framework for Python MCP servers and embedding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,14 +103,15 @@ packages/sunpeak/
 - `sunpeak/mcp` — Server utilities (`runMCPServer`, `createMcpHandler`, `createHandler`, `createProductionMcpServer`, `startProductionHttpServer`, `setJsonLogging`, `detectClientFromHeaders`), tool types (`AppToolConfig`, `ToolHandlerExtra`, `CallToolResult`, `AuthInfo`), server config (`ServerConfig`, `MCPServerConfig`, `MCPServerHandle`), production types (`ProductionTool`, `ProductionResource`, `ProductionServerConfig`, `HttpServerOptions`, `AuthFunction`, `WebAuthFunction`, `WebHandlerConfig`), domain resolution (`resolveDomain`, `computeClaudeDomain`, `computeChatGPTDomain`, `injectResolvedDomain`, `injectDefaultDomain`, `DomainConfig`), favicon (`FAVICON_BASE64`, `FAVICON_DATA_URI`, `FAVICON_BUFFER`), SDK server helpers (`registerAppTool`, `registerAppResource`, `getUiCapability`, `EXTENSION_ID`, `RESOURCE_URI_META_KEY`, `RESOURCE_MIME_TYPE`, `McpUiAppToolConfig`, `McpUiAppResourceConfig`, `ToolConfig`, `ToolCallback`, `ReadResourceCallback`, `ResourceMetadata`)
 - `sunpeak/host` — Host detection
 - `sunpeak/host/chatgpt` — ChatGPT-specific hooks (file upload, modals, checkout)
-- `sunpeak/test` — MCP-first Playwright fixtures (`test` with `mcp` fixture including `screenshot()` for visual regression, `expect` with MCP-native matchers)
-- `sunpeak/test/config` — Playwright config factory (`defineConfig` — auto-detects sunpeak projects, or accepts `server` option for external MCP servers; supports `visual` option for visual regression config)
+- `sunpeak/test` — MCP-first Playwright fixtures (`test` with `mcp` fixture for protocol methods: `callTool(name, input?)`, `listTools()`, `listResources()`, `readResource(uri)`; and `inspector` fixture for rendering: `renderTool(name, input?, options?)` returning `InspectorResult` with `app()`, `source`, `screenshot()`; plus `inspector.host`, `inspector.page`; `expect` with MCP-native matchers)
+- `sunpeak/test/config` — Playwright config factory (`defineConfig` — auto-detects sunpeak projects, or accepts `server` option for external MCP servers; `server` supports `command`, `args`, `url`, `env`, `cwd`; top-level `timeout` for server startup; `visual` option for visual regression config)
 - `sunpeak/test/live` — Host-agnostic Playwright fixtures for live testing (`test` with `live` fixture, `expect`, `setColorScheme`)
 - `sunpeak/test/live/config` — Live test config factory (`defineLiveConfig` with `hosts` array)
 - `sunpeak/test/live/chatgpt` — ChatGPT-specific Playwright fixtures (`test` with `chatgpt` fixture)
 - `sunpeak/eval` — Eval framework (`defineEval`, `defineEvalConfig`, `checkExpectations`, `createMcpConnection`, `discoverAndConvertTools`, `runEvalCaseAggregate`)
 - `sunpeak/test/live/chatgpt/config` — ChatGPT-specific Playwright config factory
-- `sunpeak/test/inspect/config` — Inspect config factory for external MCP servers (`defineInspectConfig`; supports `visual` option for visual regression config)
+- `sunpeak/test/inspect/config` — Inspect config factory for external MCP servers (`defineInspectConfig`; supports `env`, `cwd`, `timeout`, `visual` options)
+- `sunpeak/inspect` — Programmatic inspector server (`inspectServer` — start the inspector from code instead of CLI; accepts `server`, `port`, `env`, `cwd`, etc.)
 - `sunpeak/style.css` — Main stylesheet
 
 ## Key Types
@@ -197,24 +198,55 @@ The overlay is **never** present in production builds (only injected when `viteM
 
 ### Inspector URL Parameters
 
-The inspector reads `sidebar` and `devOverlay` URL params (parsed in `use-inspector-state.ts`):
+The inspector reads URL params (parsed in `use-inspector-state.ts`):
 - `sidebar=false` — hides the sidebar, renders only conversation content (useful for headless testing or embedding)
 - `devOverlay=false` — strips the dev overlay from resource HTML (for e2e tests where the overlay could interfere with assertions)
+- `toolInput=<json>` — JSON-encoded tool arguments that override the simulation fixture's default toolInput (used by the `inspector` fixture when `renderTool` receives an `input` argument)
+- `autoRun=true` — call the tool on load when no fixture data exists (set by test fixtures to get results without clicking Run; not set during interactive use)
 
-Template e2e tests use the `mcp` fixture from `sunpeak/test`, which sets `devOverlay: false` automatically. The `dev-overlay.spec.ts` test files (excluded from `sunpeak new` via `dev-` prefix filter in `new.mjs`) test the overlay explicitly and import `createInspectorUrl` directly from `sunpeak/chatgpt`.
+Template e2e tests use the `mcp` and `inspector` fixtures from `sunpeak/test`, which set `devOverlay: false` automatically. The `dev-overlay.spec.ts` test files (excluded from `sunpeak new` via `dev-` prefix filter in `new.mjs`) test the overlay explicitly and import `createInspectorUrl` directly from `sunpeak/chatgpt`.
 
-### Testing Architecture (Three Layers)
+### sunpeak Is Three Things
 
-The testing framework has three composable layers, each usable in isolation:
+Each layer builds on the previous and works independently. The inspector and testing framework work with any MCP server in any language and can be embedded within other frameworks.
 
-1. **Inspector** (Layer 1) — `sunpeak inspect --server <url>` starts the inspector against any MCP server. Hidden plumbing for the testing framework.
-2. **Testing Framework** (Layer 2) — Works with any MCP server. `sunpeak test init` scaffolds test infrastructure. Includes:
-   - **E2E tests** — `sunpeak/test` exports an `mcp` Playwright fixture with `callTool()`, MCP-native matchers (`toBeError`, `toHaveTextContent`), and `defineConfig()`.
-   - **Live tests** — `sunpeak/test/live` exports Playwright fixtures for testing against real hosts (ChatGPT, Claude).
-   - **Evals** — `sunpeak/eval` exports `defineEval` and `defineEvalConfig` for multi-model tool calling evals. Connects to any MCP server via MCP protocol, discovers tools, sends prompts to multiple LLM models (via Vercel AI SDK), and asserts that models call the right tools with the right arguments. Each eval case runs N times per model and reports statistical pass/fail counts. Eval specs live in `tests/evals/*.eval.ts`. Configuration (models, runs, temperature) is in `tests/evals/eval.config.ts`. Requires optional peer deps: `ai` + provider packages (`@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/google`).
-3. **sunpeak Framework** (Layer 3) — Template tests use Layer 2's fixtures and configs. `defineConfig()` auto-detects sunpeak projects and starts `sunpeak dev` as the backend. For evals, the dev server auto-starts with `--prod-tools`.
+#### 1. Inspector
+
+Test any MCP server in replicated ChatGPT and Claude runtimes. No sunpeak project required.
+
+- **CLI**: `sunpeak inspect --server <url>` or `sunpeak inspect --server "python server.py"`. Supports `--env KEY=VALUE` (repeatable) and `--cwd <path>` for stdio servers.
+- **Programmatic**: `inspectServer()` from `sunpeak/inspect` lets other frameworks start the inspector from their own CLI.
+- **OAuth**: Auto-negotiates MCP OAuth when servers return 401. Handles anonymous/auto-approved OAuth without user interaction. For interactive OAuth, opens the authorization URL in the user's browser and waits for the callback. Uses the MCP SDK's standard `OAuthClientProvider` interface.
+- Built into `sunpeak dev` for app framework users.
+
+#### 2. Testing Framework
+
+Automated testing powered by the inspector. Works with any MCP server in any language. sunpeak's long-term goal is to be the generic testing framework for all MCP servers, not just MCP Apps. MCP Apps (interactive UIs in chat) are the current specialty, but the testing framework should work for any server that implements the MCP protocol. Keep MCP protocol primitives as a clean, 1:1 layer that can evolve with the spec. Layer sunpeak-specific functionality (inspector rendering, visual regression, simulations, MCP Apps features) on top without mixing it into the protocol layer.
+
+**`mcp` fixture** (`sunpeak/test`) — protocol-only methods:
+- `callTool(name, input?)` — call a tool, return the MCP result
+- `listTools()` — list tool definitions
+- `listResources()` — list resource definitions
+- `readResource(uri)` — read resource content
+
+**`inspector` fixture** (`sunpeak/test`) — rendering in the inspector:
+- `renderTool(name, input?, options?)` — call a tool, render in the inspector, return `InspectorResult` with `app()` locator, `source` field (`'fixture'` or `'server'`), and `screenshot(name?, options?)` method
+- `host` — current host ID (`'chatgpt'` or `'claude'`)
+- `page` — raw Playwright `Page` for chrome-level assertions
+
+`renderTool` with `input` navigates via `?tool=X&toolInput=JSON&autoRun=true` (real server call, bypasses fixtures). Without `input`, it uses `?simulation=X&autoRun=true` (uses fixture data when available, falls back to real call). `autoRun` tells the inspector to call the tool on load when no fixture result exists; interactive users don't set this flag so browsing tools doesn't trigger server calls. The fixture reads the tool result from a `<script id="__tool-result">` data element so MCP-native matchers (`toBeError`, `toHaveTextContent`, `toHaveStructuredContent`, `toHaveContentType`) operate on real data. Fixture timeouts are configurable via `use: { mcpTimeout }` in Playwright config or per-call `{ timeout }` option.
+
+**Server configuration**: `defineConfig({ server: { command, args, url, env, cwd }, timeout })` connects to any MCP server. For non-JS projects, `sunpeak test init` scaffolds a self-contained `tests/sunpeak/` directory with its own `package.json` (version-pinned), auto-installs dependencies, and is ready to run. `sunpeak test` auto-discovers this directory from the project root.
+
+**Embedding**: Other frameworks import `defineConfig` from `sunpeak/test/config` to generate Playwright configs programmatically. Binary resolution checks local `node_modules/.bin` first so sunpeak doesn't need to be installed globally.
+
+**Test types**: E2E (`sunpeak/test`), Visual regression (`result.screenshot()` on `InspectorResult`), Live tests (`sunpeak/test/live` for real ChatGPT/Claude), Evals (`sunpeak/eval` for multi-model tool calling via Vercel AI SDK).
 
 **CLI**: `sunpeak test` runs unit + e2e tests, `sunpeak test --unit` runs only vitest, `sunpeak test --e2e` runs only Playwright e2e tests, `sunpeak test --visual` runs e2e with visual regression comparison, `sunpeak test --visual --update` updates visual baselines, `sunpeak test --live` runs live tests against real hosts, `sunpeak test --eval` runs multi-model evals, `sunpeak test init` scaffolds test infrastructure (including eval boilerplate). Flags are additive: `--unit --e2e --live --eval` runs all four. `--update` implies `--visual`. `--eval` and `--live` are never included in the default run (they cost money).
+
+#### 3. App Framework
+
+Convention-over-configuration for building MCP Apps. The inspector and testing are built in. `defineConfig()` auto-detects sunpeak projects and starts `sunpeak dev` as the backend. Template tests use the testing framework's fixtures and configs. For evals, the dev server auto-starts with `--prod-tools`.
 
 ## Documentation (`docs/`)
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -69,18 +69,20 @@ sunpeak inspect --server "python my_server.py"
 
 Four levels of automated testing for MCP Apps (Unit, E2E, Live, Evals):
 
-**E2E tests** — the inspector as a test runtime. Define simulation fixtures (JSON), write Playwright tests that load them in the inspector across hosts, themes, and display modes:
+**E2E tests** — the inspector as a test runtime. Call tools, assert on protocol-level results, or render the UI across hosts, themes, and display modes:
 
 ```typescript
-import { createInspectorUrl } from 'sunpeak/inspector';
+import { test, expect } from 'sunpeak/test';
 
-test('album cards render in dark mode', async ({ page }) => {
-  await page.goto(createInspectorUrl({
-    simulation: 'show-albums',
-    theme: 'dark',
-    host: 'claude',
-  }));
-  // assert against the rendered resource
+test('search tool works', async ({ mcp }) => {
+  const result = await mcp.callTool('search', { query: 'headphones' });
+  expect(result.isError).toBeFalsy();
+});
+
+test('album cards render in dark mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', {}, { theme: 'dark' });
+  const app = result.app();
+  await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
 });
 ```
 

--- a/docs/mcp-apps-testing.mdx
+++ b/docs/mcp-apps-testing.mdx
@@ -10,7 +10,7 @@ sunpeak provides four levels of automated testing for MCP Apps:
 
 1. **Unit tests** — Vitest with happy-dom for component and hook logic testing.
 
-2. **E2E tests** against the [inspector](/mcp-apps-inspector) — the `mcp` fixture from `sunpeak/test` calls tools, renders them in simulated ChatGPT and Claude runtimes, and gives you a frame locator for the rendered UI. [Simulations](/testing/simulations) (JSON fixtures) define reproducible tool states. Test every combination of host, theme, display mode, and device type without deploying or burning API credits.
+2. **E2E tests** against the [inspector](/mcp-apps-inspector) — the `mcp` and `inspector` fixtures from `sunpeak/test` call tools and render them in simulated ChatGPT and Claude runtimes. The `mcp` fixture provides protocol-level methods (`callTool`, `listTools`), and the `inspector` fixture renders tools and gives you a frame locator for the UI. [Simulations](/testing/simulations) (JSON fixtures) define reproducible tool states. Test every combination of host, theme, display mode, and device type without deploying or burning API credits.
 
 3. **Live tests** against real hosts — `sunpeak/test/live` provides Playwright fixtures that open real ChatGPT (and future hosts), send messages, wait for app iframes, and let you assert against the rendered result. All host DOM interaction (auth, selectors, iframe access) is maintained by sunpeak — you only write resource assertions.
 
@@ -47,19 +47,19 @@ sunpeak test --e2e tests/e2e/albums.spec.ts  # Single file
 
 ### Writing E2E Tests
 
-Import `test` and `expect` from `sunpeak/test`. The `mcp` fixture handles inspector navigation, double-iframe traversal, and host selection:
+Import `test` and `expect` from `sunpeak/test`. The `mcp` fixture provides protocol-level methods, and the `inspector` fixture handles rendering, double-iframe traversal, and host selection:
 
 ```typescript
 import { test, expect } from 'sunpeak/test';
 
-test('should render album cards in light mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { theme: 'light' });
+test('should render album cards in light mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', {}, { theme: 'light' });
   const app = result.app();
   await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
 });
 
-test('should render in fullscreen mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { displayMode: 'fullscreen' });
+test('should render in fullscreen mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', {}, { displayMode: 'fullscreen' });
   const app = result.app();
   await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
 });
@@ -77,7 +77,7 @@ test('should render in fullscreen mode', async ({ mcp }) => {
   alt="Inspector set to inline light mode via URL params"
 />
 
-The `mcp.callTool()` method accepts options for `theme`, `displayMode`, and `prodResources`. For advanced URL parameters, see the [Inspector API Reference](/testing/inspector#createinspectorurl).
+The `inspector.renderTool()` method accepts options for `theme`, `displayMode`, and `timeout`. For advanced URL parameters, see the [Inspector API Reference](/testing/inspector#createinspectorurl).
 
 The config is a one-liner:
 
@@ -120,8 +120,8 @@ If your resource calls backend tools via [`useCallServerTool`](/app-framework/ho
 ```typescript
 import { test, expect } from 'sunpeak/test';
 
-test('should show success when server confirms', async ({ mcp }) => {
-  const result = await mcp.callTool('review-purchase');
+test('should show success when server confirms', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-purchase');
   const app = result.app();
 
   await app.locator('button:has-text("Place Order")').evaluate((el) => (el as HTMLElement).click());
@@ -138,20 +138,20 @@ A typical e2e test file tests a resource across different modes. Each test runs 
 ```typescript
 import { test, expect } from 'sunpeak/test';
 
-test('should render album cards', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { theme: 'light' });
+test('should render album cards', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', {}, { theme: 'light' });
   const app = result.app();
   await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
 });
 
-test('should render with dark theme', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { theme: 'dark' });
+test('should render with dark theme', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', {}, { theme: 'dark' });
   const app = result.app();
   await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
 });
 
-test('should render in fullscreen', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { displayMode: 'fullscreen' });
+test('should render in fullscreen', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', {}, { displayMode: 'fullscreen' });
   const app = result.app();
   await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
 });
@@ -161,32 +161,32 @@ test('should render in fullscreen', async ({ mcp }) => {
 
 Visual regression tests capture screenshots and compare them against saved baselines. This catches unintended visual changes across themes, display modes, and hosts.
 
-Screenshot comparisons only run when you pass `--visual`. Without it, `mcp.screenshot()` calls are silently skipped, so you can include them in your regular e2e tests without affecting normal runs.
+Screenshot comparisons only run when you pass `--visual`. Without it, `result.screenshot()` calls are silently skipped, so you can include them in your regular e2e tests without affecting normal runs.
 
 ```bash
 sunpeak test --visual                  # Compare against baselines
 sunpeak test --visual --update         # Update baselines
 ```
 
-Use `mcp.screenshot()` in any e2e test:
+Use `result.screenshot()` in any e2e test:
 
 ```typescript
 import { test, expect } from 'sunpeak/test';
 
-test('albums renders correctly', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { theme: 'light' });
+test('albums renders correctly', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', {}, { theme: 'light' });
   const app = result.app();
   await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
 
-  await mcp.screenshot('albums-light');
+  await result.screenshot('albums-light');
 });
 ```
 
 By default, `screenshot()` captures the app inside the double-iframe. Use `target: 'page'` for the full inspector, or pass a specific `element` locator:
 
 ```typescript
-await mcp.screenshot('full-page', { target: 'page' });
-await mcp.screenshot('card', { element: app.locator('.card') });
+await result.screenshot('full-page', { target: 'page' });
+await result.screenshot('card', { element: app.locator('.card') });
 ```
 
 Configure project-wide visual defaults in your Playwright config:

--- a/docs/testing/e2e.mdx
+++ b/docs/testing/e2e.mdx
@@ -17,26 +17,21 @@ sunpeak test --e2e tests/e2e/albums.spec.ts  # Single file
 
 ### Writing E2E Tests
 
-Import `test` and `expect` from `sunpeak/test`. The `mcp` fixture handles inspector navigation, double-iframe traversal, and host selection:
+Import `test` and `expect` from `sunpeak/test`. The `mcp` fixture provides protocol-level methods, and the `inspector` fixture handles rendering, double-iframe traversal, and host selection:
 
 ```typescript
 import { test, expect } from 'sunpeak/test';
 
-test('should render album cards in light mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { theme: 'light' });
+test('should render album cards in light mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', {}, { theme: 'light' });
   const app = result.app();
   await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
 });
 
-test('should render in fullscreen mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { displayMode: 'fullscreen' });
+test('should render in fullscreen mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', {}, { displayMode: 'fullscreen' });
   const app = result.app();
   await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
-});
-
-test('prod tools empty state', async ({ mcp }) => {
-  await mcp.openTool('show-albums');
-  await expect(mcp.page.locator('text=Press Run to call the tool')).toBeVisible();
 });
 ```
 
@@ -58,6 +53,20 @@ This auto-detects sunpeak projects and creates per-host Playwright projects (cha
     import { defineConfig } from 'sunpeak/test/config';
     export default defineConfig({
       server: 'http://localhost:8000/mcp',
+    });
+    ```
+
+    For stdio servers, pass a command and optional configuration:
+
+    ```typescript
+    import { defineConfig } from 'sunpeak/test/config';
+    export default defineConfig({
+      server: {
+        command: 'python', args: ['server.py'],
+        env: { DATABASE_URL: 'sqlite:///test.db' },
+        cwd: './my-server',
+      },
+      timeout: 90_000, // Server startup timeout in ms (default: 60000)
     });
     ```
   </Tab>
@@ -83,7 +92,67 @@ This auto-detects sunpeak projects and creates per-host Playwright projects (cha
   alt="Inspector set to inline light mode via URL params"
 />
 
-The `mcp.callTool()` method accepts options for `theme`, `displayMode`, and `prodResources`. For advanced URL parameters, see the [Inspector API Reference](/testing/inspector#createinspectorurl).
+### Protocol methods
+
+Test your MCP server at the protocol level without rendering anything:
+
+```typescript
+test('server exposes expected tools', async ({ mcp }) => {
+  const tools = await mcp.listTools();
+  const search = tools.find(t => t.name === 'search');
+  expect(search).toBeDefined();
+  expect(search.inputSchema.properties).toHaveProperty('query');
+});
+
+test('search tool returns results', async ({ mcp }) => {
+  const result = await mcp.callTool('search', { query: 'headphones' });
+  expect(result.isError).toBeFalsy();
+  expect(result.structuredContent.results.length).toBeGreaterThan(0);
+});
+
+test('resources have correct metadata', async ({ mcp }) => {
+  const resources = await mcp.listResources();
+  const app = resources.find(r => r.name === 'search-results');
+  expect(app?.mimeType).toBe('text/html');
+});
+```
+
+| Method | Description |
+|--------|-------------|
+| `listTools()` | List all tools. Returns `Tool[]`. |
+| `callTool(name, input?)` | Call a tool, return the raw MCP result. |
+| `listResources()` | List all resources. Returns `Resource[]`. |
+| `readResource(uri)` | Read a resource by URI. Returns the content string. |
+
+### renderTool
+
+`inspector.renderTool` renders the tool result in the inspector and returns an `InspectorResult` with both the MCP data and a UI locator. With `input`, the tool is called on the real server. Without `input`, simulation fixture data is used when available. The returned `InspectorResult` includes a `source` field (`'fixture'` or `'server'`) indicating where the data came from, and a `screenshot()` method for visual regression.
+
+```typescript
+// Call the real server with specific arguments
+const result = await inspector.renderTool('search', { query: 'test', limit: 10 });
+expect(result).not.toBeError();
+
+const app = result.app();
+await expect(app.getByText('test')).toBeVisible();
+
+// Use simulation fixture data, or call server with empty args
+const result = await inspector.renderTool('show-albums', undefined, { theme: 'dark' });
+```
+
+The options object accepts `theme`, `displayMode`, and `timeout`. Per-call timeout overrides the config default.
+
+### Configuring default timeouts
+
+```typescript
+import { defineConfig } from 'sunpeak/test/config';
+export default defineConfig({
+  server: { url: 'http://localhost:8000/mcp' },
+  use: {
+    mcpTimeout: 30_000, // Default for renderTool (default: 15s)
+  },
+});
+```
 
 ### Testing Backend-Only Tools
 
@@ -118,8 +187,8 @@ If your resource calls backend tools via `useCallServerTool`, define mock respon
 ```typescript
 import { test, expect } from 'sunpeak/test';
 
-test('should show success when server confirms', async ({ mcp }) => {
-  const result = await mcp.callTool('review-purchase');
+test('should show success when server confirms', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-purchase');
   const app = result.app();
 
   await app.locator('button:has-text("Place Order")').evaluate((el) => (el as HTMLElement).click());
@@ -128,8 +197,8 @@ test('should show success when server confirms', async ({ mcp }) => {
   await expect(app.locator('text=Completed.')).toBeVisible({ timeout: 10000 });
 });
 
-test('should show cancel when user rejects', async ({ mcp }) => {
-  const result = await mcp.callTool('review-purchase');
+test('should show cancel when user rejects', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-purchase');
   const app = result.app();
 
   await app.locator('button:has-text("Cancel")').evaluate((el) => (el as HTMLElement).click());
@@ -148,8 +217,8 @@ A typical e2e test file tests a resource across different modes. Each test runs 
 ```typescript
 import { test, expect } from 'sunpeak/test';
 
-test('should render album cards with correct styles', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { theme: 'light' });
+test('should render album cards with correct styles', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', {}, { theme: 'light' });
   const app = result.app();
 
   const albumCard = app.locator('button:has-text("Summer Slice")');
@@ -163,22 +232,21 @@ test('should render album cards with correct styles', async ({ mcp }) => {
   expect(styles.borderRadius).toBe('12px');
 });
 
-test('should render with dark theme', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { theme: 'dark' });
+test('should render with dark theme', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', {}, { theme: 'dark' });
   const app = result.app();
   await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
 });
 
-test('should render in fullscreen', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { displayMode: 'fullscreen' });
+test('should render in fullscreen', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', {}, { displayMode: 'fullscreen' });
   const app = result.app();
   await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
 });
 
-test('pip mode works (ChatGPT only)', async ({ mcp }) => {
-  test.skip(mcp.host === 'claude', 'Claude does not support PiP');
-  const result = await mcp.callTool('show-albums');
-  await mcp.setDisplayMode('pip');
+test('pip mode works (ChatGPT only)', async ({ inspector }) => {
+  test.skip(inspector.host === 'claude', 'Claude does not support PiP');
+  const result = await inspector.renderTool('show-albums', {}, { displayMode: 'pip' });
   await expect(result.app().locator('button:has-text("Summer Slice")')).toBeVisible();
 });
 ```
@@ -212,19 +280,19 @@ test('pip mode works (ChatGPT only)', async ({ mcp }) => {
   </Accordion>
 
   <Accordion title="Test across hosts, themes, and display modes">
-    Use `mcp.callTool()` options to test your resources in different configurations. Tests run across ChatGPT and Claude hosts automatically via Playwright projects. Pass `theme` and `displayMode` as options:
+    Use `inspector.renderTool()` options to test your resources in different configurations. Tests run across ChatGPT and Claude hosts automatically via Playwright projects. Pass `theme` and `displayMode` as options:
     ```typescript
-    await mcp.callTool('show-weather', {}, { theme: 'dark', displayMode: 'fullscreen' });
+    await inspector.renderTool('show-weather', {}, { theme: 'dark', displayMode: 'fullscreen' });
     ```
 
     See [MCP Apps Display Modes](/mcp-apps/introduction#what-display-modes-are-available) for how hosts handle inline, fullscreen, and PiP views.
   </Accordion>
 
   <Accordion title="Add visual regression tests for key states">
-    Use `mcp.screenshot()` in tests that cover important visual states (light/dark theme, fullscreen, empty states). Visual tests catch CSS regressions that functional assertions miss:
+    Use `result.screenshot()` in tests that cover important visual states (light/dark theme, fullscreen, empty states). Visual tests catch CSS regressions that functional assertions miss:
     ```typescript
-    await mcp.screenshot('albums-dark');
-    await mcp.screenshot('albums-fullscreen', { target: 'page' });
+    await result.screenshot('albums-dark');
+    await result.screenshot('albums-fullscreen', { target: 'page' });
     ```
   </Accordion>
 

--- a/docs/testing/getting-started.mdx
+++ b/docs/testing/getting-started.mdx
@@ -101,6 +101,8 @@ Install dependencies:
 sunpeak test
 ```
 
+For non-JS projects, `sunpeak test` auto-discovers `tests/sunpeak/playwright.config.ts` when no root-level config exists. You can run it from your project root without cd-ing into the test directory.
+
 The scaffolded smoke test verifies that the inspector can connect to your server and load. You should see one passing test.
 
 ## 5. Write your first real test
@@ -110,24 +112,26 @@ Open the scaffolded smoke test (`smoke.test.ts`) and add a test for one of your 
 ```typescript
 import { test, expect } from 'sunpeak/test';
 
-test('server is reachable and inspector loads', async ({ mcp }) => {
-  await expect(mcp.page.locator('#root')).not.toBeEmpty();
+test('server is reachable and inspector loads', async ({ inspector }) => {
+  await expect(inspector.page.locator('#root')).not.toBeEmpty();
 });
 
 test('my tool returns a result', async ({ mcp }) => {
   const result = await mcp.callTool('your-tool', { key: 'value' });
-  expect(result).not.toBeError();
+  expect(result.isError).toBeFalsy();
 });
 
 // If your tool renders a UI, you can interact with it:
-test('my tool renders a UI', async ({ mcp }) => {
-  const result = await mcp.callTool('your-tool', { key: 'value' });
+test('my tool renders a UI', async ({ inspector }) => {
+  const result = await inspector.renderTool('your-tool', { key: 'value' });
   const app = result.app();
   await expect(app.getByText('Expected text')).toBeVisible();
 });
 ```
 
-The `mcp` fixture handles all the plumbing: starting the inspector, connecting to your server, navigating to the tool, and traversing the double-iframe sandbox. Each test runs automatically against both ChatGPT and Claude hosts.
+The `mcp` and `inspector` fixtures handle all the plumbing: starting the inspector, connecting to your server, navigating to the tool, and traversing the double-iframe sandbox. Each test runs automatically against both ChatGPT and Claude hosts.
+
+There are two fixtures: `mcp` for protocol-level testing (`callTool`, `listTools`, etc., returning raw MCP data) and `inspector` for UI testing (`renderTool`, which renders the result in the inspector). When you pass `input` to `renderTool`, the tool is called on your real server and the result is rendered. Without `input`, the tool uses pre-baked simulation fixture data (if available) for fast, deterministic tests. See [Simulations](/testing/simulations#simulations-vs-real-server-calls) for more on when to use each approach.
 
 <Tip>
   Run `sunpeak inspect --server <url>` to browse your tools interactively and find the right tool names and arguments to use in tests.
@@ -165,6 +169,12 @@ Start with E2E tests (free, fast, local). Add visual regression when you want to
 
         // Option 3: HTTP server (no shell needed)
         // url: 'http://localhost:8000/mcp',
+
+        // Pass environment variables to the server process
+        env: { PYTHONPATH: './src', DATABASE_URL: 'sqlite:///test.db' },
+
+        // Set the working directory
+        cwd: './my-python-server',
       },
     });
     ```
@@ -178,6 +188,7 @@ Start with E2E tests (free, fast, local). Add visual regression when you want to
     export default defineConfig({
       server: {
         command: 'go', args: ['run', './cmd/server'],
+        env: { GO_ENV: 'test' },
 
         // Or connect to a running HTTP server:
         // url: 'http://localhost:8000/mcp',

--- a/docs/testing/inspector.mdx
+++ b/docs/testing/inspector.mdx
@@ -12,6 +12,39 @@ import InspectorSnippet from '/snippets/inspector.mdx';
 
 The `Inspector` component provides a local development environment that replicates the MCP App runtime used by hosts like ChatGPT and Claude. It renders your resources inside iframes, matching the production hosting behavior. The inspector supports multiple host shells — switch between ChatGPT and Claude conversation chrome, theming, and reported capabilities from the sidebar or via URL parameters.
 
+## CLI Usage
+
+```bash
+sunpeak inspect --server <url-or-command>
+```
+
+### CLI Flags
+
+| Flag | Description |
+|------|-------------|
+| `--server <url>` | HTTP URL or stdio command for the MCP server |
+| `--env KEY=VALUE` | Set an environment variable for stdio server processes. Repeatable. |
+| `--cwd <path>` | Working directory for stdio server processes |
+
+Examples:
+
+```bash
+# HTTP server
+sunpeak inspect --server http://localhost:8000/mcp
+
+# Python stdio server with env vars
+sunpeak inspect --server "python server.py" --env DATABASE_URL=sqlite:///test.db --env DEBUG=1
+
+# Stdio server with a working directory
+sunpeak inspect --server "python server.py" --cwd ./my-server
+```
+
+### Authentication
+
+sunpeak auto-negotiates MCP OAuth when connecting to servers that return 401 Unauthorized. For servers with auto-approved (anonymous) OAuth, this happens without user interaction. For servers requiring interactive login, sunpeak opens the authorization URL in your browser and waits for the callback.
+
+No configuration is needed. sunpeak follows the [MCP OAuth specification](https://spec.modelcontextprotocol.io), discovering metadata from `/.well-known/oauth-protected-resource` and registering a client dynamically.
+
 ## Import
 
 ```tsx

--- a/docs/testing/simulations.mdx
+++ b/docs/testing/simulations.mdx
@@ -143,6 +143,60 @@ The `when` object does shallow key matching against the tool call arguments. The
 
 Use `structuredContent` in the result to return structured data to the calling resource. For example, the review tool returns `{ status: 'success', message: '...' }` or `{ status: 'cancelled', message: '...' }` — the review resource reads `status` to determine success/error styling and displays `message`. Use `isError: true` only for actual tool execution failures.
 
+## Simulations vs real server calls
+
+When testing an external MCP server (Python, Go, etc.), you have two testing modes:
+
+**Simulation fixtures (fast, no server needed):** Write JSON files with pre-baked `toolResult` data. The inspector renders the result without calling your server. Use this for visual regression tests and UI state testing where you want fast, deterministic results.
+
+```typescript
+// Uses fixture data from tests/simulations/search.json
+const result = await inspector.renderTool('search');
+const app = result.app();
+await expect(app.getByText('Results')).toBeVisible();
+```
+
+**Real server calls (integration testing):** Pass `input` to `inspector.renderTool`. The inspector calls your MCP server with those arguments and renders the response. Use this to verify that your server returns correct data and the UI handles it properly. You can also use `mcp.callTool` for protocol-level assertions without rendering.
+
+```typescript
+// Calls the real server with { query: 'headphones' } and renders
+const result = await inspector.renderTool('search', { query: 'headphones' });
+expect(result).not.toBeError();
+const app = result.app();
+await expect(app.getByText('headphones')).toBeVisible();
+
+// Or test at the protocol level without rendering
+const raw = await mcp.callTool('search', { query: 'headphones' });
+expect(raw.isError).toBeFalsy();
+```
+
+Both modes work for external servers. Without any simulation fixtures, `inspector.renderTool` falls back to real server calls by default.
+
+### Simulation fixtures for external servers
+
+External servers don't have `src/tools/` directories. Instead, tools are auto-discovered via `listTools()` when the inspector connects. You can still write simulation fixtures to test specific UI states without calling the server. Create a `tests/simulations/` directory and pass it to your config:
+
+```typescript
+export default defineConfig({
+  server: { command: 'python', args: ['server.py'] },
+  simulationsDir: 'tests/simulations',
+});
+```
+
+The JSON format is the same as for sunpeak projects. The `tool` field references the tool name as reported by `listTools()`:
+
+```json
+{
+  "tool": "search",
+  "toolInput": { "query": "headphones" },
+  "toolResult": {
+    "structuredContent": {
+      "results": [{ "name": "Sony WH-1000XM5", "price": 348 }]
+    }
+  }
+}
+```
+
 ## Properties
 
 <ResponseField name="name" type="string" required>

--- a/docs/testing/troubleshooting.mdx
+++ b/docs/testing/troubleshooting.mdx
@@ -14,6 +14,27 @@ If the inspector loads but the resource iframe is blank:
 
 For standalone usage (`sunpeak inspect --server`), verify your MCP server is running and reachable at the URL you provided.
 
+## Stdio server fails to start
+
+When a stdio MCP server fails to start, sunpeak captures and displays the server's stderr output. This includes Python tracebacks, import errors, missing dependencies, and other startup failures. Check the error message for the specific cause.
+
+Common fixes:
+
+- **Python `ModuleNotFoundError`**: Install missing dependencies or set `PYTHONPATH` via the `env` option in your config or `--env` on the CLI.
+- **Wrong working directory**: Set `cwd` in your config or `--cwd` on the CLI so the server resolves relative imports correctly.
+- **Missing environment variables**: Pass them with `server.env` in `defineConfig()` or `--env KEY=VALUE` on the CLI.
+
+```typescript
+// Example: fixing a Python server that needs a specific working directory and env
+export default defineConfig({
+  server: {
+    command: 'python', args: ['server.py'],
+    cwd: './backend',
+    env: { PYTHONPATH: './src' },
+  },
+});
+```
+
 ## Tests failing with iframe errors
 
 E2E tests must use the double-iframe locator pattern because resource content renders inside a nested sandbox:
@@ -26,15 +47,38 @@ page.locator('.my-element')
 page.frameLocator('iframe').frameLocator('iframe').locator('.my-element')
 ```
 
-When using the `mcp` fixture from `sunpeak/test`, `result.app()` returns a locator already scoped to the inner iframe, so you don't need to chain `frameLocator` manually:
+When using the `inspector` fixture from `sunpeak/test`, `result.app()` returns a locator already scoped to the inner iframe, so you don't need to chain `frameLocator` manually:
 
 ```typescript
-const result = await mcp.callTool('show-albums');
+const result = await inspector.renderTool('show-albums');
 const app = result.app();
 await expect(app.locator('.my-element')).toBeVisible();
 ```
 
 See the [Inspector architecture](/testing/inspector) for details on the double-iframe sandbox.
+
+## MCP server requires authentication (OAuth)
+
+sunpeak auto-negotiates OAuth when connecting to MCP servers that require it. If your server returns a 401 response, sunpeak will:
+
+1. Discover the server's OAuth metadata
+2. Register a client dynamically
+3. Complete the authorization flow
+
+For servers with auto-approved (anonymous) OAuth, this happens automatically with no user interaction. For servers that require interactive login, sunpeak opens the authorization URL in your browser and waits for the callback.
+
+If OAuth negotiation fails, check that your server's OAuth endpoints are accessible and return standard MCP OAuth responses (`/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server`).
+
+## Server startup timeout
+
+If your MCP server takes a long time to start (compiling, loading large models, etc.), you may see a timeout error. Increase the startup timeout in your config:
+
+```typescript
+export default defineConfig({
+  server: { command: 'python', args: ['server.py'] },
+  timeout: 120_000, // 120 seconds (default: 60000)
+});
+```
 
 ## Flaky E2E tests
 

--- a/docs/testing/visual.mdx
+++ b/docs/testing/visual.mdx
@@ -8,7 +8,7 @@ keywords: ["MCP app testing", "visual regression", "screenshot testing", "Playwr
 
 Visual regression tests capture screenshots of your resources and compare them against saved baselines. This catches unintended visual changes across themes, display modes, and hosts.
 
-Screenshot comparisons only run when you pass `--visual`. Without it, `mcp.screenshot()` calls are silently skipped, so you can include them in your regular e2e tests without affecting normal runs.
+Screenshot comparisons only run when you pass `--visual`. Without it, `result.screenshot()` calls are silently skipped, so you can include them in your regular e2e tests without affecting normal runs.
 
 ## Running Visual Tests
 
@@ -19,25 +19,25 @@ sunpeak test --visual --update         # Update baselines
 
 ## Writing Visual Tests
 
-Use `mcp.screenshot()` in any e2e test. It accepts an optional name and Playwright `toHaveScreenshot` options:
+Use `result.screenshot()` in any e2e test. It accepts an optional name and Playwright `toHaveScreenshot` options:
 
 ```typescript
 import { test, expect } from 'sunpeak/test';
 
-test('albums renders correctly in light mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { theme: 'light' });
+test('albums renders correctly in light mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', {}, { theme: 'light' });
   const app = result.app();
   await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
 
-  await mcp.screenshot('albums-light');
+  await result.screenshot('albums-light');
 });
 
-test('albums renders correctly in dark mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { theme: 'dark' });
+test('albums renders correctly in dark mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', {}, { theme: 'dark' });
   const app = result.app();
   await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
 
-  await mcp.screenshot('albums-dark');
+  await result.screenshot('albums-dark');
 });
 ```
 
@@ -47,13 +47,13 @@ By default, `screenshot()` captures the app content inside the double-iframe. Us
 
 ```typescript
 // Screenshot just the app (default)
-await mcp.screenshot('app-view');
+await result.screenshot('app-view');
 
 // Screenshot the full inspector page (host chrome + app)
-await mcp.screenshot('full-page', { target: 'page' });
+await result.screenshot('full-page', { target: 'page' });
 
 // Screenshot a specific element
-await mcp.screenshot('album-card', {
+await result.screenshot('album-card', {
   element: result.app().locator('button:has-text("Summer Slice")'),
 });
 ```

--- a/examples/albums-example/package.json
+++ b/examples/albums-example/package.json
@@ -17,7 +17,7 @@
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",
     "embla-carousel-wheel-gestures": "^8.1.0",
-    "sunpeak": "^0.19.13",
+    "sunpeak": "^0.20.0",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"
   },

--- a/examples/albums-example/tests/e2e/albums.spec.ts
+++ b/examples/albums-example/tests/e2e/albums.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from 'sunpeak/test';
 
-test('should render album cards with correct styles', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums');
+test('should render album cards with correct styles', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums');
   const app = result.app();
 
   const albumCard = app.locator('button:has-text("Summer Slice")');
@@ -15,8 +15,8 @@ test('should render album cards with correct styles', async ({ mcp }) => {
   expect(styles.borderRadius).toBe('12px');
 });
 
-test('should have album image with correct aspect ratio', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums');
+test('should have album image with correct aspect ratio', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums');
   const app = result.app();
 
   const imageContainer = app.locator('button:has-text("Summer Slice") .aspect-\\[4\\/3\\]');
@@ -30,8 +30,8 @@ test('should have album image with correct aspect ratio', async ({ mcp }) => {
   expect(styles.overflow).toBe('hidden');
 });
 
-test('should render album cards in dark mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { theme: 'dark' });
+test('should render album cards in dark mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', undefined, { theme: 'dark' });
   const app = result.app();
 
   const albumTitle = app.locator('button:has-text("Summer Slice") div').first();
@@ -43,44 +43,16 @@ test('should render album cards in dark mode', async ({ mcp }) => {
   expect(titleStyles.color).toBeTruthy();
 });
 
-test('should show empty state with Run button in prod tools mode', async ({ mcp }) => {
-  await mcp.openTool('show-albums', { theme: 'dark' });
-
-  await expect(mcp.page.locator('text=Press Run to call the tool')).toBeVisible();
-  await expect(mcp.page.locator('button:has-text("Run")')).toBeVisible();
-  await expect(mcp.page.locator('iframe')).not.toBeAttached();
-});
-
-test('should have themed empty state colors in light mode', async ({ mcp }) => {
-  await mcp.openTool('show-albums', { theme: 'light' });
-
-  const emptyState = mcp.page.locator('text=Press Run to call the tool');
-  await expect(emptyState).toBeVisible();
-
-  const color = await emptyState.evaluate((el) => window.getComputedStyle(el).color);
-  const [r, g, b] = color.match(/\d+/g)!.map(Number);
-  expect(r + g + b).toBeLessThan(600);
-});
-
-test('should have themed empty state colors in dark mode', async ({ mcp }) => {
-  await mcp.openTool('show-albums', { theme: 'dark' });
-
-  const emptyState = mcp.page.locator('text=Press Run to call the tool');
-  await expect(emptyState).toBeVisible();
-
-  const color = await emptyState.evaluate((el) => window.getComputedStyle(el).color);
-  const [r, g, b] = color.match(/\d+/g)!.map(Number);
-  expect(r + g + b).toBeGreaterThan(200);
-});
-
-test('should activate prod resources mode without errors', async ({ mcp }) => {
-  await mcp.callTool('show-albums', {}, { theme: 'dark', prodResources: true });
-  const root = mcp.page.locator('#root');
+test('should activate prod resources mode without errors', async ({ inspector }) => {
+  await inspector.renderTool('show-albums', undefined, { theme: 'dark', prodResources: true });
+  const root = inspector.page.locator('#root');
   await expect(root).not.toBeEmpty();
 });
 
-test('should render correctly in fullscreen', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { displayMode: 'fullscreen' });
+test('should render correctly in fullscreen', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', undefined, {
+    displayMode: 'fullscreen',
+  });
   const app = result.app();
 
   const albumCard = app.locator('button:has-text("Summer Slice")');
@@ -94,22 +66,22 @@ test('should render correctly in fullscreen', async ({ mcp }) => {
   expect(styles.borderRadius).toBe('12px');
 });
 
-test('should preserve content when switching to fullscreen', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { theme: 'dark' });
+test('should render content in fullscreen mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', undefined, {
+    theme: 'dark',
+    displayMode: 'fullscreen',
+  });
   const app = result.app();
   await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
-
-  await mcp.setDisplayMode('fullscreen');
-  await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible({ timeout: 5000 });
 });
 
-test('should preserve content when switching to PiP', async ({ mcp }) => {
-  test.skip(mcp.host === 'claude', 'Claude does not support PiP');
+test('should render content in PiP mode', async ({ inspector }) => {
+  test.skip(inspector.host === 'claude', 'Claude does not support PiP');
 
-  const result = await mcp.callTool('show-albums', {}, { theme: 'dark' });
+  const result = await inspector.renderTool('show-albums', undefined, {
+    theme: 'dark',
+    displayMode: 'pip',
+  });
   const app = result.app();
   await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
-
-  await mcp.setDisplayMode('pip');
-  await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible({ timeout: 5000 });
 });

--- a/examples/carousel-example/package.json
+++ b/examples/carousel-example/package.json
@@ -17,7 +17,7 @@
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",
     "embla-carousel-wheel-gestures": "^8.1.0",
-    "sunpeak": "^0.19.13",
+    "sunpeak": "^0.20.0",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"
   },

--- a/examples/carousel-example/tests/e2e/carousel.spec.ts
+++ b/examples/carousel-example/tests/e2e/carousel.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from 'sunpeak/test';
 
-test('should render carousel cards with correct styles', async ({ mcp }) => {
-  const result = await mcp.callTool('show-carousel');
+test('should render carousel cards with correct styles', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-carousel');
   const app = result.app();
 
   const card = app.locator('.rounded-2xl').first();
@@ -15,8 +15,8 @@ test('should render carousel cards with correct styles', async ({ mcp }) => {
   expect(styles.cursor).toBe('pointer');
 });
 
-test('should have card with border styling', async ({ mcp }) => {
-  const result = await mcp.callTool('show-carousel');
+test('should have card with border styling', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-carousel');
   const app = result.app();
 
   const card = app.locator('.rounded-2xl.border').first();
@@ -30,8 +30,8 @@ test('should have card with border styling', async ({ mcp }) => {
   expect(styles.borderStyle).toBe('solid');
 });
 
-test('should have interactive buttons', async ({ mcp }) => {
-  const result = await mcp.callTool('show-carousel');
+test('should have interactive buttons', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-carousel');
   const app = result.app();
 
   const visitButton = app.locator('button:has-text("Visit")').first();
@@ -43,51 +43,23 @@ test('should have interactive buttons', async ({ mcp }) => {
   expect(styles.cursor).toBe('pointer');
 });
 
-test('should show empty state with Run button in prod tools mode', async ({ mcp }) => {
-  await mcp.openTool('show-carousel', { theme: 'dark' });
-
-  await expect(mcp.page.locator('text=Press Run to call the tool')).toBeVisible();
-  await expect(mcp.page.locator('button:has-text("Run")')).toBeVisible();
-  await expect(mcp.page.locator('iframe')).not.toBeAttached();
-});
-
-test('should have themed empty state colors in light mode', async ({ mcp }) => {
-  await mcp.openTool('show-carousel', { theme: 'light' });
-
-  const emptyState = mcp.page.locator('text=Press Run to call the tool');
-  await expect(emptyState).toBeVisible();
-
-  const color = await emptyState.evaluate((el) => window.getComputedStyle(el).color);
-  const [r, g, b] = color.match(/\d+/g)!.map(Number);
-  expect(r + g + b).toBeLessThan(600);
-});
-
-test('should have themed empty state colors in dark mode', async ({ mcp }) => {
-  await mcp.openTool('show-carousel', { theme: 'dark' });
-
-  const emptyState = mcp.page.locator('text=Press Run to call the tool');
-  await expect(emptyState).toBeVisible();
-
-  const color = await emptyState.evaluate((el) => window.getComputedStyle(el).color);
-  const [r, g, b] = color.match(/\d+/g)!.map(Number);
-  expect(r + g + b).toBeGreaterThan(200);
-});
-
-test('should activate prod resources mode without errors', async ({ mcp }) => {
-  await mcp.callTool('show-carousel', {}, { theme: 'dark', prodResources: true });
-  const root = mcp.page.locator('#root');
+test('should activate prod resources mode without errors', async ({ inspector }) => {
+  await inspector.renderTool('show-carousel', undefined, { theme: 'dark', prodResources: true });
+  const root = inspector.page.locator('#root');
   await expect(root).not.toBeEmpty();
 });
 
-test('should render correctly in fullscreen', async ({ mcp }) => {
-  await mcp.callTool('show-carousel', {}, { displayMode: 'fullscreen' });
-  await mcp.page.waitForLoadState('networkidle');
-  const root = mcp.page.locator('#root');
+test('should render correctly in fullscreen', async ({ inspector }) => {
+  await inspector.renderTool('show-carousel', undefined, { displayMode: 'fullscreen' });
+  await inspector.page.waitForLoadState('networkidle');
+  const root = inspector.page.locator('#root');
   await expect(root).not.toBeEmpty();
 });
 
-test('should show detail view with place info in fullscreen', async ({ mcp }) => {
-  const result = await mcp.callTool('show-carousel', {}, { displayMode: 'fullscreen' });
+test('should show detail view with place info in fullscreen', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-carousel', undefined, {
+    displayMode: 'fullscreen',
+  });
   const app = result.app();
 
   const card = app.locator('.rounded-2xl').first();
@@ -99,8 +71,10 @@ test('should show detail view with place info in fullscreen', async ({ mcp }) =>
   await expect(app.locator('text=Tips')).toBeVisible();
 });
 
-test('should show detail view when Learn More is clicked', async ({ mcp }) => {
-  const result = await mcp.callTool('show-carousel', {}, { displayMode: 'fullscreen' });
+test('should show detail view when Learn More is clicked', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-carousel', undefined, {
+    displayMode: 'fullscreen',
+  });
   const app = result.app();
 
   const learnMore = app.locator('button:has-text("Learn More")').first();
@@ -111,8 +85,10 @@ test('should show detail view when Learn More is clicked', async ({ mcp }) => {
   await expect(app.locator('text=Address')).toBeVisible();
 });
 
-test('should not have a back button in detail view', async ({ mcp }) => {
-  const result = await mcp.callTool('show-carousel', {}, { displayMode: 'fullscreen' });
+test('should not have a back button in detail view', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-carousel', undefined, {
+    displayMode: 'fullscreen',
+  });
   const app = result.app();
 
   const card = app.locator('.rounded-2xl').first();
@@ -124,8 +100,10 @@ test('should not have a back button in detail view', async ({ mcp }) => {
   await expect(backButton).not.toBeAttached();
 });
 
-test('should center the hero image without stretching', async ({ mcp }) => {
-  const result = await mcp.callTool('show-carousel', {}, { displayMode: 'fullscreen' });
+test('should center the hero image without stretching', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-carousel', undefined, {
+    displayMode: 'fullscreen',
+  });
   const app = result.app();
 
   const card = app.locator('.rounded-2xl').first();
@@ -140,8 +118,8 @@ test('should center the hero image without stretching', async ({ mcp }) => {
   expect(styles.justifyContent).toBe('center');
 });
 
-test('should render carousel in dark mode with correct styles', async ({ mcp }) => {
-  const result = await mcp.callTool('show-carousel', {}, { theme: 'dark' });
+test('should render carousel in dark mode with correct styles', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-carousel', undefined, { theme: 'dark' });
   const app = result.app();
 
   const card = app.locator('.rounded-2xl').first();
@@ -155,8 +133,8 @@ test('should render carousel in dark mode with correct styles', async ({ mcp }) 
   expect(styles.cursor).toBe('pointer');
 });
 
-test('should have appropriate dark mode styling', async ({ mcp }) => {
-  const result = await mcp.callTool('show-carousel', {}, { theme: 'dark' });
+test('should have appropriate dark mode styling', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-carousel', undefined, { theme: 'dark' });
   const app = result.app();
 
   const card = app.locator('.rounded-2xl.border').first();
@@ -170,13 +148,13 @@ test('should have appropriate dark mode styling', async ({ mcp }) => {
   expect(styles.borderStyle).toBe('solid');
 });
 
-test('should load without console errors in dark mode', async ({ mcp }) => {
+test('should load without console errors in dark mode', async ({ inspector }) => {
   const errors: string[] = [];
-  mcp.page.on('console', (msg) => {
+  inspector.page.on('console', (msg) => {
     if (msg.type() === 'error') errors.push(msg.text());
   });
 
-  const result = await mcp.callTool('show-carousel', {}, { theme: 'dark' });
+  const result = await inspector.renderTool('show-carousel', undefined, { theme: 'dark' });
   const app = result.app();
   await expect(app.locator('.rounded-2xl').first()).toBeVisible();
 

--- a/examples/map-example/package.json
+++ b/examples/map-example/package.json
@@ -17,7 +17,7 @@
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",
     "mapbox-gl": "^3.21.0",
-    "sunpeak": "^0.19.13",
+    "sunpeak": "^0.20.0",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"
   },

--- a/examples/map-example/tests/e2e/map.spec.ts
+++ b/examples/map-example/tests/e2e/map.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from 'sunpeak/test';
 
-test('should render map container with correct styles', async ({ mcp }) => {
-  const result = await mcp.callTool('show-map');
+test('should render map container with correct styles', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-map');
   const app = result.app();
 
   const mapContainer = app.locator('.antialiased.w-full.overflow-hidden').first();
@@ -13,8 +13,8 @@ test('should render map container with correct styles', async ({ mcp }) => {
   expect(styles.overflow).toBe('hidden');
 });
 
-test('should have rounded border in inline mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-map', {}, { displayMode: 'inline' });
+test('should have rounded border in inline mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-map', undefined, { displayMode: 'inline' });
   const app = result.app();
 
   const innerContainer = app.locator('.border.rounded-2xl').first();
@@ -26,8 +26,8 @@ test('should have rounded border in inline mode', async ({ mcp }) => {
   expect(parseInt(styles.borderRadius)).toBeGreaterThanOrEqual(16);
 });
 
-test('should have fullscreen expand button in inline mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-map', {}, { displayMode: 'inline' });
+test('should have fullscreen expand button in inline mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-map', undefined, { displayMode: 'inline' });
   const app = result.app();
 
   const expandButton = app.locator('button[aria-label="Enter fullscreen"]');
@@ -41,13 +41,13 @@ test('should have fullscreen expand button in inline mode', async ({ mcp }) => {
   expect(styles.position).toBe('absolute');
 });
 
-test('should load without console errors in light mode', async ({ mcp }) => {
+test('should load without console errors in light mode', async ({ inspector }) => {
   const errors: string[] = [];
-  mcp.page.on('console', (msg) => {
+  inspector.page.on('console', (msg) => {
     if (msg.type() === 'error') errors.push(msg.text());
   });
 
-  const result = await mcp.callTool('show-map');
+  const result = await inspector.renderTool('show-map');
   const app = result.app();
   await expect(app.locator('.antialiased.w-full.overflow-hidden').first()).toBeVisible({
     timeout: 10000,
@@ -63,52 +63,25 @@ test('should load without console errors in light mode', async ({ mcp }) => {
   expect(unexpectedErrors).toHaveLength(0);
 });
 
-test('should show empty state with Run button in prod tools mode', async ({ mcp }) => {
-  await mcp.openTool('show-map', { theme: 'dark' });
-
-  await expect(mcp.page.locator('text=Press Run to call the tool')).toBeVisible();
-  await expect(mcp.page.locator('button:has-text("Run")')).toBeVisible();
-  await expect(mcp.page.locator('iframe')).not.toBeAttached();
-});
-
-test('should have themed empty state colors in light mode', async ({ mcp }) => {
-  await mcp.openTool('show-map', { theme: 'light' });
-
-  const emptyState = mcp.page.locator('text=Press Run to call the tool');
-  await expect(emptyState).toBeVisible();
-
-  const color = await emptyState.evaluate((el) => window.getComputedStyle(el).color);
-  const [r, g, b] = color.match(/\d+/g)!.map(Number);
-  expect(r + g + b).toBeLessThan(600);
-});
-
-test('should have themed empty state colors in dark mode', async ({ mcp }) => {
-  await mcp.openTool('show-map', { theme: 'dark' });
-
-  const emptyState = mcp.page.locator('text=Press Run to call the tool');
-  await expect(emptyState).toBeVisible();
-
-  const color = await emptyState.evaluate((el) => window.getComputedStyle(el).color);
-  const [r, g, b] = color.match(/\d+/g)!.map(Number);
-  expect(r + g + b).toBeGreaterThan(200);
-});
-
-test('should activate prod resources mode without errors', async ({ mcp }) => {
-  await mcp.callTool('show-map', {}, { theme: 'dark', prodResources: true });
-  const root = mcp.page.locator('#root');
+test('should activate prod resources mode without errors', async ({ inspector }) => {
+  await inspector.renderTool('show-map', undefined, { theme: 'dark', prodResources: true });
+  const root = inspector.page.locator('#root');
   await expect(root).not.toBeEmpty();
 });
 
-test('should render map in dark mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-map', {}, { theme: 'dark' });
+test('should render map in dark mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-map', undefined, { theme: 'dark' });
   const app = result.app();
   await expect(app.locator('.antialiased.w-full.overflow-hidden').first()).toBeVisible({
     timeout: 10000,
   });
 });
 
-test('should have appropriate border color in dark mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-map', {}, { theme: 'dark', displayMode: 'inline' });
+test('should have appropriate border color in dark mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-map', undefined, {
+    theme: 'dark',
+    displayMode: 'inline',
+  });
   const app = result.app();
 
   const innerContainer = app.locator('.border.rounded-2xl').first();
@@ -120,13 +93,13 @@ test('should have appropriate border color in dark mode', async ({ mcp }) => {
   expect(styles.borderColor).toBeTruthy();
 });
 
-test('should load without console errors in dark mode', async ({ mcp }) => {
+test('should load without console errors in dark mode', async ({ inspector }) => {
   const errors: string[] = [];
-  mcp.page.on('console', (msg) => {
+  inspector.page.on('console', (msg) => {
     if (msg.type() === 'error') errors.push(msg.text());
   });
 
-  const result = await mcp.callTool('show-map', {}, { theme: 'dark' });
+  const result = await inspector.renderTool('show-map', undefined, { theme: 'dark' });
   const app = result.app();
   await expect(app.locator('.antialiased.w-full.overflow-hidden').first()).toBeVisible({
     timeout: 10000,
@@ -142,8 +115,10 @@ test('should load without console errors in dark mode', async ({ mcp }) => {
   expect(unexpectedErrors).toHaveLength(0);
 });
 
-test('should not have rounded border in fullscreen mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-map', {}, { displayMode: 'fullscreen' });
+test('should not have rounded border in fullscreen mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-map', undefined, {
+    displayMode: 'fullscreen',
+  });
   const app = result.app();
 
   const innerContainer = app.locator('.rounded-none.border-0').first();
@@ -155,8 +130,10 @@ test('should not have rounded border in fullscreen mode', async ({ mcp }) => {
   expect(styles.borderRadius).toBe('0px');
 });
 
-test('should not show fullscreen button in fullscreen mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-map', {}, { displayMode: 'fullscreen' });
+test('should not show fullscreen button in fullscreen mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-map', undefined, {
+    displayMode: 'fullscreen',
+  });
   const app = result.app();
 
   await expect(app.locator('.antialiased.w-full.overflow-hidden').first()).toBeVisible({
@@ -165,10 +142,12 @@ test('should not show fullscreen button in fullscreen mode', async ({ mcp }) => 
   await expect(app.locator('button[aria-label="Enter fullscreen"]')).not.toBeVisible();
 });
 
-test('should show suggestion chips in fullscreen on desktop', async ({ mcp }) => {
-  await mcp.page.setViewportSize({ width: 1024, height: 768 });
+test('should show suggestion chips in fullscreen on desktop', async ({ inspector }) => {
+  await inspector.page.setViewportSize({ width: 1024, height: 768 });
 
-  const result = await mcp.callTool('show-map', {}, { displayMode: 'fullscreen' });
+  const result = await inspector.renderTool('show-map', undefined, {
+    displayMode: 'fullscreen',
+  });
   const app = result.app();
 
   await expect(app.locator('.antialiased.w-full.overflow-hidden').first()).toBeVisible({

--- a/examples/review-example/package.json
+++ b/examples/review-example/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
-    "sunpeak": "^0.19.13",
+    "sunpeak": "^0.20.0",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"
   },

--- a/examples/review-example/tests/e2e/review.spec.ts
+++ b/examples/review-example/tests/e2e/review.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from 'sunpeak/test';
 
-test('should render review title with correct styles', async ({ mcp }) => {
-  const result = await mcp.callTool('review-diff');
+test('should render review title with correct styles', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-diff');
   const app = result.app();
 
   const title = app.locator('h1:has-text("Refactor Authentication Module")');
@@ -13,8 +13,8 @@ test('should render review title with correct styles', async ({ mcp }) => {
   expect(parseInt(styles.fontWeight)).toBeGreaterThanOrEqual(600);
 });
 
-test('should render change items with type-specific styling', async ({ mcp }) => {
-  const result = await mcp.callTool('review-diff');
+test('should render change items with type-specific styling', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-diff');
   const app = result.app();
 
   const changeItem = app.locator('li').first();
@@ -27,8 +27,8 @@ test('should render change items with type-specific styling', async ({ mcp }) =>
   expect(styles.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
 });
 
-test('should have interactive apply and cancel buttons', async ({ mcp }) => {
-  const result = await mcp.callTool('review-diff');
+test('should have interactive apply and cancel buttons', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-diff');
   const app = result.app();
 
   const applyButton = app.locator('button:has-text("Apply Changes")');
@@ -40,8 +40,8 @@ test('should have interactive apply and cancel buttons', async ({ mcp }) => {
   expect(await cancelButton.evaluate((el) => window.getComputedStyle(el).cursor)).toBe('pointer');
 });
 
-test('should have expand fullscreen button in inline mode', async ({ mcp }) => {
-  const result = await mcp.callTool('review-diff', {}, { displayMode: 'inline' });
+test('should have expand fullscreen button in inline mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-diff', undefined, { displayMode: 'inline' });
   const app = result.app();
 
   const expandButton = app.locator('button[aria-label="Enter fullscreen"]');
@@ -49,50 +49,20 @@ test('should have expand fullscreen button in inline mode', async ({ mcp }) => {
   expect(await expandButton.evaluate((el) => window.getComputedStyle(el).cursor)).toBe('pointer');
 });
 
-test('should show empty state with Run button in prod tools mode', async ({ mcp }) => {
-  await mcp.openTool('review-diff', { theme: 'dark' });
-
-  await expect(mcp.page.locator('text=Press Run to call the tool')).toBeVisible();
-  await expect(mcp.page.locator('button:has-text("Run")')).toBeVisible();
-  await expect(mcp.page.locator('iframe')).not.toBeAttached();
-});
-
-test('should have themed empty state colors in light mode', async ({ mcp }) => {
-  await mcp.openTool('review-diff', { theme: 'light' });
-
-  const emptyState = mcp.page.locator('text=Press Run to call the tool');
-  await expect(emptyState).toBeVisible();
-
-  const color = await emptyState.evaluate((el) => window.getComputedStyle(el).color);
-  const [r, g, b] = color.match(/\d+/g)!.map(Number);
-  expect(r + g + b).toBeLessThan(600);
-});
-
-test('should have themed empty state colors in dark mode', async ({ mcp }) => {
-  await mcp.openTool('review-diff', { theme: 'dark' });
-
-  const emptyState = mcp.page.locator('text=Press Run to call the tool');
-  await expect(emptyState).toBeVisible();
-
-  const color = await emptyState.evaluate((el) => window.getComputedStyle(el).color);
-  const [r, g, b] = color.match(/\d+/g)!.map(Number);
-  expect(r + g + b).toBeGreaterThan(200);
-});
-
-test('should activate prod resources mode without errors', async ({ mcp }) => {
-  await mcp.callTool('review-diff', {}, { theme: 'dark', prodResources: true });
-  const root = mcp.page.locator('#root');
+test('should activate prod resources mode without errors', async ({ inspector }) => {
+  await inspector.renderTool('review-diff', undefined, { theme: 'dark', prodResources: true });
+  const root = inspector.page.locator('#root');
   await expect(root).not.toBeEmpty();
 });
 
-test('should render review title in dark mode', async ({ mcp }) => {
-  const result = await mcp.callTool('review-diff', {}, { theme: 'dark' });
+test('should render review title in dark mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-diff', undefined, { theme: 'dark' });
   const app = result.app();
   await expect(app.locator('h1:has-text("Refactor Authentication Module")')).toBeVisible();
 });
 
-test('should have appropriate text colors in dark mode', async ({ mcp }) => {
-  const result = await mcp.callTool('review-diff', {}, { theme: 'dark' });
+test('should have appropriate text colors in dark mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-diff', undefined, { theme: 'dark' });
   const app = result.app();
 
   const title = app.locator('h1').first();
@@ -104,19 +74,19 @@ test('should have appropriate text colors in dark mode', async ({ mcp }) => {
   expect(styles.color).toBeTruthy();
 });
 
-test('should render change items in dark mode', async ({ mcp }) => {
-  const result = await mcp.callTool('review-diff', {}, { theme: 'dark' });
+test('should render change items in dark mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-diff', undefined, { theme: 'dark' });
   const app = result.app();
   await expect(app.locator('li').first()).toBeVisible();
 });
 
-test('should load without console errors in dark mode', async ({ mcp }) => {
+test('should load without console errors in dark mode', async ({ inspector }) => {
   const errors: string[] = [];
-  mcp.page.on('console', (msg) => {
+  inspector.page.on('console', (msg) => {
     if (msg.type() === 'error') errors.push(msg.text());
   });
 
-  const result = await mcp.callTool('review-diff', {}, { theme: 'dark' });
+  const result = await inspector.renderTool('review-diff', undefined, { theme: 'dark' });
   const app = result.app();
   await expect(app.locator('h1').first()).toBeVisible();
 
@@ -130,40 +100,41 @@ test('should load without console errors in dark mode', async ({ mcp }) => {
   expect(unexpectedErrors).toHaveLength(0);
 });
 
-test('should not show fullscreen button in fullscreen mode', async ({ mcp }) => {
-  const result = await mcp.callTool('review-diff', {}, { displayMode: 'fullscreen' });
+test('should not show fullscreen button in fullscreen mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-diff', undefined, {
+    displayMode: 'fullscreen',
+  });
   const app = result.app();
 
   await expect(app.locator('h1').first()).toBeVisible();
   await expect(app.locator('button[aria-label="Enter fullscreen"]')).not.toBeVisible();
 });
 
-test('should render content in fullscreen mode', async ({ mcp }) => {
-  const result = await mcp.callTool(
-    'review-diff',
-    {},
-    { theme: 'dark', displayMode: 'fullscreen' }
-  );
+test('should render content in fullscreen mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-diff', undefined, {
+    theme: 'dark',
+    displayMode: 'fullscreen',
+  });
   const app = result.app();
 
-  await expect(mcp.page.locator('#root')).not.toBeEmpty();
+  await expect(inspector.page.locator('#root')).not.toBeEmpty();
   await expect(app.locator('h1')).toBeVisible();
 });
 
-test('should render post review in light mode', async ({ mcp }) => {
-  await mcp.callTool('review-post');
-  await mcp.page.waitForLoadState('networkidle');
-  await expect(mcp.page.locator('#root')).not.toBeEmpty();
+test('should render post review in light mode', async ({ inspector }) => {
+  await inspector.renderTool('review-post');
+  await inspector.page.waitForLoadState('networkidle');
+  await expect(inspector.page.locator('#root')).not.toBeEmpty();
 });
 
-test('should render post review in dark mode', async ({ mcp }) => {
-  await mcp.callTool('review-post', {}, { theme: 'dark' });
-  await mcp.page.waitForLoadState('networkidle');
-  await expect(mcp.page.locator('#root')).not.toBeEmpty();
+test('should render post review in dark mode', async ({ inspector }) => {
+  await inspector.renderTool('review-post', undefined, { theme: 'dark' });
+  await inspector.page.waitForLoadState('networkidle');
+  await expect(inspector.page.locator('#root')).not.toBeEmpty();
 });
 
-test('should show server success message when confirming post', async ({ mcp }) => {
-  const result = await mcp.callTool('review-post', {}, { theme: 'dark' });
+test('should show server success message when confirming post', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-post', undefined, { theme: 'dark' });
   const app = result.app();
 
   const publishButton = app.locator('button:has-text("Publish")');
@@ -174,8 +145,8 @@ test('should show server success message when confirming post', async ({ mcp }) 
   await expect(app.locator('text=Publishing post...')).toBeVisible({ timeout: 10000 });
 });
 
-test('should show server cancel message when rejecting post', async ({ mcp }) => {
-  const result = await mcp.callTool('review-post', {}, { theme: 'dark' });
+test('should show server cancel message when rejecting post', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-post', undefined, { theme: 'dark' });
   const app = result.app();
 
   const cancelButton = app.locator('button:has-text("Cancel")');
@@ -185,20 +156,20 @@ test('should show server cancel message when rejecting post', async ({ mcp }) =>
   await expect(app.locator('text=Cancelled.')).toBeVisible({ timeout: 10000 });
 });
 
-test('should render purchase review in light mode', async ({ mcp }) => {
-  await mcp.callTool('review-purchase');
-  await mcp.page.waitForLoadState('networkidle');
-  await expect(mcp.page.locator('#root')).not.toBeEmpty();
+test('should render purchase review in light mode', async ({ inspector }) => {
+  await inspector.renderTool('review-purchase');
+  await inspector.page.waitForLoadState('networkidle');
+  await expect(inspector.page.locator('#root')).not.toBeEmpty();
 });
 
-test('should render purchase review in dark mode', async ({ mcp }) => {
-  await mcp.callTool('review-purchase', {}, { theme: 'dark' });
-  await mcp.page.waitForLoadState('networkidle');
-  await expect(mcp.page.locator('#root')).not.toBeEmpty();
+test('should render purchase review in dark mode', async ({ inspector }) => {
+  await inspector.renderTool('review-purchase', undefined, { theme: 'dark' });
+  await inspector.page.waitForLoadState('networkidle');
+  await expect(inspector.page.locator('#root')).not.toBeEmpty();
 });
 
-test('should show loading then result when placing order', async ({ mcp }) => {
-  const result = await mcp.callTool('review-purchase');
+test('should show loading then result when placing order', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-purchase');
   const app = result.app();
 
   const placeOrderButton = app.locator('button:has-text("Place Order")');
@@ -209,8 +180,8 @@ test('should show loading then result when placing order', async ({ mcp }) => {
   await expect(app.locator('text=Completed.')).toBeVisible({ timeout: 10000 });
 });
 
-test('should confirm review-diff and show server success', async ({ mcp }) => {
-  const result = await mcp.callTool('review-diff', {}, { theme: 'dark' });
+test('should confirm review-diff and show server success', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-diff', undefined, { theme: 'dark' });
   const app = result.app();
 
   const applyButton = app.locator('button:has-text("Apply Changes")');
@@ -221,8 +192,8 @@ test('should confirm review-diff and show server success', async ({ mcp }) => {
   await expect(app.locator('text=Completed.')).toBeVisible({ timeout: 10000 });
 });
 
-test('should cancel review-diff and show server cancelled', async ({ mcp }) => {
-  const result = await mcp.callTool('review-diff', {}, { theme: 'dark' });
+test('should cancel review-diff and show server cancelled', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-diff', undefined, { theme: 'dark' });
   const app = result.app();
 
   const cancelButton = app.locator('button:has-text("Cancel")');

--- a/packages/sunpeak/README.md
+++ b/packages/sunpeak/README.md
@@ -53,8 +53,8 @@ Automatically test any MCP server against replicated ChatGPT and Claude runtimes
 ```ts
 import { test, expect } from 'sunpeak/test';
 
-test('review tool renders title', async ({ mcp }) => {
-  const result = await mcp.callTool('review-diff');
+test('review tool renders title', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-diff');
   const app = result.app();
   await expect(app.locator('h1:has-text("Refactor")')).toBeVisible();
 });

--- a/packages/sunpeak/bin/commands/inspect.mjs
+++ b/packages/sunpeak/bin/commands/inspect.mjs
@@ -18,6 +18,7 @@ import * as path from 'path';
 const { existsSync, readdirSync, readFileSync } = fs;
 const { join, resolve, dirname } = path;
 import { fileURLToPath, pathToFileURL } from 'url';
+import { createServer as createHttpServer } from 'http';
 import { getPort } from '../lib/get-port.mjs';
 import { startSandboxServer } from '../lib/sandbox-server.mjs';
 import { getDevOverlayScript } from '../lib/dev-overlay.mjs';
@@ -35,6 +36,8 @@ function parseArgs(args) {
     simulations: undefined,
     port: undefined,
     name: undefined,
+    env: undefined,
+    cwd: undefined,
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -47,6 +50,16 @@ function parseArgs(args) {
       opts.port = Number(args[++i]);
     } else if (arg === '--name' && i + 1 < args.length) {
       opts.name = args[++i];
+    } else if (arg === '--env' && i + 1 < args.length) {
+      // Repeatable: --env KEY=VALUE --env KEY2=VALUE2
+      const pair = args[++i];
+      const eqIdx = pair.indexOf('=');
+      if (eqIdx > 0) {
+        opts.env = opts.env || {};
+        opts.env[pair.slice(0, eqIdx)] = pair.slice(eqIdx + 1);
+      }
+    } else if (arg === '--cwd' && i + 1 < args.length) {
+      opts.cwd = args[++i];
     } else if (arg === '--help' || arg === '-h') {
       printHelp();
       process.exit(0);
@@ -68,11 +81,14 @@ Options:
   --simulations <dir>        Simulation JSON directory (opt-in, no default)
   --port, -p <number>        Dev server port (default: 3000)
   --name <string>            App name in inspector chrome
+  --env <KEY=VALUE>          Environment variable for stdio servers (repeatable)
+  --cwd <path>               Working directory for stdio servers
   --help, -h                 Show this help
 
 Examples:
   sunpeak inspect --server http://localhost:8000/mcp
   sunpeak inspect --server "python my_server.py"
+  sunpeak inspect --server "python server.py" --env API_KEY=sk-123 --cwd ./backend
   sunpeak inspect --server http://localhost:8000/mcp --simulations tests/simulations
 `);
 }
@@ -161,10 +177,218 @@ function createInMemoryOAuthProvider(redirectUrl, opts = {}) {
 }
 
 /**
+ * Negotiate OAuth with an MCP server and return an authenticated provider.
+ *
+ * Handles two cases:
+ * 1. Anonymous/auto-approved OAuth: the authorization endpoint redirects
+ *    immediately back with a code (no user interaction needed).
+ * 2. Interactive OAuth: opens the authorization URL in the user's browser
+ *    and waits for the callback.
+ *
+ * @param {string} serverUrl - The MCP server URL
+ * @returns {Promise<import('@modelcontextprotocol/sdk/client/auth.js').OAuthClientProvider>}
+ */
+async function negotiateOAuth(serverUrl) {
+  const { auth } = await import('@modelcontextprotocol/sdk/client/auth.js');
+
+  // Start a temporary callback server for receiving the OAuth code.
+  const callbackPort = await getPort(24681);
+  const callbackUrl = `http://localhost:${callbackPort}/oauth/callback`;
+
+  const oauthState = createInMemoryOAuthProvider(callbackUrl);
+  const { provider } = oauthState;
+
+  // First call to auth() — discovers metadata, registers client, and either
+  // returns AUTHORIZED (client_credentials) or REDIRECT (authorization_code).
+  const result = await auth(provider, { serverUrl: new URL(serverUrl) });
+
+  if (result === 'AUTHORIZED') {
+    return provider;
+  }
+
+  // result === 'REDIRECT': we need to follow the authorization URL.
+  const authUrl = oauthState.getAuthUrl();
+  if (!authUrl) {
+    throw new Error('OAuth flow returned REDIRECT but no authorization URL was captured');
+  }
+
+  // Try the anonymous/auto-approved path first: follow the authorization URL
+  // without a browser and see if it immediately redirects with a code.
+  const code = await tryAnonymousOAuth(authUrl.toString(), callbackUrl);
+  if (code) {
+    // Complete the flow with the authorization code.
+    const tokenResult = await auth(provider, {
+      serverUrl: new URL(serverUrl),
+      authorizationCode: code,
+    });
+    if (tokenResult === 'AUTHORIZED') {
+      return provider;
+    }
+    throw new Error('OAuth token exchange failed after anonymous authorization');
+  }
+
+  // Anonymous path didn't work — this server requires interactive login.
+  // Start a callback server and open the auth URL in the user's browser.
+  const interactiveCode = await waitForInteractiveOAuth(
+    authUrl.toString(),
+    callbackUrl,
+    callbackPort
+  );
+
+  const tokenResult = await auth(provider, {
+    serverUrl: new URL(serverUrl),
+    authorizationCode: interactiveCode,
+  });
+  if (tokenResult === 'AUTHORIZED') {
+    return provider;
+  }
+  throw new Error('OAuth token exchange failed after interactive authorization');
+}
+
+/**
+ * Try to complete OAuth without user interaction by following redirects.
+ * Returns the authorization code if the server auto-approves, or null if
+ * the server requires interactive login (returns an HTML page).
+ *
+ * @param {string} authUrl - The authorization URL
+ * @param {string} callbackUrl - The expected callback URL prefix
+ * @returns {Promise<string | null>}
+ */
+async function tryAnonymousOAuth(authUrl, callbackUrl) {
+  // Follow redirects manually to detect when the server redirects back
+  // to our callback URL with a code parameter.
+  let url = authUrl;
+  const maxRedirects = 10;
+  for (let i = 0; i < maxRedirects; i++) {
+    const response = await fetch(url, { redirect: 'manual' });
+    const location = response.headers.get('location');
+
+    if (!location) {
+      // No redirect — server returned a page (login form). Not auto-approved.
+      // Drain the response body to free the socket.
+      await response.text().catch(() => {});
+      return null;
+    }
+
+    // Resolve relative redirects.
+    const resolved = new URL(location, url).toString();
+
+    // Check if the redirect goes to our callback URL.
+    if (resolved.startsWith(callbackUrl)) {
+      const params = new URL(resolved).searchParams;
+      const code = params.get('code');
+      if (code) return code;
+      const error = params.get('error');
+      if (error) {
+        throw new Error(`OAuth authorization failed: ${error} — ${params.get('error_description') || ''}`);
+      }
+      return null;
+    }
+
+    url = resolved;
+  }
+
+  return null;
+}
+
+/**
+ * Wait for the user to complete an interactive OAuth flow in their browser.
+ * Starts a temporary HTTP server to receive the callback, opens the auth URL,
+ * and resolves with the authorization code.
+ *
+ * @param {string} authUrl - The authorization URL to open in the browser
+ * @param {string} callbackUrl - Our callback URL
+ * @param {number} callbackPort - Port for the callback server
+ * @returns {Promise<string>}
+ */
+async function waitForInteractiveOAuth(authUrl, callbackUrl, callbackPort) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const settle = (fn, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      server.close();
+      fn(value);
+    };
+
+    const server = createHttpServer((req, res) => {
+      const reqUrl = new URL(req.url, callbackUrl);
+      if (!reqUrl.pathname.startsWith('/oauth/callback')) {
+        res.writeHead(404);
+        res.end('Not found');
+        return;
+      }
+
+      const code = reqUrl.searchParams.get('code');
+      const error = reqUrl.searchParams.get('error');
+
+      // Serve a simple page that tells the user they can close the tab.
+      const escHtml = (s) => s.replace(/[<>&"']/g, (c) =>
+        ({ '<': '&lt;', '>': '&gt;', '&': '&amp;', '"': '&quot;', "'": '&#39;' })[c]
+      );
+      const message = code
+        ? 'Authorization complete. You can close this tab.'
+        : `Authorization failed: ${escHtml(error || 'unknown error')}`;
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(`<!DOCTYPE html><html><body><p>${message}</p></body></html>`);
+
+      if (code) {
+        settle(resolve, code);
+      } else {
+        settle(reject, new Error(`OAuth authorization failed: ${error || 'unknown error'}`));
+      }
+    });
+
+    server.on('error', (err) => {
+      settle(reject, new Error(`OAuth callback server failed: ${err.message}`));
+    });
+
+    server.listen(callbackPort, async () => {
+      console.log('Opening browser for OAuth authorization...');
+      // Use execFile with array args to avoid shell injection from the auth URL.
+      const { execFile } = await import('child_process');
+      const cmd = process.platform === 'darwin' ? 'open' :
+                  process.platform === 'win32' ? 'start' : 'xdg-open';
+      execFile(cmd, [authUrl], (err) => {
+        if (err) console.error(`Failed to open browser: ${err.message}`);
+      });
+    });
+
+    // Timeout after 2 minutes.
+    const timer = setTimeout(() => {
+      settle(reject, new Error('OAuth authorization timed out (2 minutes)'));
+    }, 120_000);
+  });
+}
+
+/**
+ * Detect if an error from createMcpConnection is an auth error (401/Unauthorized).
+ * @param {Error} err
+ * @returns {boolean}
+ */
+function isAuthError(err) {
+  // The MCP SDK throws UnauthorizedError for auth failures.
+  if (err.constructor?.name === 'UnauthorizedError') return true;
+
+  // StreamableHTTPError includes a status code in its message.
+  // Check for the specific "401" HTTP status pattern, not substring matches.
+  const msg = err.message || '';
+  if (msg.includes('invalid_token')) return true;
+
+  // Connection errors (ECONNREFUSED, ETIMEDOUT, etc.) are never auth errors.
+  if (msg.includes('ECONNREFUSED') || msg.includes('ETIMEDOUT') || msg.includes('ENOTFOUND')) {
+    return false;
+  }
+
+  return false;
+}
+
+/**
  * Create an MCP client connection.
  * @param {string} serverArg - URL or command string
- * @param {{ type?: 'none' | 'bearer' | 'oauth', bearerToken?: string, authProvider?: import('@modelcontextprotocol/sdk/client/auth.js').OAuthClientProvider }} [authConfig]
- * @returns {Promise<{ client: import('@modelcontextprotocol/sdk/client/index.js').Client, transport: import('@modelcontextprotocol/sdk/types.js').Transport }>}
+ * @param {{ type?: 'none' | 'bearer' | 'oauth', bearerToken?: string, authProvider?: import('@modelcontextprotocol/sdk/client/auth.js').OAuthClientProvider, env?: Record<string, string>, cwd?: string }} [authConfig]
+ * @returns {Promise<{ client: import('@modelcontextprotocol/sdk/client/index.js').Client, transport: import('@modelcontextprotocol/sdk/types.js').Transport, stderrOutput?: string[] }>}
  */
 async function createMcpConnection(serverArg, authConfig) {
   const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
@@ -197,9 +421,47 @@ async function createMcpConnection(serverArg, authConfig) {
     const { StdioClientTransport } = await import(
       '@modelcontextprotocol/sdk/client/stdio.js'
     );
-    const transport = new StdioClientTransport({ command, args: cmdArgs });
-    await client.connect(transport);
-    return { client, transport };
+
+    const transportOpts = {
+      command,
+      args: cmdArgs,
+      stderr: 'pipe',
+      ...(authConfig?.env ? { env: { ...process.env, ...authConfig.env } } : {}),
+      ...(authConfig?.cwd ? { cwd: authConfig.cwd } : {}),
+    };
+
+    const transport = new StdioClientTransport(transportOpts);
+
+    // Buffer stderr lines so we can surface them on connection failure,
+    // while still printing them in real time (preserving the SDK's default
+    // 'inherit' behavior for interactive use).
+    const stderrOutput = [];
+    const MAX_STDERR_LINES = 50;
+    if (transport.stderr) {
+      transport.stderr.on('data', (chunk) => {
+        process.stderr.write(chunk);
+        const lines = chunk.toString().split('\n');
+        for (const line of lines) {
+          if (line) {
+            stderrOutput.push(line);
+            if (stderrOutput.length > MAX_STDERR_LINES) {
+              stderrOutput.shift();
+            }
+          }
+        }
+      });
+    }
+
+    try {
+      await client.connect(transport);
+    } catch (err) {
+      // Attach captured stderr so callers can surface it for diagnostics.
+      err._stderrOutput = stderrOutput;
+      // Clean up the spawned process so it doesn't linger.
+      try { await transport.close(); } catch { /* best-effort */ }
+      throw err;
+    }
+    return { client, transport, stderrOutput };
   }
 }
 
@@ -402,6 +664,20 @@ function sunpeakInspectEndpointsPlugin(getClient, setClient, pluginOpts = {}) {
         } catch (err) {
           res.writeHead(500, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: err.message }));
+        }
+      });
+
+      // List resources from connected server
+      server.middlewares.use('/__sunpeak/list-resources', async (_req, res) => {
+        try {
+          const client = getClient();
+          const result = await client.listResources();
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(result));
+        } catch (err) {
+          // Server may not support resources — return empty list
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ resources: [] }));
         }
       });
 
@@ -911,6 +1187,8 @@ function readRequestBody(req) {
  * @param {Record<string, string>} [opts.resolveAlias] - Vite resolve aliases (e.g., to map sunpeak imports to source)
  * @param {object[]} [opts.vitePlugins] - Additional Vite plugins (e.g., Tailwind for source CSS)
  * @param {object} [opts.viteCssConfig] - Vite css config override (e.g., lightningcss customAtRules)
+ * @param {Record<string, string>} [opts.env] - Extra environment variables for stdio server processes
+ * @param {string} [opts.cwd] - Working directory for stdio server processes
  */
 export async function inspectServer(opts) {
   const {
@@ -928,6 +1206,8 @@ export async function inspectServer(opts) {
     resolveAlias,
     vitePlugins: extraVitePlugins = [],
     viteCssConfig,
+    env: serverEnv,
+    cwd: serverCwd,
   } = opts;
 
   // Load favicon from sunpeak package for the inspector UI.
@@ -948,14 +1228,47 @@ export async function inspectServer(opts) {
 
   // Connect to the MCP server (with retry for local servers that may still be starting)
   let mcpConnection;
+  let lastStderrOutput = [];
   const maxRetries = 5;
+  const connectionOpts = {};
+  if (serverEnv) connectionOpts.env = serverEnv;
+  if (serverCwd) connectionOpts.cwd = serverCwd;
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      mcpConnection = await createMcpConnection(serverArg);
+      mcpConnection = await createMcpConnection(serverArg, connectionOpts);
       break;
     } catch (err) {
+      // Capture stderr from the failed connection attempt for diagnostics.
+      if (err._stderrOutput?.length) {
+        lastStderrOutput = err._stderrOutput;
+      }
+
+      // If the server requires OAuth, negotiate it and retry once.
+      if (isAuthError(err) && serverArg.startsWith('http')) {
+        console.log('Server requires authentication. Negotiating OAuth...');
+        try {
+          const authProvider = await negotiateOAuth(serverArg);
+          console.log('OAuth authorized. Reconnecting...');
+          mcpConnection = await createMcpConnection(serverArg, {
+            ...connectionOpts,
+            type: 'oauth',
+            authProvider,
+          });
+          break;
+        } catch (oauthErr) {
+          console.error(`OAuth negotiation failed: ${oauthErr.message}`);
+          process.exit(1);
+        }
+      }
+
       if (attempt === maxRetries) {
         console.error(`Failed to connect to MCP server: ${err.message}`);
+        if (lastStderrOutput.length) {
+          console.error('\nServer stderr output:');
+          for (const line of lastStderrOutput) {
+            console.error(`  ${line}`);
+          }
+        }
         process.exit(1);
       }
       console.log(`Connection attempt ${attempt}/${maxRetries} failed, retrying...`);
@@ -1195,5 +1508,7 @@ export async function inspect(args) {
     simulationsDir,
     port: opts.port,
     name: opts.name,
+    env: opts.env,
+    cwd: opts.cwd,
   });
 }

--- a/packages/sunpeak/bin/commands/test-init.mjs
+++ b/packages/sunpeak/bin/commands/test-init.mjs
@@ -1,9 +1,22 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { execSync } from 'child_process';
 import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
 import * as p from '@clack/prompts';
 import { EVAL_PROVIDERS, generateModelLines } from '../lib/eval/eval-providers.mjs';
 import { detectPackageManager } from '../utils.mjs';
+
+/** Read the current sunpeak package version for pinning in scaffolded configs. */
+function getSunpeakVersion() {
+  try {
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const pkgPath = join(__dirname, '..', '..', 'package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    return pkg.version ? `^${pkg.version}` : 'latest';
+  } catch {
+    return 'latest';
+  }
+}
 
 /**
  * Default dependencies (real implementations).
@@ -49,7 +62,7 @@ export const defaultDeps = {
  *
  * Scaffolds all 5 test types:
  * 1. E2E tests — Playwright-based inspector tests (mcp fixture)
- * 2. Visual regression — Screenshot comparison via mcp.screenshot()
+ * 2. Visual regression — Screenshot comparison via result.screenshot()
  * 3. Live tests — Test against real ChatGPT/Claude hosts
  * 4. Evals — Multi-model tool calling reliability tests
  * 5. Unit tests — Direct tool handler tests (JS/TS projects only)
@@ -228,7 +241,16 @@ function generateServerConfigBlock(server, relativeTo = '.') {
   // server: { command: 'go', args: ['run', './cmd/server'] },
   //
   // Node.js:
-  // server: { command: 'node', args: ['server.js'] },`;
+  // server: { command: 'node', args: ['server.js'] },
+  //
+  // Optional server options:
+  // server: {
+  //   command: 'python', args: ['server.py'],
+  //   env: { API_KEY: 'test-key' },  // Extra environment variables
+  //   cwd: './backend',               // Working directory
+  // },
+  //
+  // timeout: 120_000,  // Server startup timeout in ms (default: 60s)`;
   }
   if (server.type === 'url') {
     return `  server: {
@@ -381,31 +403,31 @@ function scaffoldVisualTest(filePath, d) {
  * Uncomment the tests below and replace 'your-tool' with your tool name.
  */
 
-// test('tool renders correctly in light mode', async ({ mcp }) => {
-//   const result = await mcp.callTool('your-tool', { key: 'value' }, { theme: 'light' });
+// test('tool renders correctly in light mode', async ({ inspector }) => {
+//   const result = await inspector.renderTool('your-tool', { key: 'value' }, { theme: 'light' });
 //   expect(result).not.toBeError();
 //
 //   // Wait for UI to render, then screenshot:
 //   // const app = result.app();
 //   // await expect(app.getByText('Expected text')).toBeVisible();
-//   // await mcp.screenshot('tool-light');
+//   // await result.screenshot('tool-light');
 // });
 
-// test('tool renders correctly in dark mode', async ({ mcp }) => {
-//   const result = await mcp.callTool('your-tool', { key: 'value' }, { theme: 'dark' });
+// test('tool renders correctly in dark mode', async ({ inspector }) => {
+//   const result = await inspector.renderTool('your-tool', { key: 'value' }, { theme: 'dark' });
 //   expect(result).not.toBeError();
 //
 //   // const app = result.app();
 //   // await expect(app.getByText('Expected text')).toBeVisible();
-//   // await mcp.screenshot('tool-dark');
+//   // await result.screenshot('tool-dark');
 // });
 
 // Full-page screenshot (captures the inspector chrome too):
-// test('full page renders correctly', async ({ mcp }) => {
-//   const result = await mcp.callTool('your-tool', {}, { theme: 'light' });
+// test('full page renders correctly', async ({ inspector }) => {
+//   const result = await inspector.renderTool('your-tool', {}, { theme: 'light' });
 //   const app = result.app();
 //   await expect(app.getByText('Expected text')).toBeVisible();
-//   await mcp.screenshot('tool-page', { target: 'page', maxDiffPixelRatio: 0.02 });
+//   await result.screenshot('tool-page', { target: 'page', maxDiffPixelRatio: 0.02 });
 // });
 `
   );
@@ -569,7 +591,7 @@ async function initExternalProject(cliServer, d) {
         type: 'module',
         devDependencies: {
           '@types/node': 'latest',
-          sunpeak: 'latest',
+          sunpeak: getSunpeakVersion(),
           '@playwright/test': 'latest',
         },
         scripts: {
@@ -611,24 +633,28 @@ ${serverBlock}
     ) + '\n'
   );
 
-  // 1. E2E test — smoke test, verifies the server is reachable
+  // 1. E2E test — smoke test, verifies the server exposes tools
   d.writeFileSync(
     join(testDir, 'smoke.test.ts'),
     `import { test, expect } from 'sunpeak/test';
 
-test('server is reachable and inspector loads', async ({ mcp }) => {
-  // Verify the inspector page loads successfully
-  await expect(mcp.page.locator('#root')).not.toBeEmpty();
+test('server exposes tools', async ({ mcp }) => {
+  const tools = await mcp.listTools();
+  expect(tools.length).toBeGreaterThan(0);
 });
 
-// Uncomment and customize for your tools:
-// test('my tool renders correctly', async ({ mcp }) => {
+// Protocol-level test (no UI rendering):
+// test('my tool returns data', async ({ mcp }) => {
 //   const result = await mcp.callTool('your-tool', { key: 'value' });
+//   expect(result.isError).toBeFalsy();
+// });
+
+// UI rendering test:
+// test('my tool renders correctly', async ({ inspector }) => {
+//   const result = await inspector.renderTool('your-tool', { key: 'value' });
 //   expect(result).not.toBeError();
-//
-//   // If your tool has a UI:
-//   // const app = result.app();
-//   // await expect(app.getByText('Hello')).toBeVisible();
+//   const app = result.app();
+//   await expect(app.getByText('Hello')).toBeVisible();
 // });
 `
   );
@@ -646,14 +672,24 @@ test('server is reachable and inspector loads', async ({ mcp }) => {
   if (server.type === 'later') {
     d.log.warn('Server not configured. Edit tests/sunpeak/playwright.config.ts before running tests.');
   }
-  d.log.step('Next steps:');
-  d.log.message('  Requires: Node.js 20+');
-  d.log.message('');
+
+  // Auto-install dependencies so users can run tests immediately
   const pm = d.detectPackageManager();
-  d.log.message('  cd tests/sunpeak');
-  d.log.message(`  ${pm} install`);
-  d.log.message(`  ${pm} exec playwright install chromium`);
-  d.log.message('');
+  d.log.step('Installing dependencies...');
+  try {
+    d.execSync(`${pm} install`, { cwd: testDir, stdio: 'inherit' });
+  } catch {
+    d.log.warn(`Dependency install failed. Run manually: cd tests/sunpeak && ${pm} install`);
+  }
+
+  d.log.step('Installing Playwright browser...');
+  try {
+    d.execSync(`${pm} exec playwright install chromium`, { cwd: testDir, stdio: 'inherit' });
+  } catch {
+    d.log.warn(`Browser install failed. Run manually: cd tests/sunpeak && ${pm} exec playwright install chromium`);
+  }
+
+  d.log.step('Ready! Run tests with:');
   d.log.message('  sunpeak test              # E2E tests');
   d.log.message('  sunpeak test --visual      # Visual regression (generates baselines on first run)');
   d.log.message('  sunpeak test --live         # Live tests against real hosts (requires login)');
@@ -694,18 +730,23 @@ ${serverBlock}
       testPath,
       `import { test, expect } from 'sunpeak/test';
 
-test('server is reachable and inspector loads', async ({ mcp }) => {
-  await expect(mcp.page.locator('#root')).not.toBeEmpty();
+test('server exposes tools', async ({ mcp }) => {
+  const tools = await mcp.listTools();
+  expect(tools.length).toBeGreaterThan(0);
 });
 
-// Uncomment and customize for your tools:
-// test('my tool renders correctly', async ({ mcp }) => {
+// Protocol-level test (no UI rendering):
+// test('my tool returns data', async ({ mcp }) => {
 //   const result = await mcp.callTool('your-tool', { key: 'value' });
+//   expect(result.isError).toBeFalsy();
+// });
+
+// UI rendering test:
+// test('my tool renders correctly', async ({ inspector }) => {
+//   const result = await inspector.renderTool('your-tool', { key: 'value' });
 //   expect(result).not.toBeError();
-//
-//   // If your tool has a UI:
-//   // const app = result.app();
-//   // await expect(app.getByText('Hello')).toBeVisible();
+//   const app = result.app();
+//   await expect(app.getByText('Hello')).toBeVisible();
 // });
 `
     );
@@ -792,6 +833,6 @@ export default defineConfig();
   d.log.message('  Replace: import { test, expect } from "@playwright/test"');
   d.log.message('  With:    import { test, expect } from "sunpeak/test"');
   d.log.message('');
-  d.log.message('  Use the `mcp` fixture instead of raw page navigation.');
+  d.log.message('  Use the `mcp` and `inspector` fixtures instead of raw page navigation.');
   d.log.message('  See sunpeak docs for migration examples.');
 }

--- a/packages/sunpeak/bin/commands/test.mjs
+++ b/packages/sunpeak/bin/commands/test.mjs
@@ -70,6 +70,9 @@ export async function runTest(args) {
         'playwright.config.js',
         'sunpeak.config.ts',
         'sunpeak.config.js',
+        // Fallback for non-JS projects: tests/sunpeak/ self-contained directory
+        'tests/sunpeak/playwright.config.ts',
+        'tests/sunpeak/playwright.config.js',
       ],
       visual: isVisual,
       updateSnapshots: isVisual && isUpdate,
@@ -82,6 +85,9 @@ export async function runTest(args) {
       configCandidates: [
         'tests/live/playwright.config.ts',
         'tests/live/playwright.config.js',
+        // Fallback for non-JS projects: tests/sunpeak/ self-contained directory
+        'tests/sunpeak/live/playwright.config.ts',
+        'tests/sunpeak/live/playwright.config.js',
       ],
       configRequired: true,
       configErrorMessage: 'No live test config found at tests/live/playwright.config.ts',

--- a/packages/sunpeak/bin/lib/inspect/inspect-config.mjs
+++ b/packages/sunpeak/bin/lib/inspect/inspect-config.mjs
@@ -15,6 +15,7 @@
  * and external servers.
  */
 import { createBaseConfig, resolvePorts } from '../test/base-config.mjs';
+import { resolveSunpeakBin } from '../resolve-bin.mjs';
 
 /**
  * Create a complete Playwright config for testing an external MCP server.
@@ -26,6 +27,9 @@ import { createBaseConfig, resolvePorts } from '../test/base-config.mjs';
  * @param {string[]} [options.hosts=['chatgpt', 'claude']] - Host shells to test
  * @param {string} [options.name] - App name in inspector chrome
  * @param {Object} [options.use] - Additional Playwright `use` options
+ * @param {number} [options.timeout] - Server startup timeout in ms (default: 60000)
+ * @param {Record<string, string>} [options.env] - Environment variables for stdio servers
+ * @param {string} [options.cwd] - Working directory for stdio servers
  * @returns {import('@playwright/test').PlaywrightTestConfig}
  */
 export function defineInspectConfig(options) {
@@ -37,6 +41,9 @@ export function defineInspectConfig(options) {
     name,
     use: userUse,
     visual,
+    timeout,
+    env,
+    cwd,
   } = options;
 
   if (!server) {
@@ -49,8 +56,15 @@ export function defineInspectConfig(options) {
   const serverArg = server.includes(' ') ? `"${server}"` : server;
   const command = [
     `SUNPEAK_SANDBOX_PORT=${sandboxPort}`,
-    'sunpeak inspect',
+    `${resolveSunpeakBin()} inspect`,
     `--server ${serverArg}`,
+    ...(env
+      ? Object.entries(env).map(([k, v]) => {
+          const pair = `${k}=${v}`;
+          return pair.includes(' ') ? `--env "${pair}"` : `--env ${pair}`;
+        })
+      : []),
+    ...(cwd ? [cwd.includes(' ') ? `--cwd "${cwd}"` : `--cwd ${cwd}`] : []),
     ...(simulationsDir ? [`--simulations ${simulationsDir}`] : []),
     `--port ${port}`,
     ...(name ? [`--name "${name}"`] : []),
@@ -62,6 +76,7 @@ export function defineInspectConfig(options) {
     port,
     use: userUse,
     visual,
+    timeout,
     webServer: {
       command,
       healthUrl: `http://localhost:${port}/health`,

--- a/packages/sunpeak/bin/lib/inspect/inspect-server.d.mts
+++ b/packages/sunpeak/bin/lib/inspect/inspect-server.d.mts
@@ -1,0 +1,32 @@
+/**
+ * Start the sunpeak inspector server programmatically.
+ *
+ * Connects to the provided MCP server, discovers tools and resources,
+ * and serves the inspector UI on the specified port.
+ */
+export function inspectServer(opts: {
+  /** MCP server URL or stdio command. */
+  server: string;
+  /** Path to simulation fixtures directory. */
+  simulationsDir?: string | null;
+  /** Dev server port (default: 3000). */
+  port?: number;
+  /** App name in inspector chrome. */
+  name?: string;
+  /** Existing sandbox server URL (skips creating one). */
+  sandboxUrl?: string;
+  /** If true, show framework-only controls (Prod Resources). */
+  frameworkMode?: boolean;
+  /** Initial prod resources state. */
+  defaultProdResources?: boolean;
+  /** Project directory for serving /dist/ files (prod resources). */
+  projectRoot?: string | null;
+  /** Whether to open browser (default: !CI). */
+  open?: boolean;
+  /** Additional cleanup callback on exit. */
+  onCleanup?: () => Promise<void>;
+  /** Extra environment variables for stdio server processes. */
+  env?: Record<string, string>;
+  /** Working directory for stdio server processes. */
+  cwd?: string;
+}): Promise<void>;

--- a/packages/sunpeak/bin/lib/inspect/inspect-server.mjs
+++ b/packages/sunpeak/bin/lib/inspect/inspect-server.mjs
@@ -1,0 +1,11 @@
+/**
+ * Programmatic entry point for the sunpeak inspector server.
+ *
+ * Allows frameworks to start the inspector from their own CLI without
+ * shelling out to the `sunpeak inspect` command.
+ *
+ * Usage:
+ *   import { inspectServer } from 'sunpeak/inspect';
+ *   await inspectServer({ server: 'http://localhost:8000/mcp', port: 3000 });
+ */
+export { inspectServer } from '../../commands/inspect.mjs';

--- a/packages/sunpeak/bin/lib/resolve-bin.mjs
+++ b/packages/sunpeak/bin/lib/resolve-bin.mjs
@@ -1,0 +1,39 @@
+/**
+ * Resolve the sunpeak CLI binary path.
+ *
+ * When sunpeak is installed as a local dependency (e.g., in tests/sunpeak/
+ * for non-JS projects), the bare `sunpeak` command won't be on PATH.
+ * This utility checks for the local .bin entry first, then falls back
+ * to the bare command name for global installs.
+ */
+import { existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+/**
+ * Find the sunpeak binary, preferring the local node_modules/.bin entry.
+ *
+ * Checks in order:
+ * 1. process.cwd() (works when running from the test directory directly)
+ * 2. The directory containing this file's package (works when the config is
+ *    loaded from a parent directory, e.g., `sunpeak test` run from project root
+ *    with config at tests/sunpeak/playwright.config.ts)
+ *
+ * @returns {string} Path to the sunpeak binary, or bare 'sunpeak' as fallback
+ */
+export function resolveSunpeakBin() {
+  // Check cwd first (covers `cd tests/sunpeak && sunpeak test`)
+  const cwdBin = join(process.cwd(), 'node_modules', '.bin', 'sunpeak');
+  if (existsSync(cwdBin)) return cwdBin;
+
+  // Check the directory containing this module's package, which is the
+  // sunpeak package root. Walk up from bin/lib/ to find node_modules/.bin/.
+  // This covers running from a parent dir (e.g., project root) where sunpeak
+  // is installed in a subdirectory (tests/sunpeak/node_modules/sunpeak/).
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const pkgRoot = join(__dirname, '..', '..');
+  const pkgBin = join(pkgRoot, '..', '.bin', 'sunpeak');
+  if (existsSync(pkgBin)) return pkgBin;
+
+  return 'sunpeak';
+}

--- a/packages/sunpeak/bin/lib/test/base-config.mjs
+++ b/packages/sunpeak/bin/lib/test/base-config.mjs
@@ -15,9 +15,10 @@ import { getPortSync } from '../get-port.mjs';
  * @param {number} options.port - Inspector port
  * @param {Object} [options.use] - Additional Playwright `use` options
  * @param {string} [options.globalSetup] - Global setup file path
+ * @param {number} [options.timeout] - WebServer startup timeout in ms (default: 60000)
  * @returns {import('@playwright/test').PlaywrightTestConfig}
  */
-export function createBaseConfig({ hosts, testDir, webServer, port, use, globalSetup, visual }) {
+export function createBaseConfig({ hosts, testDir, webServer, port, use, globalSetup, visual, timeout }) {
   // Separate snapshot path from other visual options passed to expect.toHaveScreenshot
   const { snapshotPathTemplate, ...toHaveScreenshotDefaults } = visual ?? {};
 
@@ -52,7 +53,7 @@ export function createBaseConfig({ hosts, testDir, webServer, port, use, globalS
       command: webServer.command,
       url: webServer.healthUrl,
       reuseExistingServer: !process.env.CI,
-      timeout: 60_000,
+      timeout: timeout ?? 60_000,
     },
   };
 }

--- a/packages/sunpeak/bin/lib/test/matchers.mjs
+++ b/packages/sunpeak/bin/lib/test/matchers.mjs
@@ -1,8 +1,8 @@
 /**
  * MCP-native custom matchers for Playwright's expect.
  *
- * These matchers operate on ToolResult objects returned by mcp.callTool()
- * and provide MCP-concept-native assertions.
+ * These matchers operate on tool results from mcp.callTool() or
+ * InspectorResult from inspector.renderTool().
  */
 
 /**

--- a/packages/sunpeak/bin/lib/test/test-config.mjs
+++ b/packages/sunpeak/bin/lib/test/test-config.mjs
@@ -18,6 +18,7 @@
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { createBaseConfig, resolvePorts } from './base-config.mjs';
+import { resolveSunpeakBin } from '../resolve-bin.mjs';
 
 /**
  * @param {Object} [options]
@@ -26,11 +27,13 @@ import { createBaseConfig, resolvePorts } from './base-config.mjs';
  * @param {string[]} [options.server.args] - Command arguments
  * @param {string} [options.server.url] - HTTP server URL (alternative to command)
  * @param {Record<string, string>} [options.server.env] - Environment variables
+ * @param {string} [options.server.cwd] - Working directory for the server process
  * @param {string[]} [options.hosts] - Host shells to test (default: ['chatgpt', 'claude'])
  * @param {string} [options.testDir] - Test directory
  * @param {string} [options.simulationsDir] - Simulations directory for mock data
  * @param {string} [options.globalSetup] - Global setup file path
  * @param {Object} [options.use] - Additional Playwright `use` options
+ * @param {number} [options.timeout] - Server startup timeout in ms (default: 60000)
  * @returns {import('@playwright/test').PlaywrightTestConfig}
  */
 export function defineConfig(options = {}) {
@@ -42,6 +45,7 @@ export function defineConfig(options = {}) {
     globalSetup,
     use: userUse,
     visual,
+    timeout,
   } = options;
 
   const { port, sandboxPort } = resolvePorts();
@@ -69,6 +73,7 @@ export function defineConfig(options = {}) {
     use: userUse,
     globalSetup,
     visual,
+    timeout,
     webServer: {
       command,
       healthUrl: `http://localhost:${port}/health`,
@@ -97,13 +102,7 @@ function detectSunpeakProject() {
 function buildInspectCommand({ server, port, sandboxPort, simulationsDir }) {
   const parts = [`SUNPEAK_SANDBOX_PORT=${sandboxPort}`];
 
-  if (server.env) {
-    for (const [key, value] of Object.entries(server.env)) {
-      parts.push(`${key}=${value}`);
-    }
-  }
-
-  parts.push('sunpeak inspect');
+  parts.push(`${resolveSunpeakBin()} inspect`);
 
   if (server.url) {
     parts.push(`--server ${server.url}`);
@@ -113,6 +112,18 @@ function buildInspectCommand({ server, port, sandboxPort, simulationsDir }) {
       : server.command;
     // Quote the command if it contains spaces
     parts.push(`--server "${cmd}"`);
+  }
+
+  // Pass environment variables as --env KEY=VALUE flags (stdio servers only).
+  if (server.env) {
+    for (const [key, value] of Object.entries(server.env)) {
+      const pair = `${key}=${value}`;
+      parts.push(pair.includes(' ') ? `--env "${pair}"` : `--env ${pair}`);
+    }
+  }
+
+  if (server.cwd) {
+    parts.push(server.cwd.includes(' ') ? `--cwd "${server.cwd}"` : `--cwd ${server.cwd}`);
   }
 
   if (simulationsDir) {

--- a/packages/sunpeak/bin/lib/test/test-fixtures.d.mts
+++ b/packages/sunpeak/bin/lib/test/test-fixtures.d.mts
@@ -7,46 +7,40 @@ import type {
   PageAssertionsToHaveScreenshotOptions,
 } from '@playwright/test';
 
-/**
- * Result from calling an MCP tool via the inspector.
- */
-export interface ToolResult {
-  /** Raw MCP content items from the tool response. */
-  content: Array<{ type: string; text?: string; [key: string]: unknown }>;
-  /** Structured content from the tool response. */
-  structuredContent?: unknown;
-  /** Whether the tool returned an error. */
-  isError: boolean;
-  /**
-   * Get a FrameLocator for the rendered resource UI.
-   * Handles the double-iframe traversal automatically.
-   */
-  app(): FrameLocator;
+// ── MCP Protocol Types ──
+
+export interface Tool {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+  title?: string;
+  annotations?: Record<string, unknown>;
+  _meta?: Record<string, unknown>;
 }
 
-/**
- * Options for callTool().
- */
-export interface CallToolOptions {
-  /** Color theme for the inspector. */
+export interface Resource {
+  uri: string;
+  name: string;
+  mimeType?: string;
+  description?: string;
+  _meta?: Record<string, unknown>;
+}
+
+export interface CallToolResult {
+  content?: Array<{ type: string; text?: string; [key: string]: unknown }>;
+  structuredContent?: unknown;
+  isError?: boolean;
+}
+
+// ── sunpeak Inspector Types ──
+
+export interface RenderToolOptions {
   theme?: 'light' | 'dark';
-  /** Display mode for the resource. */
   displayMode?: 'inline' | 'pip' | 'fullscreen';
-  /** Use production resource builds instead of HMR. */
-  prodResources?: boolean;
-  /** Additional inspector URL parameters. */
+  timeout?: number;
   [key: string]: unknown;
 }
 
-/**
- * Options for screenshot().
- *
- * Extends Playwright's toHaveScreenshot() options with sunpeak-specific
- * `target` and `element` fields. All standard Playwright options (threshold,
- * maxDiffPixelRatio, maxDiffPixels, mask, maskColor, animations, caret,
- * fullPage, clip, scale, stylePath, omitBackground, timeout, etc.)
- * are passed through directly.
- */
 export interface ScreenshotOptions extends PageAssertionsToHaveScreenshotOptions {
   /** What to screenshot: 'app' (inner iframe content) or 'page' (full inspector). Default: 'app'. */
   target?: 'app' | 'page';
@@ -54,76 +48,42 @@ export interface ScreenshotOptions extends PageAssertionsToHaveScreenshotOptions
   element?: Locator;
 }
 
-/**
- * MCP test fixture for testing MCP servers via the inspector.
- */
-export interface McpFixture {
-  /** The underlying Playwright Page. */
-  page: Page;
-  /** Current host ID (from Playwright project name). */
-  host: string;
-
-  /**
-   * Call a tool and get the rendered result.
-   * Navigates the inspector, waits for the resource to render,
-   * and returns a ToolResult for assertions.
-   */
-  callTool(
-    name: string,
-    input?: Record<string, unknown>,
-    options?: CallToolOptions
-  ): Promise<ToolResult>;
-
-  /**
-   * Navigate to a tool with no mock data ("Press Run" state).
-   */
-  openTool(name: string, options?: { theme?: 'light' | 'dark' }): Promise<void>;
-
-  /**
-   * Click the Run button and return the rendered result.
-   */
-  runTool(): Promise<ToolResult>;
-
-  /** Change the theme via the sidebar toggle. */
-  setTheme(theme: 'light' | 'dark'): Promise<void>;
-
-  /** Change the display mode via the sidebar buttons. */
-  setDisplayMode(mode: 'inline' | 'pip' | 'fullscreen'): Promise<void>;
-
-  /**
-   * Take a screenshot and compare against a baseline.
-   * Only performs the comparison when visual testing is enabled
-   * (`sunpeak test --visual`). Silently skips otherwise.
-   *
-   * @param name - Snapshot name (auto-generated from test title if omitted)
-   * @param options - Screenshot and comparison options
-   */
+export interface InspectorResult {
+  content: Array<{ type: string; text?: string; [key: string]: unknown }>;
+  structuredContent?: unknown;
+  isError: boolean;
+  source: 'fixture' | 'server';
+  app(): FrameLocator;
+  screenshot(options?: ScreenshotOptions): Promise<void>;
   screenshot(name?: string, options?: ScreenshotOptions): Promise<void>;
 }
 
-/**
- * Extended Playwright test with `mcp` fixture.
- */
-export declare const test: TestType<{ mcp: McpFixture }, {}>;
+// ── Fixtures ──
 
-/**
- * Extended Playwright expect with MCP-native matchers.
- */
+/** MCP protocol fixture. Maps 1:1 to MCP protocol operations. */
+export interface McpFixture {
+  listTools(): Promise<Tool[]>;
+  callTool(name: string, input?: Record<string, unknown>): Promise<CallToolResult>;
+  listResources(): Promise<Resource[]>;
+  readResource(uri: string): Promise<string>;
+}
+
+/** sunpeak inspector fixture. Renders tools in simulated host environments. */
+export interface InspectorFixture {
+  host: string;
+  page: Page;
+  renderTool(
+    name: string,
+    input?: Record<string, unknown>,
+    options?: RenderToolOptions
+  ): Promise<InspectorResult>;
+}
+
+export declare const test: TestType<{ mcp: McpFixture; inspector: InspectorFixture }, {}>;
+
 export declare const expect: Expect<{
-  /**
-   * Assert that a tool result is an error.
-   */
   toBeError(): void;
-  /**
-   * Assert that any content item's text contains the given string.
-   */
   toHaveTextContent(text: string): void;
-  /**
-   * Assert that structuredContent matches the expected shape.
-   */
   toHaveStructuredContent(shape: unknown): void;
-  /**
-   * Assert that content array contains an item of the given type.
-   */
   toHaveContentType(type: string): void;
 }>;

--- a/packages/sunpeak/bin/lib/test/test-fixtures.mjs
+++ b/packages/sunpeak/bin/lib/test/test-fixtures.mjs
@@ -1,20 +1,24 @@
 /**
- * MCP-first Playwright fixtures for testing MCP servers.
+ * Playwright fixtures for testing MCP servers.
  *
- * Provides an `mcp` fixture that abstracts the inspector, double-iframe
- * traversal, URL construction, and host selection. Tests read like MCP
- * operations, not browser automation.
+ * Two fixtures, cleanly separated:
+ * - `mcp` — MCP protocol primitives (callTool, listTools, listResources, readResource)
+ * - `inspector` — sunpeak inspector for rendering and visual testing (renderTool, host)
  *
  * Usage:
  *   import { test, expect } from 'sunpeak/test';
  *
- *   test('weather tool', async ({ mcp }) => {
- *     const result = await mcp.callTool('get-weather', { city: 'SF' });
- *     expect(result).not.toBeError();
- *     expect(result).toHaveTextContent('temperature');
+ *   test('protocol test', async ({ mcp }) => {
+ *     const tools = await mcp.listTools();
+ *     const result = await mcp.callTool('search', { query: 'headphones' });
+ *     expect(result.isError).toBeFalsy();
+ *   });
  *
- *     const app = result.app();
- *     await expect(app.getByText('San Francisco')).toBeVisible();
+ *   test('UI test', async ({ inspector }) => {
+ *     const result = await inspector.renderTool('search', { query: 'headphones' });
+ *     expect(result).not.toBeError();
+ *     await expect(result.app().getByText('headphones')).toBeVisible();
+ *     await result.screenshot('search-results');
  *   });
  */
 import { resolvePlaywrightESM } from '../live/utils.mjs';
@@ -26,10 +30,8 @@ const { test: base, expect } = await resolvePlaywrightESM(projectRoot);
 // Register MCP-native matchers
 registerMatchers(expect);
 
-/**
- * Build an inspector URL path with query parameters.
- * Inlined to avoid importing from dist (which pulls in React).
- */
+// ── Helpers ──
+
 function buildInspectorUrl(params) {
   const sp = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
@@ -37,15 +39,11 @@ function buildInspectorUrl(params) {
       sp.set(key, String(value));
     }
   }
-  // Always disable dev overlay in tests
   sp.set('devOverlay', 'false');
   const qs = sp.toString();
   return qs ? `/?${qs}` : '/';
 }
 
-/**
- * Resolve the host ID from the Playwright project name.
- */
 function resolveHostId(projectName) {
   if (!projectName) return 'chatgpt';
   if (projectName.startsWith('chatgpt')) return 'chatgpt';
@@ -53,57 +51,186 @@ function resolveHostId(projectName) {
   return projectName;
 }
 
+async function fetchJson(page, path) {
+  const baseURL = page.context()._options?.baseURL || '';
+  const response = await page.request.get(`${baseURL}${path}`);
+  if (!response.ok()) {
+    throw new Error(`${path} returned ${response.status()}: ${await response.text()}`);
+  }
+  return response.json();
+}
+
 /**
- * Create a ToolResult wrapper around the inspector's rendered state.
+ * Read the tool result from the inspector's <script id="__tool-result"> element.
  */
-function createToolResult(page, resultData) {
+async function readToolResult(page, timeout) {
+  try {
+    const script = page.locator('#__tool-result');
+    await script.waitFor({ state: 'attached', timeout: Math.min(timeout, 5_000) });
+    const json = await script.evaluate(
+      (el, t) =>
+        new Promise((resolve) => {
+          const check = () => {
+            const text = el.textContent?.trim();
+            if (text && text !== 'null') return resolve(text);
+            let timer;
+            const observer = new MutationObserver(() => {
+              const updated = el.textContent?.trim();
+              if (updated && updated !== 'null') {
+                observer.disconnect();
+                clearTimeout(timer);
+                resolve(updated);
+              }
+            });
+            observer.observe(el, { childList: true, characterData: true, subtree: true });
+            timer = setTimeout(() => { observer.disconnect(); resolve(null); }, t);
+          };
+          check();
+        }),
+      Math.min(timeout, 10_000)
+    );
+    if (json) {
+      const parsed = JSON.parse(json);
+      return {
+        content: parsed?.content || [],
+        structuredContent: parsed?.structuredContent,
+        isError: parsed?.isError || false,
+        source: parsed?.source || 'server',
+      };
+    }
+  } catch {
+    // Fall back to empty
+  }
+  return { content: [], structuredContent: undefined, isError: false, source: 'server' };
+}
+
+/**
+ * Create an InspectorResult from the rendered state.
+ */
+function createInspectorResult(page, resultData) {
   return {
     content: resultData?.content || [],
     structuredContent: resultData?.structuredContent,
     isError: resultData?.isError || false,
+    source: resultData?.source || 'server',
 
-    /**
-     * Get a FrameLocator for the rendered resource UI.
-     * Handles the double-iframe traversal (outer sandbox proxy + inner app).
-     * Returns the locator regardless — Playwright will throw with a clear
-     * error if no iframe exists when you interact with it.
-     */
+    /** Get a FrameLocator for the rendered resource UI (handles double-iframe). */
     app() {
       return page.frameLocator('iframe').frameLocator('iframe');
+    },
+
+    /**
+     * Take a screenshot and compare against a baseline.
+     * Only runs when visual testing is enabled (`sunpeak test --visual`).
+     * Silently skips otherwise.
+     *
+     * @param {string} [name] - Snapshot name (auto-generated if omitted)
+     * @param {Object} [options] - Playwright toHaveScreenshot options
+     */
+    async screenshot(name, options = {}) {
+      if (process.env.SUNPEAK_VISUAL !== 'true') return;
+
+      if (typeof name === 'object' && name !== null) {
+        options = name;
+        name = undefined;
+      }
+
+      const { target = 'app', element, ...playwrightOptions } = options;
+      let locator;
+      if (element) {
+        locator = element;
+      } else if (target === 'page') {
+        locator = page.locator('#root');
+      } else {
+        locator = page.frameLocator('iframe').frameLocator('iframe').locator('body');
+      }
+      const fullName = name && !name.endsWith('.png') ? `${name}.png` : name;
+      const args = fullName ? [fullName, playwrightOptions] : [playwrightOptions];
+      await expect(locator).toHaveScreenshot(...args);
     },
   };
 }
 
+// ── Fixtures ──
+
 const test = base.extend({
-  mcp: async ({ page }, use, testInfo) => {
+  /**
+   * MCP protocol fixture. Maps 1:1 to MCP protocol operations.
+   * No rendering, no inspector UI, no sunpeak concepts.
+   */
+  mcp: async ({ page }, use) => {
+    const fixture = {
+      async listTools() {
+        const result = await fetchJson(page, '/__sunpeak/list-tools');
+        return result.tools || [];
+      },
+
+      async callTool(name, input) {
+        const baseURL = page.context()._options?.baseURL || '';
+        const response = await page.request.post(`${baseURL}/__sunpeak/call-tool`, {
+          data: { name, arguments: input || {} },
+        });
+        if (!response.ok()) {
+          throw new Error(`callTool(${name}) returned ${response.status()}: ${await response.text()}`);
+        }
+        return response.json();
+      },
+
+      async listResources() {
+        const result = await fetchJson(page, '/__sunpeak/list-resources');
+        return result.resources || [];
+      },
+
+      async readResource(uri) {
+        const baseURL = page.context()._options?.baseURL || '';
+        const response = await page.request.get(
+          `${baseURL}/__sunpeak/read-resource?uri=${encodeURIComponent(uri)}`
+        );
+        if (!response.ok()) {
+          throw new Error(`readResource(${uri}) returned ${response.status()}: ${await response.text()}`);
+        }
+        return response.text();
+      },
+    };
+
+    await use(fixture);
+  },
+
+  /**
+   * sunpeak inspector fixture. Renders tools in simulated host environments.
+   * Built on top of the inspector, not the MCP protocol.
+   */
+  inspector: async ({ page }, use, testInfo) => {
     const host = resolveHostId(testInfo.project.name);
 
     const fixture = {
-      page,
+      /** Current host ID ('chatgpt' or 'claude') from Playwright project. */
       host,
 
-      /**
-       * Call a tool and get the rendered result.
-       *
-       * For sunpeak projects: navigates to the matching simulation (simulation
-       * fixture data including toolInput is served by sunpeak dev).
-       * For external servers: navigates to the matching simulation created by
-       * inspectServer from discovered tools.
-       *
-       * Note: The `input` parameter is accepted for API consistency and future
-       * use but is not currently passed to the inspector. Simulation fixture
-       * data provides the tool input for rendering.
-       *
-       * @param {string} name - Tool/simulation name (e.g., 'show-albums')
-       * @param {Record<string, unknown>} [_input] - Reserved for future use
-       * @param {Object} [options] - Display options
-       * @returns {Promise<ToolResult>}
-       */
-      async callTool(name, _input, options = {}) {
-        const { theme, displayMode, ...rest } = options;
+      /** The underlying Playwright Page (for advanced assertions). */
+      page,
 
+      /**
+       * Render a tool in the inspector and return the result.
+       *
+       * With `input`, the tool is called on the real server (bypasses fixtures).
+       * Without `input`, simulation fixture data is used when available.
+       *
+       * @param {string} name - Tool name
+       * @param {Record<string, unknown>} [input] - Tool arguments (real server call)
+       * @param {Object} [options] - Display options
+       * @param {'light' | 'dark'} [options.theme]
+       * @param {'inline' | 'pip' | 'fullscreen'} [options.displayMode]
+       * @param {number} [options.timeout] - Timeout in ms (default: 15s or mcpTimeout from config)
+       * @returns {Promise<InspectorResult>}
+       */
+      async renderTool(name, input, options = {}) {
+        const { theme, displayMode, timeout: callTimeout, ...rest } = options;
+
+        const hasInput = input != null && Object.keys(input).length > 0;
         const params = {
-          simulation: name,
+          ...(hasInput ? { tool: name, toolInput: JSON.stringify(input) } : { simulation: name }),
+          autoRun: 'true',
           host,
           ...(theme && { theme }),
           ...(displayMode && { displayMode }),
@@ -112,116 +239,16 @@ const test = base.extend({
 
         await page.goto(buildInspectorUrl(params));
 
-        // Wait for the resource iframe to have content
+        const resolvedTimeout = callTimeout ?? testInfo.project.use?.mcpTimeout ?? 15_000;
         try {
           const frame = page.frameLocator('iframe').frameLocator('iframe');
-          await frame.locator('body').waitFor({ state: 'attached', timeout: 15_000 });
+          await frame.locator('body').waitFor({ state: 'attached', timeout: resolvedTimeout });
         } catch {
           // Tool may not have a resource (no UI)
         }
 
-        return createToolResult(page, {
-          content: [],
-          structuredContent: undefined,
-          isError: false,
-        });
-      },
-
-      /**
-       * Navigate to a tool with no mock data ("Press Run" state).
-       * Use for testing the empty/loading state before a tool is executed.
-       */
-      async openTool(name, options = {}) {
-        const { theme, ...rest } = options;
-        const params = {
-          tool: name,
-          host,
-          ...(theme && { theme }),
-          ...rest,
-        };
-        await page.goto(buildInspectorUrl(params));
-        await page.locator('#root').waitFor({ state: 'attached' });
-      },
-
-      /**
-       * Click the Run button and wait for the resource to render.
-       * Use after openTool() in Prod Tools mode.
-       */
-      async runTool() {
-        await page.locator('button:has-text("Run")').click();
-        await page.locator('iframe').waitFor({ state: 'attached', timeout: 30_000 });
-        return createToolResult(page, {
-          content: [],
-          structuredContent: undefined,
-          isError: false,
-        });
-      },
-
-      /**
-       * Change the theme via the sidebar toggle.
-       */
-      async setTheme(theme) {
-        const label = theme === 'light' ? 'Light' : 'Dark';
-        const button = page.locator(`button:has-text("${label}")`);
-        if (await button.isVisible().catch(() => false)) {
-          await button.click();
-          // Wait for theme to propagate to the iframe
-          await page.waitForTimeout(300);
-        }
-      },
-
-      /**
-       * Change the display mode via the sidebar buttons.
-       */
-      async setDisplayMode(mode) {
-        const labels = { inline: 'Inline', pip: 'PiP', fullscreen: 'Full' };
-        const label = labels[mode] || mode;
-        await page.locator(`button:has-text("${label}")`).click();
-        // Wait for display mode transition
-        await page.waitForTimeout(500);
-      },
-
-      /**
-       * Take a screenshot and compare against a baseline.
-       * Only performs the comparison when visual testing is enabled
-       * (`sunpeak test --visual`). Silently skips otherwise, so tests
-       * that include screenshot() calls still pass during normal runs.
-       *
-       * Accepts all Playwright toHaveScreenshot() options (threshold,
-       * maxDiffPixelRatio, maxDiffPixels, mask, animations, caret,
-       * fullPage, clip, scale, stylePath, etc.) and passes them through.
-       *
-       * @param {string} [name] - Snapshot name (auto-generated from test title if omitted)
-       * @param {Object} [options] - Screenshot and comparison options
-       * @param {'app' | 'page'} [options.target='app'] - What to screenshot
-       * @param {import('@playwright/test').Locator} [options.element] - Specific locator to screenshot
-       */
-      async screenshot(name, options = {}) {
-        if (process.env.SUNPEAK_VISUAL !== 'true') return;
-
-        // Support screenshot(options) without a name
-        if (typeof name === 'object' && name !== null) {
-          options = name;
-          name = undefined;
-        }
-
-        const { target = 'app', element, ...playwrightOptions } = options;
-
-        let locator;
-        if (element) {
-          locator = element;
-        } else if (target === 'page') {
-          locator = page.locator('#root');
-        } else {
-          locator = page.frameLocator('iframe').frameLocator('iframe').locator('body');
-        }
-
-        const fullName = name && !name.endsWith('.png') ? `${name}.png` : name;
-        const args = fullName
-          ? [fullName, playwrightOptions]
-          : [playwrightOptions];
-
-        await expect(locator).toHaveScreenshot(...args);
+        const resultData = await readToolResult(page, resolvedTimeout);
+        return createInspectorResult(page, resultData);
       },
     };
 

--- a/packages/sunpeak/package.json
+++ b/packages/sunpeak/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sunpeak",
-  "version": "0.19.15",
+  "version": "0.20.0",
   "description": "Inspector, testing framework, and app framework for MCP Apps.",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -94,6 +94,12 @@
       "import": {
         "types": "./bin/lib/inspect/inspect-config.d.mts",
         "default": "./bin/lib/inspect/inspect-config.mjs"
+      }
+    },
+    "./inspect": {
+      "import": {
+        "types": "./bin/lib/inspect/inspect-server.d.mts",
+        "default": "./bin/lib/inspect/inspect-server.mjs"
       }
     },
     "./eval": {

--- a/packages/sunpeak/scripts/validate.mjs
+++ b/packages/sunpeak/scripts/validate.mjs
@@ -393,7 +393,7 @@ function runTestInitSmokeTest() {
       }
 
       const visualContent = readFileSync(join(dir, 'tests/e2e/visual.test.ts'), 'utf-8');
-      if (!visualContent.includes("from 'sunpeak/test'") || !visualContent.includes('mcp.screenshot')) {
+      if (!visualContent.includes("from 'sunpeak/test'") || !visualContent.includes('result.screenshot')) {
         return { ok: false, step: 'test-init js: visual test missing expected content', output: allOutput.join('\n') };
       }
 

--- a/packages/sunpeak/src/cli/commands.test.ts
+++ b/packages/sunpeak/src/cli/commands.test.ts
@@ -782,7 +782,7 @@ describe('CLI Commands', () => {
 
       const visual = getWrittenContent(writeFileSync, 'e2e/visual.test.ts');
       expect(visual).toContain("from 'sunpeak/test'");
-      expect(visual).toContain('mcp.screenshot');
+      expect(visual).toContain('result.screenshot');
 
       const liveTest = getWrittenContent(writeFileSync, 'live/example.test.ts');
       expect(liveTest).toContain("from 'sunpeak/test/live'");
@@ -958,9 +958,7 @@ describe('CLI Commands', () => {
         })
       );
 
-      expect(logWarnMock).toHaveBeenCalledWith(
-        expect.stringContaining('Server not configured')
-      );
+      expect(logWarnMock).toHaveBeenCalledWith(expect.stringContaining('Server not configured'));
     });
 
     it('should warn when server is "configure later" for JS projects', async () => {
@@ -976,12 +974,10 @@ describe('CLI Commands', () => {
         })
       );
 
-      expect(logWarnMock).toHaveBeenCalledWith(
-        expect.stringContaining('Server not configured')
-      );
+      expect(logWarnMock).toHaveBeenCalledWith(expect.stringContaining('Server not configured'));
     });
 
-    it('should show Node.js requirement in external project next steps', async () => {
+    it('should show run commands in external project next steps', async () => {
       const { testInit } = await importTestInit();
       const logMessageMock = vi.fn();
 
@@ -992,9 +988,7 @@ describe('CLI Commands', () => {
         })
       );
 
-      expect(logMessageMock).toHaveBeenCalledWith(
-        expect.stringContaining('Node.js 20+')
-      );
+      expect(logMessageMock).toHaveBeenCalledWith(expect.stringContaining('sunpeak test'));
     });
   });
 

--- a/packages/sunpeak/src/cli/inspect.test.ts
+++ b/packages/sunpeak/src/cli/inspect.test.ts
@@ -9,6 +9,56 @@ import * as path from 'path';
 // not exported. Instead, test the public behavior via the module.
 
 const importInspectConfig = () => import('../../bin/lib/inspect/inspect-config.mjs');
+const importTestConfig = () => import('../../bin/lib/test/test-config.mjs');
+
+describe('defineConfig (external server)', () => {
+  it('resolves local sunpeak binary when available', async () => {
+    const { defineConfig } = await importTestConfig();
+    const config = defineConfig({
+      server: { url: 'http://localhost:8000/mcp' },
+    });
+
+    // Should contain 'sunpeak inspect' — either bare or with a node_modules/.bin prefix
+    expect(config.webServer.command).toContain('sunpeak inspect');
+  });
+
+  it('passes env as --env flags in the inspect command', async () => {
+    const { defineConfig } = await importTestConfig();
+    const config = defineConfig({
+      server: { command: 'python', args: ['server.py'], env: { SECRET: 'abc' } },
+    });
+
+    expect(config.webServer.command).toContain('--env SECRET=abc');
+  });
+
+  it('quotes env values with spaces', async () => {
+    const { defineConfig } = await importTestConfig();
+    const config = defineConfig({
+      server: { command: 'python', args: ['server.py'], env: { MSG: 'hi there' } },
+    });
+
+    expect(config.webServer.command).toContain('--env "MSG=hi there"');
+  });
+
+  it('passes cwd as --cwd flag', async () => {
+    const { defineConfig } = await importTestConfig();
+    const config = defineConfig({
+      server: { command: 'python', args: ['server.py'], cwd: './backend' },
+    });
+
+    expect(config.webServer.command).toContain('--cwd ./backend');
+  });
+
+  it('uses custom timeout', async () => {
+    const { defineConfig } = await importTestConfig();
+    const config = defineConfig({
+      server: { url: 'http://localhost:8000/mcp' },
+      timeout: 180_000,
+    });
+
+    expect(config.webServer.timeout).toBe(180_000);
+  });
+});
 
 describe('defineInspectConfig', () => {
   it('generates a valid Playwright config shape', async () => {
@@ -96,6 +146,66 @@ describe('defineInspectConfig', () => {
     expect(() => defineInspectConfig({})).toThrow('`server` option is required');
   });
 
+  it('passes env as --env flags for stdio servers', async () => {
+    const { defineInspectConfig } = await importInspectConfig();
+    const config = defineInspectConfig({
+      server: 'python server.py',
+      env: { API_KEY: 'test-123', DEBUG: 'true' },
+    });
+
+    expect(config.webServer.command).toContain('--env API_KEY=test-123');
+    expect(config.webServer.command).toContain('--env DEBUG=true');
+  });
+
+  it('quotes env values that contain spaces', async () => {
+    const { defineInspectConfig } = await importInspectConfig();
+    const config = defineInspectConfig({
+      server: 'python server.py',
+      env: { GREETING: 'hello world' },
+    });
+
+    expect(config.webServer.command).toContain('--env "GREETING=hello world"');
+  });
+
+  it('passes cwd as --cwd flag for stdio servers', async () => {
+    const { defineInspectConfig } = await importInspectConfig();
+    const config = defineInspectConfig({
+      server: 'python server.py',
+      cwd: './backend',
+    });
+
+    expect(config.webServer.command).toContain('--cwd ./backend');
+  });
+
+  it('quotes cwd paths that contain spaces', async () => {
+    const { defineInspectConfig } = await importInspectConfig();
+    const config = defineInspectConfig({
+      server: 'python server.py',
+      cwd: './my project',
+    });
+
+    expect(config.webServer.command).toContain('--cwd "./my project"');
+  });
+
+  it('uses custom timeout when provided', async () => {
+    const { defineInspectConfig } = await importInspectConfig();
+    const config = defineInspectConfig({
+      server: 'http://localhost:8000/mcp',
+      timeout: 120_000,
+    });
+
+    expect(config.webServer.timeout).toBe(120_000);
+  });
+
+  it('defaults timeout to 60s when not provided', async () => {
+    const { defineInspectConfig } = await importInspectConfig();
+    const config = defineInspectConfig({
+      server: 'http://localhost:8000/mcp',
+    });
+
+    expect(config.webServer.timeout).toBe(60_000);
+  });
+
   it('sets appropriate worker limits', async () => {
     const { defineInspectConfig } = await importInspectConfig();
     const config = defineInspectConfig({ server: 'http://localhost:8000/mcp' });
@@ -124,6 +234,56 @@ describe('defineInspectConfig', () => {
     expect(baseUrlPort).toBeGreaterThan(0);
     expect(sandboxPort).toBeGreaterThan(0);
     expect(baseUrlPort).not.toBe(sandboxPort);
+  });
+});
+
+describe('isAuthError', () => {
+  // isAuthError is not exported, so we re-implement the same logic to verify
+  // the detection patterns are correct. Keep this in sync with inspect.mjs.
+  const isAuthError = (err: Error) => {
+    if (err.constructor?.name === 'UnauthorizedError') return true;
+    const msg = err.message || '';
+    if (msg.includes('invalid_token')) return true;
+    if (msg.includes('ECONNREFUSED') || msg.includes('ETIMEDOUT') || msg.includes('ENOTFOUND')) {
+      return false;
+    }
+    return false;
+  };
+
+  it('detects invalid_token error', () => {
+    const err = new Error(
+      'Streamable HTTP error: Error POSTing to endpoint: {"error":"invalid_token"}'
+    );
+    expect(isAuthError(err)).toBe(true);
+  });
+
+  it('detects UnauthorizedError by class name', () => {
+    class UnauthorizedError extends Error {
+      constructor() {
+        super('Unauthorized');
+      }
+    }
+    expect(isAuthError(new UnauthorizedError())).toBe(true);
+  });
+
+  it('does not match ECONNREFUSED', () => {
+    const err = new Error('connect ECONNREFUSED 127.0.0.1:8000');
+    expect(isAuthError(err)).toBe(false);
+  });
+
+  it('does not match ETIMEDOUT', () => {
+    const err = new Error('connect ETIMEDOUT 10.0.0.1:443');
+    expect(isAuthError(err)).toBe(false);
+  });
+
+  it('does not match generic errors', () => {
+    const err = new Error('Something went wrong');
+    expect(isAuthError(err)).toBe(false);
+  });
+
+  it('does not false-positive on URLs containing 401', () => {
+    const err = new Error('Failed to fetch http://example.com/path/4014');
+    expect(isAuthError(err)).toBe(false);
   });
 });
 

--- a/packages/sunpeak/src/inspector/inspector.test.tsx
+++ b/packages/sunpeak/src/inspector/inspector.test.tsx
@@ -865,6 +865,65 @@ describe('Inspector', () => {
     });
   });
 
+  describe('Tool result data element', () => {
+    it('renders __tool-result script element with simulation data', () => {
+      const sim = createSim({
+        toolResult: { content: [{ type: 'text', text: 'hello' }], structuredContent: { v: 1 } },
+      });
+      render(<Inspector simulations={{ test: sim }} />);
+
+      const script = document.getElementById('__tool-result');
+      expect(script).toBeInTheDocument();
+      expect(script?.getAttribute('type')).toBe('application/json');
+      const data = JSON.parse(script?.textContent || 'null');
+      expect(data.content).toEqual([{ type: 'text', text: 'hello' }]);
+      expect(data.structuredContent).toEqual({ v: 1 });
+      expect(data.source).toBe('fixture');
+    });
+
+    it('renders null when no tool result exists', () => {
+      render(<Inspector simulations={{ test: createSim() }} />);
+
+      const script = document.getElementById('__tool-result');
+      expect(script).toBeInTheDocument();
+      expect(JSON.parse(script?.textContent || 'null')).toBeNull();
+    });
+
+    it('sets source to server after calling real tool handler', async () => {
+      const user = userEvent.setup();
+      const onCallTool = vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: 'server response' }],
+      });
+
+      // Use a sim without fixture data so "None (call server)" is the default
+      const sim = createSim({ toolInput: undefined, toolResult: undefined });
+      render(<Inspector simulations={{ test: sim }} onCallTool={onCallTool} />);
+
+      await user.click(screen.getByRole('button', { name: /run/i }));
+
+      await waitFor(() => {
+        const script = document.getElementById('__tool-result');
+        const data = JSON.parse(script?.textContent || 'null');
+        expect(data?.source).toBe('server');
+        expect(data?.content[0]?.text).toBe('server response');
+      });
+    });
+
+    it('escapes < in tool result to prevent script injection', () => {
+      const sim = createSim({
+        toolResult: { content: [{ type: 'text', text: '<script>alert(1)</script>' }] },
+      });
+      render(<Inspector simulations={{ test: sim }} />);
+
+      const script = document.getElementById('__tool-result');
+      // The raw innerHTML should not contain unescaped <
+      expect(script?.innerHTML).not.toContain('</script>');
+      // But parsing should recover the original text
+      const data = JSON.parse(script?.textContent || 'null');
+      expect(data.content[0].text).toBe('<script>alert(1)</script>');
+    });
+  });
+
   // ── Story 2: Inspect-only user ──
   describe('Inspect-only: exploring external servers', () => {
     it('starts empty, then populates after reconnect', async () => {

--- a/packages/sunpeak/src/inspector/inspector.tsx
+++ b/packages/sunpeak/src/inspector/inspector.tsx
@@ -153,12 +153,16 @@ export function Inspector({
 
   // Parse URL params once for tool/simulation initialization.
   const initUrlParams = React.useMemo(() => {
-    if (typeof window === 'undefined') return { tool: null, simulation: null, noMockData: false };
+    if (typeof window === 'undefined')
+      return { tool: null, simulation: null, noMockData: false, autoRun: false };
     const params = new URLSearchParams(window.location.search);
     return {
       tool: params.get('tool'),
       simulation: params.get('simulation'),
       noMockData: false,
+      // autoRun: test fixtures set this to call the tool immediately on load
+      // when no fixture data exists. Interactive users don't set this.
+      autoRun: params.get('autoRun') === 'true',
     };
   }, []);
 
@@ -518,6 +522,23 @@ export function Inspector({
       setIsRunning(false);
     }
   }, [onCallTool, onCallToolDirect, simulations, effectiveSimulationName, state]);
+
+  // Auto-run: when ?autoRun=true is set (by test fixtures) and no fixture data
+  // is active, call the tool immediately with the current toolInput. Interactive
+  // users don't set this flag, so browsing tools in the sidebar never triggers
+  // an automatic server call. Only fires once on mount.
+  const autoRunFired = React.useRef(false);
+  React.useEffect(() => {
+    if (
+      initUrlParams.autoRun &&
+      !autoRunFired.current &&
+      activeSimulationName === null &&
+      (onCallTool || onCallToolDirect)
+    ) {
+      autoRunFired.current = true;
+      handleRun();
+    }
+  }, [initUrlParams.autoRun, activeSimulationName, onCallTool, onCallToolDirect, handleRun]);
 
   // Resolve the active host shell
   const activeShell = getHostShell(state.activeHost);
@@ -1487,6 +1508,21 @@ export function Inspector({
       >
         {conversationContent}
       </SimpleSidebar>
+      {/* Expose tool result as structured data for test fixtures to read.
+          This is the authoritative source — test matchers read from here,
+          not from sidebar textarea values. Includes `source` so tests can
+          distinguish fixture data from real server responses. */}
+      <script
+        type="application/json"
+        id="__tool-result"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            state.toolResult
+              ? { ...state.toolResult, source: activeSimulationName ? 'fixture' : 'server' }
+              : null
+          ).replace(/</g, '\\u003c'),
+        }}
+      />
     </ThemeProvider>
   );
 }

--- a/packages/sunpeak/src/inspector/mcp-app-host.ts
+++ b/packages/sunpeak/src/inspector/mcp-app-host.ts
@@ -17,6 +17,14 @@ import type {
 
 const DEFAULT_HOST_INFO = { name: 'SunpeakInspector', version: '1.0.0' };
 
+/**
+ * Debug logger for MCP bridge messages. Uses CSS-formatted console.log in browsers,
+ * no-ops during unit tests (Vitest) where the output is just noise.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const debugLog: (...args: any[]) => void =
+  typeof process !== 'undefined' && process.env?.VITEST ? () => {} : console.log;
+
 const DEFAULT_HOST_CAPABILITIES: McpUiHostCapabilities = {
   openLinks: {},
   serverTools: {},
@@ -111,7 +119,7 @@ export class McpAppHost {
         }
       }
       const ack = {};
-      console.log(
+      debugLog(
         `%c[MCP ↓]%c host → app: %copenLink ack`,
         'color:#f9a8d4',
         'color:inherit',
@@ -126,7 +134,7 @@ export class McpAppHost {
         this.options.onMessage(role, content);
       }
       const ack = {};
-      console.log(
+      debugLog(
         `%c[MCP ↓]%c host → app: %csendMessage ack`,
         'color:#f9a8d4',
         'color:inherit',
@@ -139,7 +147,7 @@ export class McpAppHost {
     this.bridge.onrequestdisplaymode = async ({ mode }) => {
       this.options.onDisplayModeChange?.(mode);
       const result = { mode };
-      console.log(
+      debugLog(
         `%c[MCP ↓]%c host → app: %crequestDisplayMode result`,
         'color:#f9a8d4',
         'color:inherit',
@@ -152,7 +160,7 @@ export class McpAppHost {
     this.bridge.onupdatemodelcontext = async ({ content, structuredContent }) => {
       this.options.onUpdateModelContext?.(content ?? [], structuredContent);
       const ack = {};
-      console.log(
+      debugLog(
         `%c[MCP ↓]%c host → app: %cupdateModelContext ack`,
         'color:#f9a8d4',
         'color:inherit',
@@ -204,7 +212,7 @@ export class McpAppHost {
           ],
         };
       }
-      console.log(
+      debugLog(
         `%c[MCP ↓]%c host → app: %ccallServerTool result(${params.name})`,
         'color:#f9a8d4',
         'color:inherit',
@@ -219,7 +227,7 @@ export class McpAppHost {
         this.options.onDownloadFile(contents);
       }
       const ack = {};
-      console.log(
+      debugLog(
         `%c[MCP ↓]%c host → app: %cdownloadFile ack`,
         'color:#f9a8d4',
         'color:inherit',
@@ -233,7 +241,7 @@ export class McpAppHost {
       if (this.options.onRequestTeardown) {
         this.options.onRequestTeardown();
       } else {
-        console.log('[MCP App] requestTeardown (app requested close)');
+        debugLog('[MCP App] requestTeardown (app requested close)');
       }
     };
 
@@ -270,7 +278,7 @@ export class McpAppHost {
       if (method?.startsWith('sunpeak/') || method === 'ui/notifications/sandbox-proxy-ready')
         return;
       const label = method ?? (data.id != null ? `response #${data.id}` : 'unknown');
-      console.log(
+      debugLog(
         `%c[MCP ↑]%c app → host: %c${label}`,
         'color:#6ee7b7',
         'color:inherit',
@@ -343,7 +351,7 @@ export class McpAppHost {
    * to commit its DOM before firing onDisplayModeReady.
    */
   setHostContext(context: McpUiHostContext): void {
-    console.log(
+    debugLog(
       `%c[MCP ↓]%c host → app: %csetHostContext`,
       'color:#f9a8d4',
       'color:inherit',
@@ -368,7 +376,7 @@ export class McpAppHost {
    */
   sendToolInput(args: Record<string, unknown>): void {
     const params: McpUiToolInputNotification['params'] = { arguments: args };
-    console.log(
+    debugLog(
       `%c[MCP ↓]%c host → app: %csendToolInput`,
       'color:#f9a8d4',
       'color:inherit',
@@ -387,7 +395,7 @@ export class McpAppHost {
    * If the app hasn't initialized yet, the result is queued.
    */
   sendToolResult(result: CallToolResult): void {
-    console.log(
+    debugLog(
       `%c[MCP ↓]%c host → app: %csendToolResult`,
       'color:#f9a8d4',
       'color:inherit',
@@ -407,7 +415,7 @@ export class McpAppHost {
    */
   sendToolInputPartial(args: Record<string, unknown>): void {
     const params: McpUiToolInputPartialNotification['params'] = { arguments: args };
-    console.log(
+    debugLog(
       `%c[MCP ↓]%c host → app: %csendToolInputPartial`,
       'color:#f9a8d4',
       'color:inherit',
@@ -426,7 +434,7 @@ export class McpAppHost {
    */
   sendToolCancelled(reason?: string): void {
     const params: McpUiToolCancelledNotification['params'] = reason ? { reason } : {};
-    console.log(
+    debugLog(
       `%c[MCP ↓]%c host → app: %csendToolCancelled`,
       'color:#f9a8d4',
       'color:inherit',

--- a/packages/sunpeak/src/inspector/use-inspector-state.ts
+++ b/packages/sunpeak/src/inspector/use-inspector-state.ts
@@ -146,11 +146,14 @@ export interface InspectorState {
  * - safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight: number
  * - host: 'chatgpt' | 'claude'
  * - tool: tool name (e.g., 'show-albums') — selects tool without mock data
+ * - toolInput: JSON-encoded tool arguments (overrides simulation fixture data)
+ * - autoRun: 'true' — call the tool on load when no fixture data exists (set by test fixtures)
  * - prodResources: 'true' | 'false'
  */
 function parseUrlParams(): {
   simulation?: string;
   tool?: string;
+  toolInput?: Record<string, unknown>;
   theme?: McpUiTheme;
   displayMode?: McpUiDisplayMode;
   locale?: string;
@@ -170,6 +173,15 @@ function parseUrlParams(): {
 
   const simulation = params.get('simulation') ?? undefined;
   const tool = params.get('tool') ?? undefined;
+  const toolInputParam = params.get('toolInput');
+  let toolInput: Record<string, unknown> | undefined;
+  if (toolInputParam) {
+    try {
+      toolInput = JSON.parse(toolInputParam);
+    } catch {
+      // Invalid JSON — ignore, simulation data will be used instead
+    }
+  }
   const theme = params.get('theme') as McpUiTheme | null;
   const displayMode = params.get('displayMode') as McpUiDisplayMode | null;
   const locale = params.get('locale');
@@ -228,6 +240,7 @@ function parseUrlParams(): {
   return {
     simulation,
     tool,
+    toolInput,
     theme: theme ?? undefined,
     displayMode: displayMode ?? undefined,
     locale: locale ?? undefined,
@@ -412,7 +425,7 @@ export function useInspectorState({
   // ── Tool data state ──
 
   const [toolInput, setToolInput] = useState<Record<string, unknown>>(
-    () => selectedSim?.toolInput ?? {}
+    () => urlParams.toolInput ?? selectedSim?.toolInput ?? {}
   );
   const [toolResult, setToolResult] = useState<CallToolResult | undefined>(
     () => selectedSim?.toolResult as CallToolResult | undefined
@@ -436,9 +449,11 @@ export function useInspectorState({
   const [toolResultError, setToolResultError] = useState('');
   const [modelContextError, setModelContextError] = useState('');
 
-  // Reset tool data when simulation changes.
+  // Reset tool data when simulation changes. URL-provided toolInput takes
+  // precedence over the simulation fixture data, allowing tests to pass
+  // dynamic arguments to the server.
   useEffect(() => {
-    const newInput = selectedSim?.toolInput ?? {};
+    const newInput = urlParams.toolInput ?? selectedSim?.toolInput ?? {};
     const newResult = (selectedSim?.toolResult as CallToolResult | undefined) ?? undefined;
     setToolInput(newInput);
     setToolResult(newResult);

--- a/packages/sunpeak/template/tests/e2e/albums.spec.ts
+++ b/packages/sunpeak/template/tests/e2e/albums.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from 'sunpeak/test';
 
-test('should render album cards with correct styles', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums');
+test('should render album cards with correct styles', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums');
   const app = result.app();
 
   const albumCard = app.locator('button:has-text("Summer Slice")');
@@ -15,8 +15,8 @@ test('should render album cards with correct styles', async ({ mcp }) => {
   expect(styles.borderRadius).toBe('12px');
 });
 
-test('should have album image with correct aspect ratio', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums');
+test('should have album image with correct aspect ratio', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums');
   const app = result.app();
 
   const imageContainer = app.locator('button:has-text("Summer Slice") .aspect-\\[4\\/3\\]');
@@ -30,8 +30,8 @@ test('should have album image with correct aspect ratio', async ({ mcp }) => {
   expect(styles.overflow).toBe('hidden');
 });
 
-test('should render album cards in dark mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { theme: 'dark' });
+test('should render album cards in dark mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', undefined, { theme: 'dark' });
   const app = result.app();
 
   const albumTitle = app.locator('button:has-text("Summer Slice") div').first();
@@ -43,44 +43,16 @@ test('should render album cards in dark mode', async ({ mcp }) => {
   expect(titleStyles.color).toBeTruthy();
 });
 
-test('should show empty state with Run button in prod tools mode', async ({ mcp }) => {
-  await mcp.openTool('show-albums', { theme: 'dark' });
-
-  await expect(mcp.page.locator('text=Press Run to call the tool')).toBeVisible();
-  await expect(mcp.page.locator('button:has-text("Run")')).toBeVisible();
-  await expect(mcp.page.locator('iframe')).not.toBeAttached();
-});
-
-test('should have themed empty state colors in light mode', async ({ mcp }) => {
-  await mcp.openTool('show-albums', { theme: 'light' });
-
-  const emptyState = mcp.page.locator('text=Press Run to call the tool');
-  await expect(emptyState).toBeVisible();
-
-  const color = await emptyState.evaluate((el) => window.getComputedStyle(el).color);
-  const [r, g, b] = color.match(/\d+/g)!.map(Number);
-  expect(r + g + b).toBeLessThan(600);
-});
-
-test('should have themed empty state colors in dark mode', async ({ mcp }) => {
-  await mcp.openTool('show-albums', { theme: 'dark' });
-
-  const emptyState = mcp.page.locator('text=Press Run to call the tool');
-  await expect(emptyState).toBeVisible();
-
-  const color = await emptyState.evaluate((el) => window.getComputedStyle(el).color);
-  const [r, g, b] = color.match(/\d+/g)!.map(Number);
-  expect(r + g + b).toBeGreaterThan(200);
-});
-
-test('should activate prod resources mode without errors', async ({ mcp }) => {
-  await mcp.callTool('show-albums', {}, { theme: 'dark', prodResources: true });
-  const root = mcp.page.locator('#root');
+test('should activate prod resources mode without errors', async ({ inspector }) => {
+  await inspector.renderTool('show-albums', undefined, { theme: 'dark', prodResources: true });
+  const root = inspector.page.locator('#root');
   await expect(root).not.toBeEmpty();
 });
 
-test('should render correctly in fullscreen', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { displayMode: 'fullscreen' });
+test('should render correctly in fullscreen', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', undefined, {
+    displayMode: 'fullscreen',
+  });
   const app = result.app();
 
   const albumCard = app.locator('button:has-text("Summer Slice")');
@@ -94,22 +66,22 @@ test('should render correctly in fullscreen', async ({ mcp }) => {
   expect(styles.borderRadius).toBe('12px');
 });
 
-test('should preserve content when switching to fullscreen', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { theme: 'dark' });
+test('should render content in fullscreen mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', undefined, {
+    theme: 'dark',
+    displayMode: 'fullscreen',
+  });
   const app = result.app();
   await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
-
-  await mcp.setDisplayMode('fullscreen');
-  await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible({ timeout: 5000 });
 });
 
-test('should preserve content when switching to PiP', async ({ mcp }) => {
-  test.skip(mcp.host === 'claude', 'Claude does not support PiP');
+test('should render content in PiP mode', async ({ inspector }) => {
+  test.skip(inspector.host === 'claude', 'Claude does not support PiP');
 
-  const result = await mcp.callTool('show-albums', {}, { theme: 'dark' });
+  const result = await inspector.renderTool('show-albums', undefined, {
+    theme: 'dark',
+    displayMode: 'pip',
+  });
   const app = result.app();
   await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
-
-  await mcp.setDisplayMode('pip');
-  await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible({ timeout: 5000 });
 });

--- a/packages/sunpeak/template/tests/e2e/carousel.spec.ts
+++ b/packages/sunpeak/template/tests/e2e/carousel.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from 'sunpeak/test';
 
-test('should render carousel cards with correct styles', async ({ mcp }) => {
-  const result = await mcp.callTool('show-carousel');
+test('should render carousel cards with correct styles', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-carousel');
   const app = result.app();
 
   const card = app.locator('.rounded-2xl').first();
@@ -15,8 +15,8 @@ test('should render carousel cards with correct styles', async ({ mcp }) => {
   expect(styles.cursor).toBe('pointer');
 });
 
-test('should have card with border styling', async ({ mcp }) => {
-  const result = await mcp.callTool('show-carousel');
+test('should have card with border styling', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-carousel');
   const app = result.app();
 
   const card = app.locator('.rounded-2xl.border').first();
@@ -30,8 +30,8 @@ test('should have card with border styling', async ({ mcp }) => {
   expect(styles.borderStyle).toBe('solid');
 });
 
-test('should have interactive buttons', async ({ mcp }) => {
-  const result = await mcp.callTool('show-carousel');
+test('should have interactive buttons', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-carousel');
   const app = result.app();
 
   const visitButton = app.locator('button:has-text("Visit")').first();
@@ -43,51 +43,23 @@ test('should have interactive buttons', async ({ mcp }) => {
   expect(styles.cursor).toBe('pointer');
 });
 
-test('should show empty state with Run button in prod tools mode', async ({ mcp }) => {
-  await mcp.openTool('show-carousel', { theme: 'dark' });
-
-  await expect(mcp.page.locator('text=Press Run to call the tool')).toBeVisible();
-  await expect(mcp.page.locator('button:has-text("Run")')).toBeVisible();
-  await expect(mcp.page.locator('iframe')).not.toBeAttached();
-});
-
-test('should have themed empty state colors in light mode', async ({ mcp }) => {
-  await mcp.openTool('show-carousel', { theme: 'light' });
-
-  const emptyState = mcp.page.locator('text=Press Run to call the tool');
-  await expect(emptyState).toBeVisible();
-
-  const color = await emptyState.evaluate((el) => window.getComputedStyle(el).color);
-  const [r, g, b] = color.match(/\d+/g)!.map(Number);
-  expect(r + g + b).toBeLessThan(600);
-});
-
-test('should have themed empty state colors in dark mode', async ({ mcp }) => {
-  await mcp.openTool('show-carousel', { theme: 'dark' });
-
-  const emptyState = mcp.page.locator('text=Press Run to call the tool');
-  await expect(emptyState).toBeVisible();
-
-  const color = await emptyState.evaluate((el) => window.getComputedStyle(el).color);
-  const [r, g, b] = color.match(/\d+/g)!.map(Number);
-  expect(r + g + b).toBeGreaterThan(200);
-});
-
-test('should activate prod resources mode without errors', async ({ mcp }) => {
-  await mcp.callTool('show-carousel', {}, { theme: 'dark', prodResources: true });
-  const root = mcp.page.locator('#root');
+test('should activate prod resources mode without errors', async ({ inspector }) => {
+  await inspector.renderTool('show-carousel', undefined, { theme: 'dark', prodResources: true });
+  const root = inspector.page.locator('#root');
   await expect(root).not.toBeEmpty();
 });
 
-test('should render correctly in fullscreen', async ({ mcp }) => {
-  await mcp.callTool('show-carousel', {}, { displayMode: 'fullscreen' });
-  await mcp.page.waitForLoadState('networkidle');
-  const root = mcp.page.locator('#root');
+test('should render correctly in fullscreen', async ({ inspector }) => {
+  await inspector.renderTool('show-carousel', undefined, { displayMode: 'fullscreen' });
+  await inspector.page.waitForLoadState('networkidle');
+  const root = inspector.page.locator('#root');
   await expect(root).not.toBeEmpty();
 });
 
-test('should show detail view with place info in fullscreen', async ({ mcp }) => {
-  const result = await mcp.callTool('show-carousel', {}, { displayMode: 'fullscreen' });
+test('should show detail view with place info in fullscreen', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-carousel', undefined, {
+    displayMode: 'fullscreen',
+  });
   const app = result.app();
 
   const card = app.locator('.rounded-2xl').first();
@@ -99,8 +71,10 @@ test('should show detail view with place info in fullscreen', async ({ mcp }) =>
   await expect(app.locator('text=Tips')).toBeVisible();
 });
 
-test('should show detail view when Learn More is clicked', async ({ mcp }) => {
-  const result = await mcp.callTool('show-carousel', {}, { displayMode: 'fullscreen' });
+test('should show detail view when Learn More is clicked', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-carousel', undefined, {
+    displayMode: 'fullscreen',
+  });
   const app = result.app();
 
   const learnMore = app.locator('button:has-text("Learn More")').first();
@@ -111,8 +85,10 @@ test('should show detail view when Learn More is clicked', async ({ mcp }) => {
   await expect(app.locator('text=Address')).toBeVisible();
 });
 
-test('should not have a back button in detail view', async ({ mcp }) => {
-  const result = await mcp.callTool('show-carousel', {}, { displayMode: 'fullscreen' });
+test('should not have a back button in detail view', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-carousel', undefined, {
+    displayMode: 'fullscreen',
+  });
   const app = result.app();
 
   const card = app.locator('.rounded-2xl').first();
@@ -124,8 +100,10 @@ test('should not have a back button in detail view', async ({ mcp }) => {
   await expect(backButton).not.toBeAttached();
 });
 
-test('should center the hero image without stretching', async ({ mcp }) => {
-  const result = await mcp.callTool('show-carousel', {}, { displayMode: 'fullscreen' });
+test('should center the hero image without stretching', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-carousel', undefined, {
+    displayMode: 'fullscreen',
+  });
   const app = result.app();
 
   const card = app.locator('.rounded-2xl').first();
@@ -140,8 +118,8 @@ test('should center the hero image without stretching', async ({ mcp }) => {
   expect(styles.justifyContent).toBe('center');
 });
 
-test('should render carousel in dark mode with correct styles', async ({ mcp }) => {
-  const result = await mcp.callTool('show-carousel', {}, { theme: 'dark' });
+test('should render carousel in dark mode with correct styles', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-carousel', undefined, { theme: 'dark' });
   const app = result.app();
 
   const card = app.locator('.rounded-2xl').first();
@@ -155,8 +133,8 @@ test('should render carousel in dark mode with correct styles', async ({ mcp }) 
   expect(styles.cursor).toBe('pointer');
 });
 
-test('should have appropriate dark mode styling', async ({ mcp }) => {
-  const result = await mcp.callTool('show-carousel', {}, { theme: 'dark' });
+test('should have appropriate dark mode styling', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-carousel', undefined, { theme: 'dark' });
   const app = result.app();
 
   const card = app.locator('.rounded-2xl.border').first();
@@ -170,13 +148,13 @@ test('should have appropriate dark mode styling', async ({ mcp }) => {
   expect(styles.borderStyle).toBe('solid');
 });
 
-test('should load without console errors in dark mode', async ({ mcp }) => {
+test('should load without console errors in dark mode', async ({ inspector }) => {
   const errors: string[] = [];
-  mcp.page.on('console', (msg) => {
+  inspector.page.on('console', (msg) => {
     if (msg.type() === 'error') errors.push(msg.text());
   });
 
-  const result = await mcp.callTool('show-carousel', {}, { theme: 'dark' });
+  const result = await inspector.renderTool('show-carousel', undefined, { theme: 'dark' });
   const app = result.app();
   await expect(app.locator('.rounded-2xl').first()).toBeVisible();
 

--- a/packages/sunpeak/template/tests/e2e/map.spec.ts
+++ b/packages/sunpeak/template/tests/e2e/map.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from 'sunpeak/test';
 
-test('should render map container with correct styles', async ({ mcp }) => {
-  const result = await mcp.callTool('show-map');
+test('should render map container with correct styles', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-map');
   const app = result.app();
 
   const mapContainer = app.locator('.antialiased.w-full.overflow-hidden').first();
@@ -13,8 +13,8 @@ test('should render map container with correct styles', async ({ mcp }) => {
   expect(styles.overflow).toBe('hidden');
 });
 
-test('should have rounded border in inline mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-map', {}, { displayMode: 'inline' });
+test('should have rounded border in inline mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-map', undefined, { displayMode: 'inline' });
   const app = result.app();
 
   const innerContainer = app.locator('.border.rounded-2xl').first();
@@ -26,8 +26,8 @@ test('should have rounded border in inline mode', async ({ mcp }) => {
   expect(parseInt(styles.borderRadius)).toBeGreaterThanOrEqual(16);
 });
 
-test('should have fullscreen expand button in inline mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-map', {}, { displayMode: 'inline' });
+test('should have fullscreen expand button in inline mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-map', undefined, { displayMode: 'inline' });
   const app = result.app();
 
   const expandButton = app.locator('button[aria-label="Enter fullscreen"]');
@@ -41,13 +41,13 @@ test('should have fullscreen expand button in inline mode', async ({ mcp }) => {
   expect(styles.position).toBe('absolute');
 });
 
-test('should load without console errors in light mode', async ({ mcp }) => {
+test('should load without console errors in light mode', async ({ inspector }) => {
   const errors: string[] = [];
-  mcp.page.on('console', (msg) => {
+  inspector.page.on('console', (msg) => {
     if (msg.type() === 'error') errors.push(msg.text());
   });
 
-  const result = await mcp.callTool('show-map');
+  const result = await inspector.renderTool('show-map');
   const app = result.app();
   await expect(app.locator('.antialiased.w-full.overflow-hidden').first()).toBeVisible({
     timeout: 10000,
@@ -63,52 +63,25 @@ test('should load without console errors in light mode', async ({ mcp }) => {
   expect(unexpectedErrors).toHaveLength(0);
 });
 
-test('should show empty state with Run button in prod tools mode', async ({ mcp }) => {
-  await mcp.openTool('show-map', { theme: 'dark' });
-
-  await expect(mcp.page.locator('text=Press Run to call the tool')).toBeVisible();
-  await expect(mcp.page.locator('button:has-text("Run")')).toBeVisible();
-  await expect(mcp.page.locator('iframe')).not.toBeAttached();
-});
-
-test('should have themed empty state colors in light mode', async ({ mcp }) => {
-  await mcp.openTool('show-map', { theme: 'light' });
-
-  const emptyState = mcp.page.locator('text=Press Run to call the tool');
-  await expect(emptyState).toBeVisible();
-
-  const color = await emptyState.evaluate((el) => window.getComputedStyle(el).color);
-  const [r, g, b] = color.match(/\d+/g)!.map(Number);
-  expect(r + g + b).toBeLessThan(600);
-});
-
-test('should have themed empty state colors in dark mode', async ({ mcp }) => {
-  await mcp.openTool('show-map', { theme: 'dark' });
-
-  const emptyState = mcp.page.locator('text=Press Run to call the tool');
-  await expect(emptyState).toBeVisible();
-
-  const color = await emptyState.evaluate((el) => window.getComputedStyle(el).color);
-  const [r, g, b] = color.match(/\d+/g)!.map(Number);
-  expect(r + g + b).toBeGreaterThan(200);
-});
-
-test('should activate prod resources mode without errors', async ({ mcp }) => {
-  await mcp.callTool('show-map', {}, { theme: 'dark', prodResources: true });
-  const root = mcp.page.locator('#root');
+test('should activate prod resources mode without errors', async ({ inspector }) => {
+  await inspector.renderTool('show-map', undefined, { theme: 'dark', prodResources: true });
+  const root = inspector.page.locator('#root');
   await expect(root).not.toBeEmpty();
 });
 
-test('should render map in dark mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-map', {}, { theme: 'dark' });
+test('should render map in dark mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-map', undefined, { theme: 'dark' });
   const app = result.app();
   await expect(app.locator('.antialiased.w-full.overflow-hidden').first()).toBeVisible({
     timeout: 10000,
   });
 });
 
-test('should have appropriate border color in dark mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-map', {}, { theme: 'dark', displayMode: 'inline' });
+test('should have appropriate border color in dark mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-map', undefined, {
+    theme: 'dark',
+    displayMode: 'inline',
+  });
   const app = result.app();
 
   const innerContainer = app.locator('.border.rounded-2xl').first();
@@ -120,13 +93,13 @@ test('should have appropriate border color in dark mode', async ({ mcp }) => {
   expect(styles.borderColor).toBeTruthy();
 });
 
-test('should load without console errors in dark mode', async ({ mcp }) => {
+test('should load without console errors in dark mode', async ({ inspector }) => {
   const errors: string[] = [];
-  mcp.page.on('console', (msg) => {
+  inspector.page.on('console', (msg) => {
     if (msg.type() === 'error') errors.push(msg.text());
   });
 
-  const result = await mcp.callTool('show-map', {}, { theme: 'dark' });
+  const result = await inspector.renderTool('show-map', undefined, { theme: 'dark' });
   const app = result.app();
   await expect(app.locator('.antialiased.w-full.overflow-hidden').first()).toBeVisible({
     timeout: 10000,
@@ -142,8 +115,10 @@ test('should load without console errors in dark mode', async ({ mcp }) => {
   expect(unexpectedErrors).toHaveLength(0);
 });
 
-test('should not have rounded border in fullscreen mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-map', {}, { displayMode: 'fullscreen' });
+test('should not have rounded border in fullscreen mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-map', undefined, {
+    displayMode: 'fullscreen',
+  });
   const app = result.app();
 
   const innerContainer = app.locator('.rounded-none.border-0').first();
@@ -155,8 +130,10 @@ test('should not have rounded border in fullscreen mode', async ({ mcp }) => {
   expect(styles.borderRadius).toBe('0px');
 });
 
-test('should not show fullscreen button in fullscreen mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-map', {}, { displayMode: 'fullscreen' });
+test('should not show fullscreen button in fullscreen mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-map', undefined, {
+    displayMode: 'fullscreen',
+  });
   const app = result.app();
 
   await expect(app.locator('.antialiased.w-full.overflow-hidden').first()).toBeVisible({
@@ -165,10 +142,12 @@ test('should not show fullscreen button in fullscreen mode', async ({ mcp }) => 
   await expect(app.locator('button[aria-label="Enter fullscreen"]')).not.toBeVisible();
 });
 
-test('should show suggestion chips in fullscreen on desktop', async ({ mcp }) => {
-  await mcp.page.setViewportSize({ width: 1024, height: 768 });
+test('should show suggestion chips in fullscreen on desktop', async ({ inspector }) => {
+  await inspector.page.setViewportSize({ width: 1024, height: 768 });
 
-  const result = await mcp.callTool('show-map', {}, { displayMode: 'fullscreen' });
+  const result = await inspector.renderTool('show-map', undefined, {
+    displayMode: 'fullscreen',
+  });
   const app = result.app();
 
   await expect(app.locator('.antialiased.w-full.overflow-hidden').first()).toBeVisible({

--- a/packages/sunpeak/template/tests/e2e/review.spec.ts
+++ b/packages/sunpeak/template/tests/e2e/review.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from 'sunpeak/test';
 
-test('should render review title with correct styles', async ({ mcp }) => {
-  const result = await mcp.callTool('review-diff');
+test('should render review title with correct styles', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-diff');
   const app = result.app();
 
   const title = app.locator('h1:has-text("Refactor Authentication Module")');
@@ -13,8 +13,8 @@ test('should render review title with correct styles', async ({ mcp }) => {
   expect(parseInt(styles.fontWeight)).toBeGreaterThanOrEqual(600);
 });
 
-test('should render change items with type-specific styling', async ({ mcp }) => {
-  const result = await mcp.callTool('review-diff');
+test('should render change items with type-specific styling', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-diff');
   const app = result.app();
 
   const changeItem = app.locator('li').first();
@@ -27,8 +27,8 @@ test('should render change items with type-specific styling', async ({ mcp }) =>
   expect(styles.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
 });
 
-test('should have interactive apply and cancel buttons', async ({ mcp }) => {
-  const result = await mcp.callTool('review-diff');
+test('should have interactive apply and cancel buttons', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-diff');
   const app = result.app();
 
   const applyButton = app.locator('button:has-text("Apply Changes")');
@@ -40,8 +40,8 @@ test('should have interactive apply and cancel buttons', async ({ mcp }) => {
   expect(await cancelButton.evaluate((el) => window.getComputedStyle(el).cursor)).toBe('pointer');
 });
 
-test('should have expand fullscreen button in inline mode', async ({ mcp }) => {
-  const result = await mcp.callTool('review-diff', {}, { displayMode: 'inline' });
+test('should have expand fullscreen button in inline mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-diff', undefined, { displayMode: 'inline' });
   const app = result.app();
 
   const expandButton = app.locator('button[aria-label="Enter fullscreen"]');
@@ -49,50 +49,20 @@ test('should have expand fullscreen button in inline mode', async ({ mcp }) => {
   expect(await expandButton.evaluate((el) => window.getComputedStyle(el).cursor)).toBe('pointer');
 });
 
-test('should show empty state with Run button in prod tools mode', async ({ mcp }) => {
-  await mcp.openTool('review-diff', { theme: 'dark' });
-
-  await expect(mcp.page.locator('text=Press Run to call the tool')).toBeVisible();
-  await expect(mcp.page.locator('button:has-text("Run")')).toBeVisible();
-  await expect(mcp.page.locator('iframe')).not.toBeAttached();
-});
-
-test('should have themed empty state colors in light mode', async ({ mcp }) => {
-  await mcp.openTool('review-diff', { theme: 'light' });
-
-  const emptyState = mcp.page.locator('text=Press Run to call the tool');
-  await expect(emptyState).toBeVisible();
-
-  const color = await emptyState.evaluate((el) => window.getComputedStyle(el).color);
-  const [r, g, b] = color.match(/\d+/g)!.map(Number);
-  expect(r + g + b).toBeLessThan(600);
-});
-
-test('should have themed empty state colors in dark mode', async ({ mcp }) => {
-  await mcp.openTool('review-diff', { theme: 'dark' });
-
-  const emptyState = mcp.page.locator('text=Press Run to call the tool');
-  await expect(emptyState).toBeVisible();
-
-  const color = await emptyState.evaluate((el) => window.getComputedStyle(el).color);
-  const [r, g, b] = color.match(/\d+/g)!.map(Number);
-  expect(r + g + b).toBeGreaterThan(200);
-});
-
-test('should activate prod resources mode without errors', async ({ mcp }) => {
-  await mcp.callTool('review-diff', {}, { theme: 'dark', prodResources: true });
-  const root = mcp.page.locator('#root');
+test('should activate prod resources mode without errors', async ({ inspector }) => {
+  await inspector.renderTool('review-diff', undefined, { theme: 'dark', prodResources: true });
+  const root = inspector.page.locator('#root');
   await expect(root).not.toBeEmpty();
 });
 
-test('should render review title in dark mode', async ({ mcp }) => {
-  const result = await mcp.callTool('review-diff', {}, { theme: 'dark' });
+test('should render review title in dark mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-diff', undefined, { theme: 'dark' });
   const app = result.app();
   await expect(app.locator('h1:has-text("Refactor Authentication Module")')).toBeVisible();
 });
 
-test('should have appropriate text colors in dark mode', async ({ mcp }) => {
-  const result = await mcp.callTool('review-diff', {}, { theme: 'dark' });
+test('should have appropriate text colors in dark mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-diff', undefined, { theme: 'dark' });
   const app = result.app();
 
   const title = app.locator('h1').first();
@@ -104,19 +74,19 @@ test('should have appropriate text colors in dark mode', async ({ mcp }) => {
   expect(styles.color).toBeTruthy();
 });
 
-test('should render change items in dark mode', async ({ mcp }) => {
-  const result = await mcp.callTool('review-diff', {}, { theme: 'dark' });
+test('should render change items in dark mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-diff', undefined, { theme: 'dark' });
   const app = result.app();
   await expect(app.locator('li').first()).toBeVisible();
 });
 
-test('should load without console errors in dark mode', async ({ mcp }) => {
+test('should load without console errors in dark mode', async ({ inspector }) => {
   const errors: string[] = [];
-  mcp.page.on('console', (msg) => {
+  inspector.page.on('console', (msg) => {
     if (msg.type() === 'error') errors.push(msg.text());
   });
 
-  const result = await mcp.callTool('review-diff', {}, { theme: 'dark' });
+  const result = await inspector.renderTool('review-diff', undefined, { theme: 'dark' });
   const app = result.app();
   await expect(app.locator('h1').first()).toBeVisible();
 
@@ -130,40 +100,41 @@ test('should load without console errors in dark mode', async ({ mcp }) => {
   expect(unexpectedErrors).toHaveLength(0);
 });
 
-test('should not show fullscreen button in fullscreen mode', async ({ mcp }) => {
-  const result = await mcp.callTool('review-diff', {}, { displayMode: 'fullscreen' });
+test('should not show fullscreen button in fullscreen mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-diff', undefined, {
+    displayMode: 'fullscreen',
+  });
   const app = result.app();
 
   await expect(app.locator('h1').first()).toBeVisible();
   await expect(app.locator('button[aria-label="Enter fullscreen"]')).not.toBeVisible();
 });
 
-test('should render content in fullscreen mode', async ({ mcp }) => {
-  const result = await mcp.callTool(
-    'review-diff',
-    {},
-    { theme: 'dark', displayMode: 'fullscreen' }
-  );
+test('should render content in fullscreen mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-diff', undefined, {
+    theme: 'dark',
+    displayMode: 'fullscreen',
+  });
   const app = result.app();
 
-  await expect(mcp.page.locator('#root')).not.toBeEmpty();
+  await expect(inspector.page.locator('#root')).not.toBeEmpty();
   await expect(app.locator('h1')).toBeVisible();
 });
 
-test('should render post review in light mode', async ({ mcp }) => {
-  await mcp.callTool('review-post');
-  await mcp.page.waitForLoadState('networkidle');
-  await expect(mcp.page.locator('#root')).not.toBeEmpty();
+test('should render post review in light mode', async ({ inspector }) => {
+  await inspector.renderTool('review-post');
+  await inspector.page.waitForLoadState('networkidle');
+  await expect(inspector.page.locator('#root')).not.toBeEmpty();
 });
 
-test('should render post review in dark mode', async ({ mcp }) => {
-  await mcp.callTool('review-post', {}, { theme: 'dark' });
-  await mcp.page.waitForLoadState('networkidle');
-  await expect(mcp.page.locator('#root')).not.toBeEmpty();
+test('should render post review in dark mode', async ({ inspector }) => {
+  await inspector.renderTool('review-post', undefined, { theme: 'dark' });
+  await inspector.page.waitForLoadState('networkidle');
+  await expect(inspector.page.locator('#root')).not.toBeEmpty();
 });
 
-test('should show server success message when confirming post', async ({ mcp }) => {
-  const result = await mcp.callTool('review-post', {}, { theme: 'dark' });
+test('should show server success message when confirming post', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-post', undefined, { theme: 'dark' });
   const app = result.app();
 
   const publishButton = app.locator('button:has-text("Publish")');
@@ -174,8 +145,8 @@ test('should show server success message when confirming post', async ({ mcp }) 
   await expect(app.locator('text=Publishing post...')).toBeVisible({ timeout: 10000 });
 });
 
-test('should show server cancel message when rejecting post', async ({ mcp }) => {
-  const result = await mcp.callTool('review-post', {}, { theme: 'dark' });
+test('should show server cancel message when rejecting post', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-post', undefined, { theme: 'dark' });
   const app = result.app();
 
   const cancelButton = app.locator('button:has-text("Cancel")');
@@ -185,20 +156,20 @@ test('should show server cancel message when rejecting post', async ({ mcp }) =>
   await expect(app.locator('text=Cancelled.')).toBeVisible({ timeout: 10000 });
 });
 
-test('should render purchase review in light mode', async ({ mcp }) => {
-  await mcp.callTool('review-purchase');
-  await mcp.page.waitForLoadState('networkidle');
-  await expect(mcp.page.locator('#root')).not.toBeEmpty();
+test('should render purchase review in light mode', async ({ inspector }) => {
+  await inspector.renderTool('review-purchase');
+  await inspector.page.waitForLoadState('networkidle');
+  await expect(inspector.page.locator('#root')).not.toBeEmpty();
 });
 
-test('should render purchase review in dark mode', async ({ mcp }) => {
-  await mcp.callTool('review-purchase', {}, { theme: 'dark' });
-  await mcp.page.waitForLoadState('networkidle');
-  await expect(mcp.page.locator('#root')).not.toBeEmpty();
+test('should render purchase review in dark mode', async ({ inspector }) => {
+  await inspector.renderTool('review-purchase', undefined, { theme: 'dark' });
+  await inspector.page.waitForLoadState('networkidle');
+  await expect(inspector.page.locator('#root')).not.toBeEmpty();
 });
 
-test('should show loading then result when placing order', async ({ mcp }) => {
-  const result = await mcp.callTool('review-purchase');
+test('should show loading then result when placing order', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-purchase');
   const app = result.app();
 
   const placeOrderButton = app.locator('button:has-text("Place Order")');
@@ -209,8 +180,8 @@ test('should show loading then result when placing order', async ({ mcp }) => {
   await expect(app.locator('text=Completed.')).toBeVisible({ timeout: 10000 });
 });
 
-test('should confirm review-diff and show server success', async ({ mcp }) => {
-  const result = await mcp.callTool('review-diff', {}, { theme: 'dark' });
+test('should confirm review-diff and show server success', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-diff', undefined, { theme: 'dark' });
   const app = result.app();
 
   const applyButton = app.locator('button:has-text("Apply Changes")');
@@ -221,8 +192,8 @@ test('should confirm review-diff and show server success', async ({ mcp }) => {
   await expect(app.locator('text=Completed.')).toBeVisible({ timeout: 10000 });
 });
 
-test('should cancel review-diff and show server cancelled', async ({ mcp }) => {
-  const result = await mcp.callTool('review-diff', {}, { theme: 'dark' });
+test('should cancel review-diff and show server cancelled', async ({ inspector }) => {
+  const result = await inspector.renderTool('review-diff', undefined, { theme: 'dark' });
   const app = result.app();
 
   const cancelButton = app.locator('button:has-text("Cancel")');

--- a/packages/sunpeak/template/tests/e2e/visual.spec.ts
+++ b/packages/sunpeak/template/tests/e2e/visual.spec.ts
@@ -3,34 +3,36 @@ import { test, expect } from 'sunpeak/test';
 // Visual regression tests. Screenshot comparisons only run with `sunpeak test --visual`.
 // Update baselines with `sunpeak test --visual --update`.
 
-test('albums renders correctly in light mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { theme: 'light' });
+test('albums renders correctly in light mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', undefined, { theme: 'light' });
   const app = result.app();
   await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
 
-  await mcp.screenshot('albums-light');
+  await result.screenshot('albums-light');
 });
 
-test('albums renders correctly in dark mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { theme: 'dark' });
+test('albums renders correctly in dark mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', undefined, { theme: 'dark' });
   const app = result.app();
   await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
 
-  await mcp.screenshot('albums-dark');
+  await result.screenshot('albums-dark');
 });
 
-test('albums renders correctly in fullscreen', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { displayMode: 'fullscreen' });
+test('albums renders correctly in fullscreen', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', undefined, {
+    displayMode: 'fullscreen',
+  });
   const app = result.app();
   await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
 
-  await mcp.screenshot('albums-fullscreen');
+  await result.screenshot('albums-fullscreen');
 });
 
-test('full page renders correctly', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { theme: 'light' });
+test('full page renders correctly', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', undefined, { theme: 'light' });
   const app = result.app();
   await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
 
-  await mcp.screenshot('albums-page-light', { target: 'page', maxDiffPixelRatio: 0.02 });
+  await result.screenshot('albums-page-light', { target: 'page', maxDiffPixelRatio: 0.02 });
 });

--- a/skills/test-mcp-server/SKILL.md
+++ b/skills/test-mcp-server/SKILL.md
@@ -48,32 +48,32 @@ sunpeak test --eval          # Run evals against multiple LLM models (requires A
 
 Flags are additive: `--unit --e2e --live --eval` runs all four. `--update` implies `--visual`. `--eval` and `--live` are never included in the default run (they cost money).
 
-## E2E Tests with the `mcp` Fixture
+## E2E Tests with the `mcp` and `inspector` Fixtures
 
-Import `test` and `expect` from `sunpeak/test`. The `mcp` fixture handles inspector navigation, double-iframe traversal, URL construction, and host selection. Tests run automatically across ChatGPT and Claude hosts via Playwright projects.
+Import `test` and `expect` from `sunpeak/test`. The `mcp` fixture provides protocol-level methods, and the `inspector` fixture handles rendering, double-iframe traversal, URL construction, and host selection. Tests run automatically across ChatGPT and Claude hosts via Playwright projects.
 
 ```typescript
 import { test, expect } from 'sunpeak/test';
 
-test('renders weather card', async ({ mcp }) => {
-  const result = await mcp.callTool('show-weather');
+test('renders weather card', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-weather');
   const app = result.app();
   await expect(app.locator('h1')).toHaveText('Austin');
 });
 
-test('renders in dark mode', async ({ mcp }) => {
-  const result = await mcp.callTool('show-weather', {}, { theme: 'dark' });
+test('renders in dark mode', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-weather', {}, { theme: 'dark' });
   const app = result.app();
   await expect(app.locator('h1')).toBeVisible();
 });
 
-test('loads without console errors', async ({ mcp }) => {
+test('loads without console errors', async ({ inspector }) => {
   const errors: string[] = [];
-  mcp.page.on('console', (msg) => {
+  inspector.page.on('console', (msg) => {
     if (msg.type() === 'error') errors.push(msg.text());
   });
 
-  const result = await mcp.callTool('show-weather', {}, { theme: 'dark' });
+  const result = await inspector.renderTool('show-weather', {}, { theme: 'dark' });
   const app = result.app();
   await expect(app.locator('h1')).toBeVisible();
 
@@ -87,33 +87,38 @@ test('loads without console errors', async ({ mcp }) => {
   expect(unexpectedErrors).toHaveLength(0);
 });
 
-test('prod tools empty state', async ({ mcp }) => {
-  await mcp.openTool('show-weather');
-  await expect(mcp.page.locator('text=Press Run to call the tool')).toBeVisible();
-});
-
-test('pip mode (skip on Claude)', async ({ mcp }) => {
-  test.skip(mcp.host === 'claude', 'Claude does not support PiP');
-  const result = await mcp.callTool('show-weather');
-  await mcp.setDisplayMode('pip');
+test('pip mode (skip on Claude)', async ({ inspector }) => {
+  test.skip(inspector.host === 'claude', 'Claude does not support PiP');
+  const result = await inspector.renderTool('show-weather', {}, { displayMode: 'pip' });
   await expect(result.app().locator('h1')).toBeVisible({ timeout: 5000 });
 });
 ```
 
 ### `mcp` Fixture API
 
+Protocol-level methods (raw MCP data, no rendering):
+
 | Method | Description |
 |--------|-------------|
-| `callTool(name, input?, options?)` | Navigate to simulation, wait for render, return `ToolResult` |
-| `openTool(name, options?)` | Navigate to tool with no mock data ("Press Run" state) |
-| `runTool()` | Click Run button, wait for resource, return `ToolResult` |
-| `setTheme(theme)` | Switch to `'light'` or `'dark'` via sidebar |
-| `setDisplayMode(mode)` | Switch to `'inline'`, `'pip'`, or `'fullscreen'` via sidebar |
-| `screenshot(name?, options?)` | Take a screenshot and compare against a baseline (only runs with `--visual`) |
+| `listTools()` | List all tools from the server. Returns `Tool[]`. |
+| `callTool(name, input?)` | Call a tool, return the raw MCP result. No rendering. |
+| `listResources()` | List all resources from the server. Returns `Resource[]`. |
+| `readResource(uri)` | Read a resource by URI. Returns the content string. |
+
+### `inspector` Fixture API
+
+Rendering methods and properties:
+
+| Method | Description |
+|--------|-------------|
+| `renderTool(name, input?, options?)` | Render a tool result in the inspector, return `InspectorResult` |
+
+| Property | Description |
+|----------|-------------|
 | `page` | Raw Playwright `Page` for chrome-level assertions |
 | `host` | Current host ID (`'chatgpt'` or `'claude'`) from Playwright project |
 
-### `ToolResult` API
+### `InspectorResult` API
 
 | Property/Method | Description |
 |--------|-------------|
@@ -121,6 +126,8 @@ test('pip mode (skip on Claude)', async ({ mcp }) => {
 | `content` | Raw MCP content items |
 | `structuredContent` | Structured content from tool response |
 | `isError` | Whether the tool returned an error |
+| `source` | Where the data came from: `'fixture'` or `'server'` |
+| `screenshot(name?, options?)` | Take a screenshot and compare against a baseline (only runs with `--visual`) |
 
 ### MCP-Native Matchers
 
@@ -131,27 +138,51 @@ test('pip mode (skip on Claude)', async ({ mcp }) => {
 | `expect(result).toHaveStructuredContent(shape)` | Assert structuredContent matches shape |
 | `expect(result).toHaveContentType(type)` | Assert content includes item of given type |
 
-### `callTool` Options
+### `renderTool`
+
+`inspector.renderTool` renders the tool result in the inspector and returns an `InspectorResult`. With `input`, the tool is called on the real server with those arguments. Without `input`, simulation fixture data is used when available, or the real server is called with empty args.
+
+```typescript
+// Calls the real server with arguments and renders
+const result = await inspector.renderTool('search', { query: 'headphones' });
+
+// Uses simulation fixture data, or calls server with empty args
+const result = await inspector.renderTool('show-albums');
+```
 
 | Option | Type | Description |
 |--------|------|-------------|
 | `theme` | `'light' \| 'dark'` | Color theme (default: inspector default) |
 | `displayMode` | `'inline' \| 'pip' \| 'fullscreen'` | Display mode |
+| `timeout` | `number` | Iframe render timeout in ms (default: 15s, or `mcpTimeout` from config) |
 | `prodResources` | `boolean` | Use production-built resource bundles |
+
+### Configuring Timeouts
+
+Set default timeouts in Playwright config for servers that need more time:
+```typescript
+export default defineConfig({
+  server: { command: 'python', args: ['server.py'] },
+  timeout: 120_000,  // Server startup timeout (default: 60s)
+  use: {
+    mcpTimeout: 30_000,    // renderTool iframe timeout (default: 15s)
+  },
+});
+```
 
 ### Visual Regression Testing
 
-Use `mcp.screenshot()` to capture and compare screenshots against saved baselines. Comparisons only run with `sunpeak test --visual`. Without it, `screenshot()` silently skips, so you can include it in regular e2e tests.
+Use `result.screenshot()` to capture and compare screenshots against saved baselines. Comparisons only run with `sunpeak test --visual`. Without it, `screenshot()` silently skips, so you can include it in regular e2e tests.
 
 ```typescript
 import { test, expect } from 'sunpeak/test';
 
-test('albums renders correctly', async ({ mcp }) => {
-  const result = await mcp.callTool('show-albums', {}, { theme: 'light' });
+test('albums renders correctly', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums', {}, { theme: 'light' });
   const app = result.app();
   await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
 
-  await mcp.screenshot('albums-light');
+  await result.screenshot('albums-light');
 });
 ```
 
@@ -197,24 +228,27 @@ export default defineConfig({
   },
 });
 
-// Or with a command:
+// Or with a command (stdio server):
 export default defineConfig({
   server: {
     command: 'python',
     args: ['server.py'],
+    env: { API_KEY: 'test-key' },  // Extra environment variables
+    cwd: './backend',               // Working directory
   },
+  timeout: 120_000,  // Server startup timeout in ms (default: 60s)
 });
 ```
 
 ### Locator Rules
 
 Resource content renders inside a double-iframe (outer sandbox proxy + inner app iframe). In e2e tests:
-- Use `result.app().locator(...)` (from `mcp.callTool()`) for resource content. This handles the double-iframe sandbox architecture.
-- Use `mcp.page.locator(...)` only for inspector chrome elements (header, `#root`, sidebar controls).
+- Use `result.app().locator(...)` (from `inspector.renderTool()`) for resource content. This handles the double-iframe sandbox architecture.
+- Use `inspector.page.locator(...)` only for inspector chrome elements (header, `#root`, sidebar controls).
 
 ## Simulations
 
-E2e tests consume simulation fixtures defined in `tests/simulations/*.json`. For sunpeak projects, simulations are part of the app project structure (see the `create-sunpeak-app` skill for the simulation file format). For non-sunpeak servers, `callTool` connects to the live server via the configured `server` option.
+E2e tests consume simulation fixtures defined in `tests/simulations/*.json`. For sunpeak projects, simulations are part of the app project structure (see the `create-sunpeak-app` skill for the simulation file format). For non-sunpeak servers, `renderTool` connects to the live server via the configured `server` option.
 
 ## Live Testing (against real ChatGPT)
 
@@ -355,7 +389,7 @@ Not included in the default `sunpeak test` run (costs money, like `--live`).
 
 ## Common Mistakes
 
-1. **Wrong Playwright locator** -- Use `result.app().locator(...)` (from `mcp.callTool()`) for resource content. This handles the double-iframe sandbox architecture. Use `mcp.page.locator(...)` only for inspector chrome elements.
+1. **Wrong Playwright locator** -- Use `result.app().locator(...)` (from `inspector.renderTool()`) for resource content. This handles the double-iframe sandbox architecture. Use `inspector.page.locator(...)` only for inspector chrome elements.
 2. **Simulation tool mismatch** -- The `"tool"` field in simulation JSON must match a tool filename in `src/tools/` (e.g. `"tool": "show-weather"` matches `src/tools/show-weather.ts`).
 3. **Missing console error filter** -- When testing for console errors, always filter out expected MCP handshake errors (`[IframeResource]`, `mcp`, `PostMessage`, `connect`).
 
@@ -363,7 +397,7 @@ Not included in the default `sunpeak test` run (costs money, like `--live`).
 
 | Import | Contents |
 |--------|----------|
-| `sunpeak/test` | MCP-first Playwright fixtures (`test` with `mcp` fixture, `expect` with MCP-native matchers) |
+| `sunpeak/test` | MCP-first Playwright fixtures (`test` with `mcp` fixture for protocol methods and `inspector` fixture for rendering, `expect` with MCP-native matchers) |
 | `sunpeak/test/config` | Playwright config factory (`defineConfig` for e2e tests) |
 | `sunpeak/test/live` | Host-agnostic Playwright fixtures for live testing (`test` with `live` fixture, `expect`, `setColorScheme`) |
 | `sunpeak/test/live/config` | Live test config factory (`defineLiveConfig` with `hosts` array) |
@@ -371,6 +405,37 @@ Not included in the default `sunpeak test` run (costs money, like `--live`).
 | `sunpeak/test/live/chatgpt/config` | ChatGPT-specific Playwright config factory |
 | `sunpeak/test/inspect/config` | Inspect config factory for external MCP servers (`defineInspectConfig`) |
 | `sunpeak/eval` | Eval framework (`defineEval`, `defineEvalConfig`) for multi-model tool calling evals |
+
+## Migrating from older versions
+
+When upgrading sunpeak, check for deprecated API patterns in test files and update them. This section lists breaking changes by version.
+
+### 0.20.0: Fixture split (`mcp` + `inspector`)
+
+The single `mcp` fixture was split into two: `mcp` (MCP protocol) and `inspector` (rendering).
+
+| Old | New |
+|-----|-----|
+| `{ mcp }` (for rendering tests) | `{ inspector }` |
+| `mcp.callTool('name', {}, { theme })` | `inspector.renderTool('name', undefined, { theme })` |
+| `mcp.callTool('name')` with `result.app()` | `inspector.renderTool('name')` |
+| `mcp.screenshot('name')` | `result.screenshot('name')` (on the result object) |
+| `mcp.host` | `inspector.host` |
+| `mcp.page` | `inspector.page` |
+| `mcp.openTool(...)` | Removed. Use `inspector.renderTool` instead. |
+| `mcp.runTool(...)` | Removed. Use `inspector.renderTool` with input. |
+| `mcp.setTheme(...)` | Removed. Pass `{ theme }` to `inspector.renderTool`. |
+| `mcp.setDisplayMode(...)` | Removed. Pass `{ displayMode }` to `inspector.renderTool`. |
+| `ToolResult` type | `InspectorResult` type |
+
+How to identify tests that need migration:
+- `{ mcp }` destructuring where the test uses `result.app()`, `.screenshot()`, `theme`, `displayMode`, or `prodResources` → change to `{ inspector }` and use `inspector.renderTool`
+- `{ mcp }` destructuring where the test only uses `callTool` without `.app()` or rendering options → keep as `{ mcp }`, this is the protocol-level API (no change needed)
+- Tests using `mcp.callTool('name', {}, { theme: 'dark' })` → the empty `{}` second arg was ignored before; now change to `inspector.renderTool('name', undefined, { theme: 'dark' })`
+
+New protocol methods added to `mcp`: `listTools()`, `listResources()`, `readResource(uri)`.
+
+New `InspectorResult` fields: `source` (`'fixture'` | `'server'`), `screenshot()` method.
 
 ## References
 


### PR DESCRIPTION
## Summary

- **Breaking API change**: Split the `mcp` test fixture into two fixtures: `mcp` for protocol-level operations (`callTool`, `listTools`, `listResources`, `readResource`) and `inspector` for UI rendering (`renderTool` with `result.app()` and `result.screenshot()`). Removed `openTool`, `runTool`, `setTheme`, `setDisplayMode`.
- **OAuth auto-negotiation**: `sunpeak inspect` now connects to MCP servers that require OAuth authentication. Handles anonymous/auto-approved flows without user interaction, and interactive flows by opening the browser. Follows the MCP OAuth specification (RFC 9728, RFC 7591, PKCE).
- **Stdio server improvements**: Stderr capture and display on connection failure, `--env`/`--cwd` CLI flags, configurable startup timeout, local binary resolution for non-global installs.
- **Framework embedding**: New `sunpeak/inspect` export with `inspectServer()` for programmatic use. Version-pinned scaffolding. Root-level test discovery for non-JS projects.
- **Housekeeping**: Silenced MCP bridge debug logs during Vitest runs. Updated all docs, template specs, examples, and skills to use the new API.

## Test plan

- [x] 361 unit tests pass (`pnpm --filter sunpeak test -- --run`)
- [x] Lint and typecheck clean
- [x] Build succeeds
- [x] Verified OAuth against a real Reboot MCP server (anonymous OAuth, 10/10 e2e tests pass)
- [x] Marketing site builds with updated code snippets (103 tests pass)