### PR TITLE
Restructure docs around three layers with per-layer quickstarts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,16 +208,11 @@ Template e2e tests use the `mcp` and `inspector` fixtures from `sunpeak/test`, w
 
 ### sunpeak Is Three Things
 
-Each layer builds on the previous and works independently. The inspector and testing framework work with any MCP server in any language and can be embedded within other frameworks.
+Each layer works independently. The inspector and testing framework work with any MCP server in any language and can be embedded within other frameworks.
 
-#### 1. Inspector
+#### 1. App Framework
 
-Test any MCP server in replicated ChatGPT and Claude runtimes. No sunpeak project required.
-
-- **CLI**: `sunpeak inspect --server <url>` or `sunpeak inspect --server "python server.py"`. Supports `--env KEY=VALUE` (repeatable) and `--cwd <path>` for stdio servers.
-- **Programmatic**: `inspectServer()` from `sunpeak/inspect` lets other frameworks start the inspector from their own CLI.
-- **OAuth**: Auto-negotiates MCP OAuth when servers return 401. Handles anonymous/auto-approved OAuth without user interaction. For interactive OAuth, opens the authorization URL in the user's browser and waits for the callback. Uses the MCP SDK's standard `OAuthClientProvider` interface.
-- Built into `sunpeak dev` for app framework users.
+Convention-over-configuration for building MCP Apps. The inspector and testing are built in. `defineConfig()` auto-detects sunpeak projects and starts `sunpeak dev` as the backend. Template tests use the testing framework's fixtures and configs. For evals, the dev server auto-starts with `--prod-tools`.
 
 #### 2. Testing Framework
 
@@ -244,9 +239,14 @@ Automated testing powered by the inspector. Works with any MCP server in any lan
 
 **CLI**: `sunpeak test` runs unit + e2e tests, `sunpeak test --unit` runs only vitest, `sunpeak test --e2e` runs only Playwright e2e tests, `sunpeak test --visual` runs e2e with visual regression comparison, `sunpeak test --visual --update` updates visual baselines, `sunpeak test --live` runs live tests against real hosts, `sunpeak test --eval` runs multi-model evals, `sunpeak test init` scaffolds test infrastructure (including eval boilerplate). Flags are additive: `--unit --e2e --live --eval` runs all four. `--update` implies `--visual`. `--eval` and `--live` are never included in the default run (they cost money).
 
-#### 3. App Framework
+#### 3. Inspector
 
-Convention-over-configuration for building MCP Apps. The inspector and testing are built in. `defineConfig()` auto-detects sunpeak projects and starts `sunpeak dev` as the backend. Template tests use the testing framework's fixtures and configs. For evals, the dev server auto-starts with `--prod-tools`.
+Test any MCP server in replicated ChatGPT and Claude runtimes. No sunpeak project required.
+
+- **CLI**: `sunpeak inspect --server <url>` or `sunpeak inspect --server "python server.py"`. Supports `--env KEY=VALUE` (repeatable) and `--cwd <path>` for stdio servers.
+- **Programmatic**: `inspectServer()` from `sunpeak/inspect` lets other frameworks start the inspector from their own CLI.
+- **OAuth**: Auto-negotiates MCP OAuth when servers return 401. Handles anonymous/auto-approved OAuth without user interaction. For interactive OAuth, opens the authorization URL in the user's browser and waits for the callback. Uses the MCP SDK's standard `OAuthClientProvider` interface.
+- Built into `sunpeak dev` for app framework users.
 
 ## Documentation (`docs/`)
 

--- a/docs/app-framework/cli/new.mdx
+++ b/docs/app-framework/cli/new.mdx
@@ -9,49 +9,27 @@ keywords: ["MCP Apps", "ChatGPT Apps", "MCP app framework", "create project", "s
 The `sunpeak new` command creates a new sunpeak project with a minimal, convention-based structure for building MCP Apps.
 
 ```bash
-sunpeak new
+npx sunpeak new
 ```
-
-<Tip>
-Install sunpeak globally first:
-
-<Tabs>
-  <Tab title="pnpm">
-    ```bash
-    pnpm add -g sunpeak
-    ```
-  </Tab>
-  <Tab title="npm">
-    ```bash
-    npm install -g sunpeak
-    ```
-  </Tab>
-  <Tab title="yarn">
-    ```bash
-    yarn global add sunpeak
-    ```
-  </Tab>
-</Tabs>
-</Tip>
 
 ## Usage
 
 Create a new project interactively:
 
 ```bash
-sunpeak new
+npx sunpeak new
 ```
 
 Or specify a project name:
 
 ```bash
-sunpeak new sunpeak-app
+npx sunpeak new my-app
 ```
 
 Or specify both project name and resources to include:
 
 ```bash
-sunpeak new sunpeak-app review,carousel
+npx sunpeak new my-app review,carousel
 ```
 
 ## Arguments
@@ -92,7 +70,7 @@ sunpeak-app/
 After creating your project:
 
 1. Navigate to your project: `cd sunpeak-app`
-2. Start the dev server: `sunpeak dev`
+2. Start the dev server: `pnpm dev`
 3. Open `http://localhost:3000` to see the inspector
 
 <Card horizontal title="Project Scaffold" icon="folder-tree" href="/app-framework/project-scaffold">

--- a/docs/app-framework/cli/new.mdx
+++ b/docs/app-framework/cli/new.mdx
@@ -23,13 +23,13 @@ npx sunpeak new
 Or specify a project name:
 
 ```bash
-npx sunpeak new my-app
+npx sunpeak new sunpeak-app
 ```
 
 Or specify both project name and resources to include:
 
 ```bash
-npx sunpeak new my-app review,carousel
+npx sunpeak new sunpeak-app review,carousel
 ```
 
 ## Arguments

--- a/docs/app-framework/guides/deployment.mdx
+++ b/docs/app-framework/guides/deployment.mdx
@@ -9,7 +9,7 @@ keywords: ["MCP Apps", "ChatGPT Apps", "Claude Apps", "deployment", "production"
 Build your app for production using the sunpeak CLI:
 
 ```bash
-sunpeak build
+pnpm build
 ```
 
 This generates a `dist/` directory with built resources and compiled tools:
@@ -31,18 +31,18 @@ Each `.html` file is a complete, self-contained app bundle — no external scrip
 ## Start the Production Server
 
 ```bash
-sunpeak start
+pnpm start
 ```
 
 This loads your compiled tool handlers, Zod schemas, and optional auth from `dist/`, registers them with the [MCP protocol](/mcp-apps/mcp/overview), and starts a [Streamable HTTP](/mcp-apps/mcp/overview#transports) server on port 8000.
 
 ```bash
-sunpeak start --port 3000          # Custom port
-sunpeak start --host 127.0.0.1     # Bind to localhost only
-sunpeak start --json-logs           # Structured JSON logging
-sunpeak start --sse                 # Use SSE streaming instead of JSON responses
-sunpeak start --stateless           # Stateless mode (no session tracking)
-PORT=3000 HOST=127.0.0.1 sunpeak start  # Or via environment variables
+pnpm start -- --port 3000          # Custom port
+pnpm start -- --host 127.0.0.1     # Bind to localhost only
+pnpm start -- --json-logs           # Structured JSON logging
+pnpm start -- --sse                 # Use SSE streaming instead of JSON responses
+pnpm start -- --stateless           # Stateless mode (no session tracking)
+PORT=3000 HOST=127.0.0.1 pnpm start  # Or via environment variables
 ```
 
 The production server:
@@ -58,7 +58,7 @@ The production server:
 Use `sunpeak build` and `sunpeak start` to test production behavior locally:
 
 ```bash
-sunpeak build && sunpeak start
+pnpm build && pnpm start
 ```
 
 Then expose the MCP server with a tunnel (e.g., `ngrok http 8000`) and connect from ChatGPT.
@@ -177,7 +177,7 @@ Use this for load balancer probes, Kubernetes liveness/readiness checks, and upt
 Pass `--json-logs` to output structured JSON lines instead of human-readable logs:
 
 ```bash
-sunpeak start --json-logs
+pnpm start -- --json-logs
 ```
 
 Each line is a JSON object with `ts`, `level`, and `msg` fields, plus contextual data:
@@ -194,8 +194,8 @@ This format is compatible with log aggregation tools like Datadog, CloudWatch, L
 By default, the server binds to `0.0.0.0` (all interfaces). To restrict it to localhost only:
 
 ```bash
-sunpeak start --host 127.0.0.1
-HOST=127.0.0.1 sunpeak start
+pnpm start -- --host 127.0.0.1
+HOST=127.0.0.1 pnpm start
 ```
 
 ### Process Management
@@ -247,7 +247,7 @@ For multi-instance deployments behind a load balancer, you have two options:
 **Stateless mode (recommended for serverless)** — Disable session tracking entirely. Each request creates a fresh server instance, so any backend can handle any request:
 
 ```bash
-sunpeak start --stateless
+pnpm start -- --stateless
 ```
 
 Or with a custom server:

--- a/docs/app-framework/guides/deployment.mdx
+++ b/docs/app-framework/guides/deployment.mdx
@@ -8,9 +8,23 @@ keywords: ["MCP Apps", "ChatGPT Apps", "Claude Apps", "deployment", "production"
 
 Build your app for production using the sunpeak CLI:
 
-```bash
-pnpm build
-```
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm build
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm run build
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn build
+    ```
+  </Tab>
+</Tabs>
 
 This generates a `dist/` directory with built resources and compiled tools:
 
@@ -30,20 +44,58 @@ Each `.html` file is a complete, self-contained app bundle — no external scrip
 
 ## Start the Production Server
 
-```bash
-pnpm start
-```
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm start
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm run start
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn start
+    ```
+  </Tab>
+</Tabs>
 
 This loads your compiled tool handlers, Zod schemas, and optional auth from `dist/`, registers them with the [MCP protocol](/mcp-apps/mcp/overview), and starts a [Streamable HTTP](/mcp-apps/mcp/overview#transports) server on port 8000.
 
-```bash
-pnpm start -- --port 3000          # Custom port
-pnpm start -- --host 127.0.0.1     # Bind to localhost only
-pnpm start -- --json-logs           # Structured JSON logging
-pnpm start -- --sse                 # Use SSE streaming instead of JSON responses
-pnpm start -- --stateless           # Stateless mode (no session tracking)
-PORT=3000 HOST=127.0.0.1 pnpm start  # Or via environment variables
-```
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm start -- --port 3000          # Custom port
+    pnpm start -- --host 127.0.0.1     # Bind to localhost only
+    pnpm start -- --json-logs           # Structured JSON logging
+    pnpm start -- --sse                 # Use SSE streaming instead of JSON responses
+    pnpm start -- --stateless           # Stateless mode (no session tracking)
+    PORT=3000 HOST=127.0.0.1 pnpm start  # Or via environment variables
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm run start -- --port 3000          # Custom port
+    npm run start -- --host 127.0.0.1     # Bind to localhost only
+    npm run start -- --json-logs           # Structured JSON logging
+    npm run start -- --sse                 # Use SSE streaming instead of JSON responses
+    npm run start -- --stateless           # Stateless mode (no session tracking)
+    PORT=3000 HOST=127.0.0.1 npm run start  # Or via environment variables
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn start --port 3000          # Custom port
+    yarn start --host 127.0.0.1     # Bind to localhost only
+    yarn start --json-logs           # Structured JSON logging
+    yarn start --sse                 # Use SSE streaming instead of JSON responses
+    yarn start --stateless           # Stateless mode (no session tracking)
+    PORT=3000 HOST=127.0.0.1 yarn start  # Or via environment variables
+    ```
+  </Tab>
+</Tabs>
 
 The production server:
 - Registers each tool from `dist/tools/` with its real handler and Zod schema (input validation)
@@ -57,9 +109,23 @@ The production server:
 
 Use `sunpeak build` and `sunpeak start` to test production behavior locally:
 
-```bash
-pnpm build && pnpm start
-```
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm build && pnpm start
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm run build && npm run start
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn build && yarn start
+    ```
+  </Tab>
+</Tabs>
 
 Then expose the MCP server with a tunnel (e.g., `ngrok http 8000`) and connect from ChatGPT.
 
@@ -176,9 +242,23 @@ Use this for load balancer probes, Kubernetes liveness/readiness checks, and upt
 
 Pass `--json-logs` to output structured JSON lines instead of human-readable logs:
 
-```bash
-pnpm start -- --json-logs
-```
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm start -- --json-logs
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm run start -- --json-logs
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn start --json-logs
+    ```
+  </Tab>
+</Tabs>
 
 Each line is a JSON object with `ts`, `level`, and `msg` fields, plus contextual data:
 
@@ -193,10 +273,26 @@ This format is compatible with log aggregation tools like Datadog, CloudWatch, L
 
 By default, the server binds to `0.0.0.0` (all interfaces). To restrict it to localhost only:
 
-```bash
-pnpm start -- --host 127.0.0.1
-HOST=127.0.0.1 pnpm start
-```
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm start -- --host 127.0.0.1
+    HOST=127.0.0.1 pnpm start
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm run start -- --host 127.0.0.1
+    HOST=127.0.0.1 npm run start
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn start --host 127.0.0.1
+    HOST=127.0.0.1 yarn start
+    ```
+  </Tab>
+</Tabs>
 
 ### Process Management
 
@@ -246,9 +342,23 @@ For multi-instance deployments behind a load balancer, you have two options:
 
 **Stateless mode (recommended for serverless)** — Disable session tracking entirely. Each request creates a fresh server instance, so any backend can handle any request:
 
-```bash
-pnpm start -- --stateless
-```
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm start -- --stateless
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm run start -- --stateless
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn start --stateless
+    ```
+  </Tab>
+</Tabs>
 
 Or with a custom server:
 

--- a/docs/app-framework/guides/troubleshooting.mdx
+++ b/docs/app-framework/guides/troubleshooting.mdx
@@ -30,8 +30,8 @@ If the port changed (e.g. `port 8000 was in use`), update your tunnel and host c
 ### 3. Restart the dev server
 
 ```bash
-# Stop sunpeak dev (Ctrl+C), then restart
-sunpeak dev
+# Stop the dev server (Ctrl+C), then restart
+pnpm dev
 ```
 
 This clears any stale connections and re-registers all tools and resources.
@@ -89,10 +89,10 @@ If `--prod-resources` mode fails, the built HTML may be stale or missing:
 
 ```bash
 # Rebuild manually
-sunpeak build
+pnpm build
 
-# Then retry
-sunpeak dev --prod-resources
+# Then retry with prod resources
+pnpm dev -- --prod-resources
 ```
 
 <Note>

--- a/docs/app-framework/guides/troubleshooting.mdx
+++ b/docs/app-framework/guides/troubleshooting.mdx
@@ -29,10 +29,26 @@ If the port changed (e.g. `port 8000 was in use`), update your tunnel and host c
 
 ### 3. Restart the dev server
 
-```bash
-# Stop the dev server (Ctrl+C), then restart
-pnpm dev
-```
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    # Stop the dev server (Ctrl+C), then restart
+    pnpm dev
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    # Stop the dev server (Ctrl+C), then restart
+    npm run dev
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    # Stop the dev server (Ctrl+C), then restart
+    yarn dev
+    ```
+  </Tab>
+</Tabs>
 
 This clears any stale connections and re-registers all tools and resources.
 
@@ -87,13 +103,35 @@ Safari automatically upgrades cross-origin HTTP requests to HTTPS. The dev serve
 
 If `--prod-resources` mode fails, the built HTML may be stale or missing:
 
-```bash
-# Rebuild manually
-pnpm build
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    # Rebuild manually
+    pnpm build
 
-# Then retry with prod resources
-pnpm dev -- --prod-resources
-```
+    # Then retry with prod resources
+    pnpm dev -- --prod-resources
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    # Rebuild manually
+    npm run build
+
+    # Then retry with prod resources
+    npm run dev -- --prod-resources
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    # Rebuild manually
+    yarn build
+
+    # Then retry with prod resources
+    yarn dev --prod-resources
+    ```
+  </Tab>
+</Tabs>
 
 <Note>
 For inspector and test-related troubleshooting (blank inspector page, iframe test errors, live test auth), see [Testing Troubleshooting](/testing/troubleshooting).

--- a/docs/app-framework/lifecycle.mdx
+++ b/docs/app-framework/lifecycle.mdx
@@ -12,37 +12,17 @@ The sunpeak CLI commands support a complete development lifecycle, from project 
 
 ```mermaid
 flowchart LR
-    A[sunpeak new] --> B[sunpeak dev]
-    B --> C[sunpeak build]
-    C --> D[sunpeak start]
+    A[npx sunpeak new] --> B[dev]
+    B --> C[build]
+    C --> D[start]
 ```
 
 ### 1. Create
 
-Install sunpeak globally:
-
-<Tabs>
-  <Tab title="pnpm">
-    ```bash
-    pnpm add -g sunpeak
-    ```
-  </Tab>
-  <Tab title="npm">
-    ```bash
-    npm install -g sunpeak
-    ```
-  </Tab>
-  <Tab title="yarn">
-    ```bash
-    yarn global add sunpeak
-    ```
-  </Tab>
-</Tabs>
-
-Then start a new project:
+Start a new project:
 
 ```bash
-sunpeak new
+npx sunpeak new
 ```
 
 This scaffolds a complete sunpeak project with all the configuration and structure you need.
@@ -51,9 +31,23 @@ This scaffolds a complete sunpeak project with all the configuration and structu
 
 Run the development server with hot reload:
 
-```bash
-sunpeak dev
-```
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm dev
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm run dev
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn dev
+    ```
+  </Tab>
+</Tabs>
 
 This starts:
 - The inspector at `http://localhost:3000` for local development
@@ -66,9 +60,23 @@ Both the inspector and MCP server support Hot Module Reload, letting you iterate
 
 Create production-ready bundles:
 
-```bash
-sunpeak build
-```
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm build
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm run build
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn build
+    ```
+  </Tab>
+</Tabs>
 
 This compiles and optimizes your Resources, Tools, and optional server entry for production.
 
@@ -76,9 +84,23 @@ This compiles and optimizes your Resources, Tools, and optional server entry for
 
 Start the production MCP server:
 
-```bash
-sunpeak start
-```
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm start
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm run start
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn start
+    ```
+  </Tab>
+</Tabs>
 
 This loads your compiled tools (with real handlers and Zod schemas), serves pre-built resource HTML, and runs your `auth()` function if present. See the [Deployment Guide](/app-framework/guides/deployment) for details on publishing to ChatGPT.
 

--- a/docs/app-framework/mcp-server.mdx
+++ b/docs/app-framework/mcp-server.mdx
@@ -31,9 +31,23 @@ For details on how MCP Apps extends the protocol with interactive UIs, see the [
   <Tab title="Development">
     Start the development server:
 
-    ```bash
-    pnpm dev
-    ```
+    <Tabs>
+      <Tab title="pnpm">
+        ```bash
+        pnpm dev
+        ```
+      </Tab>
+      <Tab title="npm">
+        ```bash
+        npm run dev
+        ```
+      </Tab>
+      <Tab title="yarn">
+        ```bash
+        yarn dev
+        ```
+      </Tab>
+    </Tabs>
 
     This starts both the inspector and an MCP server with Hot Module Reload.
     The MCP server runs on port `8000` and serves simulation fixture data.
@@ -41,9 +55,23 @@ For details on how MCP Apps extends the protocol with interactive UIs, see the [
   <Tab title="Production">
     Build and start the production server:
 
-    ```bash
-    pnpm build && pnpm start
-    ```
+    <Tabs>
+      <Tab title="pnpm">
+        ```bash
+        pnpm build && pnpm start
+        ```
+      </Tab>
+      <Tab title="npm">
+        ```bash
+        npm run build && npm run start
+        ```
+      </Tab>
+      <Tab title="yarn">
+        ```bash
+        yarn build && yarn start
+        ```
+      </Tab>
+    </Tabs>
 
     This compiles your tools, resources, and optional auth, then starts a production MCP server with real handlers.
   </Tab>

--- a/docs/app-framework/mcp-server.mdx
+++ b/docs/app-framework/mcp-server.mdx
@@ -32,7 +32,7 @@ For details on how MCP Apps extends the protocol with interactive UIs, see the [
     Start the development server:
 
     ```bash
-    sunpeak dev
+    pnpm dev
     ```
 
     This starts both the inspector and an MCP server with Hot Module Reload.
@@ -42,7 +42,7 @@ For details on how MCP Apps extends the protocol with interactive UIs, see the [
     Build and start the production server:
 
     ```bash
-    sunpeak build && sunpeak start
+    pnpm build && pnpm start
     ```
 
     This compiles your tools, resources, and optional auth, then starts a production MCP server with real handlers.

--- a/docs/app-framework/run-mcp-server.mdx
+++ b/docs/app-framework/run-mcp-server.mdx
@@ -18,9 +18,23 @@ This server is for **local development only**. For production, use `sunpeak star
 
 sunpeak handles MCP server configuration automatically:
 
-```bash
-pnpm dev
-```
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm dev
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm run dev
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn dev
+    ```
+  </Tab>
+</Tabs>
 
 This starts the inspector and an MCP server with Hot Module Reload.
 The MCP server discovers tools from `src/tools/` and simulations from `tests/simulations/`, and serves the apps with automatic rebuilding.

--- a/docs/app-framework/run-mcp-server.mdx
+++ b/docs/app-framework/run-mcp-server.mdx
@@ -19,7 +19,7 @@ This server is for **local development only**. For production, use `sunpeak star
 sunpeak handles MCP server configuration automatically:
 
 ```bash
-sunpeak dev
+pnpm dev
 ```
 
 This starts the inspector and an MCP server with Hot Module Reload.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -110,9 +110,9 @@
           {
             "group": "sunpeak is an",
             "pages": [
-              "mcp-apps-inspector",
+              "mcp-apps-framework",
               "mcp-apps-testing",
-              "mcp-apps-framework"
+              "mcp-apps-inspector"
             ]
           },
           {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -93,7 +93,8 @@
     { "source": "/cli/lifecycle", "destination": "/app-framework/lifecycle" },
     { "source": "/app-framework/cli/inspect", "destination": "/testing/cli/inspect" },
     { "source": "/app-framework/cli/upgrade", "destination": "/testing/cli/upgrade" },
-    { "source": "/testing/run-mcp-server", "destination": "/app-framework/run-mcp-server" }
+    { "source": "/testing/run-mcp-server", "destination": "/app-framework/run-mcp-server" },
+    { "source": "/mcp-apps-testing", "destination": "/mcp-testing" }
   ],
   "navigation": {
     "tabs": [
@@ -111,7 +112,7 @@
             "group": "sunpeak is an",
             "pages": [
               "mcp-apps-framework",
-              "mcp-apps-testing",
+              "mcp-testing",
               "mcp-apps-inspector"
             ]
           },
@@ -119,49 +120,6 @@
             "group": "Resources",
             "pages": [
               "links"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "MCP Testing Framework",
-        "groups": [
-          {
-            "group": "Overview",
-            "pages": [
-              "testing/getting-started",
-              "testing/overview"
-            ]
-          },
-          {
-            "group": "Testing",
-            "pages": [
-              "testing/unit",
-              "testing/e2e",
-              "testing/visual",
-              "testing/live",
-              "testing/evals"
-            ]
-          },
-          {
-            "group": "Inspector & Simulations",
-            "pages": [
-              "testing/inspector",
-              "testing/simulations"
-            ]
-          },
-          {
-            "group": "CLI",
-            "pages": [
-              "testing/cli/test",
-              "testing/cli/inspect",
-              "testing/cli/upgrade"
-            ]
-          },
-          {
-            "group": "Help",
-            "pages": [
-              "testing/troubleshooting"
             ]
           }
         ]
@@ -267,7 +225,50 @@
         ]
       },
       {
-        "tab": "MCP Apps",
+        "tab": "MCP Testing Framework",
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": [
+              "testing/getting-started",
+              "testing/overview"
+            ]
+          },
+          {
+            "group": "Testing",
+            "pages": [
+              "testing/unit",
+              "testing/e2e",
+              "testing/visual",
+              "testing/live",
+              "testing/evals"
+            ]
+          },
+          {
+            "group": "Inspector & Simulations",
+            "pages": [
+              "testing/inspector",
+              "testing/simulations"
+            ]
+          },
+          {
+            "group": "CLI",
+            "pages": [
+              "testing/cli/test",
+              "testing/cli/inspect",
+              "testing/cli/upgrade"
+            ]
+          },
+          {
+            "group": "Help",
+            "pages": [
+              "testing/troubleshooting"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "MCP Apps Protocol",
         "groups": [
           {
             "group": "Overview",

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -26,9 +26,23 @@ This documentation is available via MCP at https://sunpeak.ai/docs/mcp, use it i
 <Tip>
 Install the sunpeak coding agent skills for built-in knowledge of patterns, hooks, simulations, and testing:
 
-```bash
-pnpm dlx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@test-mcp-server
-```
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm dlx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@test-mcp-server
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@test-mcp-server
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn dlx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@test-mcp-server
+    ```
+  </Tab>
+</Tabs>
 </Tip>
 
 <video
@@ -43,70 +57,72 @@ pnpm dlx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@tes
 
 ## sunpeak is three things
 
+Each layer builds on the previous one and works independently.
+
 ### 1. Inspector
 
-<Card horizontal title="Inspector" icon="desktop" href="/mcp-apps-inspector">
-  Test any MCP server in replicated ChatGPT and Claude runtimes.
-</Card>
-
-Test any MCP server — no sunpeak project required:
+See how your MCP server looks and behaves inside ChatGPT and Claude, without deploying to either. Works with any MCP server in any language.
 
 ```bash
-sunpeak inspect --server http://localhost:8000/mcp
-sunpeak inspect --server "python my_server.py"
+npx sunpeak inspect --server http://localhost:8000/mcp
 ```
 
-- Multi-host inspector replicating ChatGPT and Claude runtimes
-- Toggle themes, display modes, device types from the sidebar or URL params
-- Call real tool handlers or use simulation fixtures for mock data
-- Built into `sunpeak dev` for framework users
+The inspector replicates the ChatGPT and Claude app runtimes locally. Toggle between hosts, themes, display modes, and device types from the sidebar. Call real tool handlers or load simulation fixtures for deterministic mock data. Changes reflect instantly via HMR.
+
+No tunnel, no host account, no deployment. Just instant local feedback.
+
+<Card horizontal title="Inspector documentation" icon="desktop" href="/mcp-apps-inspector">
+  Full inspector guide, simulations, and sidebar controls.
+</Card>
 
 ### 2. Testing Framework
 
-<Card horizontal title="Testing" icon="flask" href="/testing/overview">
-  Automated tests powered by the inspector and simulations.
-</Card>
+Automated tests for any MCP server, run against replicated ChatGPT and Claude runtimes. Works with Python, Go, TypeScript, Rust, or any language.
 
-Four levels of automated testing for MCP Apps (Unit, E2E, Live, Evals):
+```bash
+npx sunpeak test init --server http://localhost:8000/mcp
+npx sunpeak test
+```
 
-**E2E tests** — the inspector as a test runtime. Call tools, assert on protocol-level results, or render the UI across hosts, themes, and display modes:
+Playwright fixtures handle inspector startup, MCP connection, iframe traversal, and host switching. Four levels of testing: E2E, visual regression, live host tests, and multi-model evals.
 
 ```typescript
 import { test, expect } from 'sunpeak/test';
 
-test('search tool works', async ({ mcp }) => {
+test('search tool returns results', async ({ mcp }) => {
   const result = await mcp.callTool('search', { query: 'headphones' });
   expect(result.isError).toBeFalsy();
 });
 
 test('album cards render in dark mode', async ({ inspector }) => {
   const result = await inspector.renderTool('show-albums', {}, { theme: 'dark' });
-  const app = result.app();
-  await expect(app.locator('button:has-text("Summer Slice")')).toBeVisible();
+  await expect(result.app().locator('button:has-text("Summer Slice")')).toBeVisible();
 });
 ```
 
-**Live tests** — automated browser tests against real ChatGPT (and future hosts). Import `sunpeak/test`, get a `live` fixture that handles auth, message sending, and iframe access:
-
-```typescript
-import { test, expect } from 'sunpeak/test';
-
-test('albums render in ChatGPT', async ({ live }) => {
-  const app = await live.invoke('show me albums');
-  await expect(app.locator('h1')).toBeVisible();
-});
-```
+<Card horizontal title="Testing documentation" icon="flask" href="/testing/overview">
+  Getting started, E2E, visual regression, live tests, and evals.
+</Card>
 
 ### 3. App Framework
 
-Next.js for MCP Apps. Convention-over-configuration with the inspector and testing built in.
+A convention-over-configuration framework for building MCP Apps with the inspector and testing built in. Like Next.js for AI chat apps.
+
+```bash
+npx sunpeak new my-app && cd my-app && pnpm dev
+```
+
+Tools, resources, and simulations are auto-discovered from the file system. Multi-platform React hooks let you write your app logic once and deploy across ChatGPT, Claude, and future hosts.
 
 <ProjectStructure />
 
-- **[Runtime APIs](/app-framework/runtime-apis)**: Multi-platform React hooks for the MCP Apps runtime
+- **[Runtime APIs](/app-framework/runtime-apis)**: `useToolData`, `useAppState`, `useTheme`, `useDisplayMode`, and more
 - **[Project Scaffold](/app-framework/project-scaffold)**: Complete dev setup with pre-configured tooling
-- **[UI Components](/app-framework/ui-components)**: Production-ready components following MCP App design guidelines
 - **Convention over configuration**: resources, tools, and [simulations](/testing/simulations) are auto-discovered from `src/` and `tests/`
+
+<Card horizontal title="App framework documentation" icon="hammer" href="/mcp-apps-framework">
+  Project structure, runtime APIs, deployment, and CLI reference.
+</Card>
 
 ### The sunpeak CLI
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Overview"
-description: "App framework, testing framework, and inspector for MCP Apps."
+description: "MCP App framework, MCP testing framework, and inspector for MCP servers and MCP Apps."
 keywords: ["MCP Apps", "ChatGPT Apps", "MCP app framework", "ChatGPT app framework", "Claude Apps", "Claude Connectors", "sunpeak"]
 ---
 
@@ -57,12 +57,12 @@ Install the sunpeak coding agent skills for built-in knowledge of patterns, hook
 
 ## sunpeak is three things
 
-### 1. App Framework
+### 1. MCP App Framework
 
 A convention-over-configuration framework for building MCP Apps with the inspector and testing built in. Like Next.js for AI chat apps.
 
 ```bash
-npx sunpeak new sunpeak-app && cd sunpeak-app && pnpm dev
+npx sunpeak new
 ```
 
 Tools, resources, and simulations are auto-discovered from the file system. Multi-platform React hooks let you write your app logic once and deploy across ChatGPT, Claude, and future hosts.
@@ -77,9 +77,9 @@ Tools, resources, and simulations are auto-discovered from the file system. Mult
   Project structure, runtime APIs, deployment, and CLI reference.
 </Card>
 
-### 2. Testing Framework
+### 2. MCP Testing Framework
 
-Automated tests for any MCP server, run against replicated ChatGPT and Claude runtimes. Works with Python, Go, TypeScript, Rust, or any language.
+Automated tests for any MCP server, no sunpeak project required. Run against replicated ChatGPT and Claude runtimes. Works with Python, Go, TypeScript, Rust, or any language.
 
 ```bash
 npx sunpeak test init --server http://localhost:8000/mcp
@@ -102,7 +102,7 @@ test('album cards render in dark mode', async ({ inspector }) => {
 });
 ```
 
-<Card horizontal title="Testing documentation" icon="flask" href="/testing/overview">
+<Card horizontal title="Testing documentation" icon="flask" href="/mcp-testing">
   Getting started, E2E, visual regression, live tests, and evals.
 </Card>
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -109,7 +109,7 @@ test('album cards render in dark mode', async ({ inspector }) => {
 A convention-over-configuration framework for building MCP Apps with the inspector and testing built in. Like Next.js for AI chat apps.
 
 ```bash
-npx sunpeak new my-app && cd my-app && pnpm dev
+npx sunpeak new sunpeak-app && cd sunpeak-app && pnpm dev
 ```
 
 Tools, resources, and simulations are auto-discovered from the file system. Multi-platform React hooks let you write your app logic once and deploy across ChatGPT, Claude, and future hosts.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Overview"
-description: "Inspector, testing framework, and app framework for MCP Apps."
+description: "App framework, testing framework, and inspector for MCP Apps."
 keywords: ["MCP Apps", "ChatGPT Apps", "MCP app framework", "ChatGPT app framework", "Claude Apps", "Claude Connectors", "sunpeak"]
 ---
 
@@ -57,22 +57,24 @@ Install the sunpeak coding agent skills for built-in knowledge of patterns, hook
 
 ## sunpeak is three things
 
-Each layer builds on the previous one and works independently.
+### 1. App Framework
 
-### 1. Inspector
-
-See how your MCP server looks and behaves inside ChatGPT and Claude, without deploying to either. Works with any MCP server in any language.
+A convention-over-configuration framework for building MCP Apps with the inspector and testing built in. Like Next.js for AI chat apps.
 
 ```bash
-npx sunpeak inspect --server http://localhost:8000/mcp
+npx sunpeak new sunpeak-app && cd sunpeak-app && pnpm dev
 ```
 
-The inspector replicates the ChatGPT and Claude app runtimes locally. Toggle between hosts, themes, display modes, and device types from the sidebar. Call real tool handlers or load simulation fixtures for deterministic mock data. Changes reflect instantly via HMR.
+Tools, resources, and simulations are auto-discovered from the file system. Multi-platform React hooks let you write your app logic once and deploy across ChatGPT, Claude, and future hosts.
 
-No tunnel, no host account, no deployment. Just instant local feedback.
+<ProjectStructure />
 
-<Card horizontal title="Inspector documentation" icon="desktop" href="/mcp-apps-inspector">
-  Full inspector guide, simulations, and sidebar controls.
+- **[Runtime APIs](/app-framework/runtime-apis)**: `useToolData`, `useAppState`, `useTheme`, `useDisplayMode`, and more
+- **[Project Scaffold](/app-framework/project-scaffold)**: Complete dev setup with pre-configured tooling
+- **Convention over configuration**: resources, tools, and [simulations](/testing/simulations) are auto-discovered from `src/` and `tests/`
+
+<Card horizontal title="App framework documentation" icon="hammer" href="/mcp-apps-framework">
+  Project structure, runtime APIs, deployment, and CLI reference.
 </Card>
 
 ### 2. Testing Framework
@@ -104,34 +106,30 @@ test('album cards render in dark mode', async ({ inspector }) => {
   Getting started, E2E, visual regression, live tests, and evals.
 </Card>
 
-### 3. App Framework
+### 3. Inspector
 
-A convention-over-configuration framework for building MCP Apps with the inspector and testing built in. Like Next.js for AI chat apps.
+See how your MCP server looks and behaves inside ChatGPT and Claude, without deploying to either. Works with any MCP server in any language.
 
 ```bash
-npx sunpeak new sunpeak-app && cd sunpeak-app && pnpm dev
+npx sunpeak inspect --server http://localhost:8000/mcp
 ```
 
-Tools, resources, and simulations are auto-discovered from the file system. Multi-platform React hooks let you write your app logic once and deploy across ChatGPT, Claude, and future hosts.
+The inspector replicates the ChatGPT and Claude app runtimes locally. Toggle between hosts, themes, display modes, and device types from the sidebar. Call real tool handlers or load simulation fixtures for deterministic mock data. Changes reflect instantly via HMR.
 
-<ProjectStructure />
+No tunnel, no host account, no deployment. Just instant local feedback.
 
-- **[Runtime APIs](/app-framework/runtime-apis)**: `useToolData`, `useAppState`, `useTheme`, `useDisplayMode`, and more
-- **[Project Scaffold](/app-framework/project-scaffold)**: Complete dev setup with pre-configured tooling
-- **Convention over configuration**: resources, tools, and [simulations](/testing/simulations) are auto-discovered from `src/` and `tests/`
-
-<Card horizontal title="App framework documentation" icon="hammer" href="/mcp-apps-framework">
-  Project structure, runtime APIs, deployment, and CLI reference.
+<Card horizontal title="Inspector documentation" icon="desktop" href="/mcp-apps-inspector">
+  Full inspector guide, simulations, and sidebar controls.
 </Card>
 
 ### The sunpeak CLI
 
 - [`sunpeak new`](/app-framework/cli/new) - Create a new project
 - [`sunpeak dev`](/app-framework/cli/dev) - Start dev server with inspector and MCP endpoint
-- [`sunpeak inspect`](/testing/cli/inspect) - Inspect any MCP server (standalone)
-- [`sunpeak test`](/testing/cli/test) - Run unit, E2E, visual, live, and eval tests
 - [`sunpeak build`](/app-framework/cli/build) - Build resources for production
 - [`sunpeak start`](/app-framework/cli/start) - Start the production MCP server
+- [`sunpeak test`](/testing/cli/test) - Run unit, E2E, visual, live, and eval tests
+- [`sunpeak inspect`](/testing/cli/inspect) - Inspect any MCP server (standalone)
 - [`sunpeak upgrade`](/testing/cli/upgrade) - Upgrade sunpeak to latest version
 
 <Examples />

--- a/docs/mcp-apps-framework.mdx
+++ b/docs/mcp-apps-framework.mdx
@@ -11,7 +11,7 @@ import ProjectStructure from '/snippets/project-structure.mdx';
 Create a new MCP App project with one command:
 
 ```bash
-npx sunpeak new my-app && cd my-app && pnpm dev
+npx sunpeak new sunpeak-app && cd sunpeak-app && pnpm dev
 ```
 
 This scaffolds a project with example tools, resources, simulations, and tests, then starts a dev server with HMR and opens the inspector at `http://localhost:3000`. An MCP endpoint starts at `http://localhost:8000/mcp` for testing with real hosts.

--- a/docs/mcp-apps-framework.mdx
+++ b/docs/mcp-apps-framework.mdx
@@ -89,11 +89,29 @@ if (isChatGPT()) {
 
 The MCP server lets you serve your apps to AI hosts like ChatGPT and Claude. During development, [`sunpeak dev`](/app-framework/cli/dev) runs an MCP server that serves simulation fixture data. For production, use [`sunpeak build`](/app-framework/cli/build) followed by [`sunpeak start`](/app-framework/cli/start).
 
-```bash
-pnpm dev        # Dev server with HMR + inspector + MCP endpoint
-pnpm build      # Build resources for production
-pnpm start      # Start the production MCP server
-```
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm dev        # Dev server with HMR + inspector + MCP endpoint
+    pnpm build      # Build resources for production
+    pnpm start      # Start the production MCP server
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm run dev        # Dev server with HMR + inspector + MCP endpoint
+    npm run build      # Build resources for production
+    npm run start      # Start the production MCP server
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn dev        # Dev server with HMR + inspector + MCP endpoint
+    yarn build      # Build resources for production
+    yarn start      # Start the production MCP server
+    ```
+  </Tab>
+</Tabs>
 
 See the [Deployment Guide](/app-framework/guides/deployment) for connecting to hosts, tunnels, and production setup.
 

--- a/docs/mcp-apps-framework.mdx
+++ b/docs/mcp-apps-framework.mdx
@@ -6,15 +6,23 @@ keywords: ["MCP Apps", "ChatGPT Apps", "Claude Apps", "MCP app framework", "Chat
 
 import ProjectStructure from '/snippets/project-structure.mdx';
 
-## Overview
+## Quickstart
 
-The sunpeak framework is a convention-over-configuration structure for building MCP Apps — like Next.js for AI host applications. It bundles the [inspector](/mcp-apps-inspector) and [testing framework](/mcp-apps-testing) with a structured project layout, auto-discovery, and a CLI.
+Create a new MCP App project with one command:
 
 ```bash
-sunpeak new my-app
-cd my-app
-sunpeak dev
+npx sunpeak new my-app && cd my-app && pnpm dev
 ```
+
+This scaffolds a project with example tools, resources, simulations, and tests, then starts a dev server with HMR and opens the inspector at `http://localhost:3000`. An MCP endpoint starts at `http://localhost:8000/mcp` for testing with real hosts.
+
+See the [full quickstart guide](/quickstart) for step-by-step setup through production deployment.
+
+## What it does
+
+The sunpeak framework is a convention-over-configuration structure for building MCP Apps. It bundles the [inspector](/mcp-apps-inspector) and [testing framework](/mcp-apps-testing) with a structured project layout, auto-discovery, and a CLI.
+
+Building an MCP App from scratch means wiring up an MCP server, handling protocol details, managing resource HTML, and setting up a dev environment. sunpeak handles all of that and gives you a structured project with testing from the start.
 
 <ProjectStructure />
 
@@ -82,9 +90,9 @@ if (isChatGPT()) {
 The MCP server lets you serve your apps to AI hosts like ChatGPT and Claude. During development, [`sunpeak dev`](/app-framework/cli/dev) runs an MCP server that serves simulation fixture data. For production, use [`sunpeak build`](/app-framework/cli/build) followed by [`sunpeak start`](/app-framework/cli/start).
 
 ```bash
-sunpeak dev        # Dev server with HMR + inspector + MCP endpoint
-sunpeak build      # Build resources for production
-sunpeak start      # Start the production MCP server
+pnpm dev        # Dev server with HMR + inspector + MCP endpoint
+pnpm build      # Build resources for production
+pnpm start      # Start the production MCP server
 ```
 
 See the [Deployment Guide](/app-framework/guides/deployment) for connecting to hosts, tunnels, and production setup.

--- a/docs/mcp-apps-framework.mdx
+++ b/docs/mcp-apps-framework.mdx
@@ -133,10 +133,10 @@ See [UI Components](/app-framework/ui-components) for the full list.
 |---------|-------------|
 | [`sunpeak new`](/app-framework/cli/new) | Create a new project |
 | [`sunpeak dev`](/app-framework/cli/dev) | Dev server with inspector and MCP endpoint |
-| [`sunpeak inspect`](/testing/cli/inspect) | [Inspect any MCP server](/mcp-apps-inspector) (standalone) |
-| [`sunpeak test`](/testing/cli/test) | Run unit, E2E, visual, live, and eval tests |
 | [`sunpeak build`](/app-framework/cli/build) | Build resources for production |
 | [`sunpeak start`](/app-framework/cli/start) | Start the production MCP server |
+| [`sunpeak test`](/testing/cli/test) | Run unit, E2E, visual, live, and eval tests |
+| [`sunpeak inspect`](/testing/cli/inspect) | [Inspect any MCP server](/mcp-apps-inspector) (standalone) |
 | [`sunpeak upgrade`](/testing/cli/upgrade) | Upgrade sunpeak to latest version |
 
 

--- a/docs/mcp-apps-framework.mdx
+++ b/docs/mcp-apps-framework.mdx
@@ -11,7 +11,7 @@ import ProjectStructure from '/snippets/project-structure.mdx';
 Create a new MCP App project with one command:
 
 ```bash
-npx sunpeak new sunpeak-app && cd sunpeak-app && pnpm dev
+npx sunpeak new
 ```
 
 This scaffolds a project with example tools, resources, simulations, and tests, then starts a dev server with HMR and opens the inspector at `http://localhost:3000`. An MCP endpoint starts at `http://localhost:8000/mcp` for testing with real hosts.
@@ -20,7 +20,7 @@ See the [full quickstart guide](/quickstart) for step-by-step setup through prod
 
 ## What it does
 
-The sunpeak framework is a convention-over-configuration structure for building MCP Apps. It bundles the [inspector](/mcp-apps-inspector) and [testing framework](/mcp-apps-testing) with a structured project layout, auto-discovery, and a CLI.
+The sunpeak framework is a convention-over-configuration structure for building MCP Apps. It bundles the [inspector](/mcp-apps-inspector) and [testing framework](/mcp-testing) with a structured project layout, auto-discovery, and a CLI.
 
 Building an MCP App from scratch means wiring up an MCP server, handling protocol details, managing resource HTML, and setting up a dev environment. sunpeak handles all of that and gives you a structured project with testing from the start.
 

--- a/docs/mcp-apps-inspector.mdx
+++ b/docs/mcp-apps-inspector.mdx
@@ -6,41 +6,38 @@ keywords: ["MCP Apps", "ChatGPT Apps", "Claude Apps", "MCP app inspector", "Chat
 
 import InspectorSnippet from '/snippets/inspector.mdx';
 
+## Quickstart
+
+No installation required. Point the inspector at any running MCP server:
+
+```bash
+npx sunpeak inspect --server http://localhost:8000/mcp
+```
+
+For stdio servers, pass the command directly:
+
+```bash
+npx sunpeak inspect --server "python my_server.py"
+npx sunpeak inspect --server "go run ./cmd/server"
+```
+
+This opens the inspector at `http://localhost:3000`. See [sunpeak inspect CLI Reference](/testing/cli/inspect) for all options.
+
+<Note>In sunpeak framework projects, the inspector is built into `sunpeak dev` automatically.</Note>
+
 <img
   src="https://cdn.sunpeak.ai/chatgpt-simulator.png"
   alt="MCP App Inspector"
 />
 
-## Overview
+## What it does
 
-The sunpeak inspector replicates MCP App host runtimes (ChatGPT, Claude) for local development and testing. It works with any MCP server — no sunpeak project required.
-
-<Tabs>
-  <Tab title="Standalone (any MCP server)">
-    Inspect any MCP server:
-
-    ```bash
-    sunpeak inspect --server http://localhost:8000/mcp
-    sunpeak inspect --server "python my_server.py"
-    ```
-
-    See [sunpeak inspect CLI Reference](/testing/cli/inspect) for all options.
-  </Tab>
-  <Tab title="Built into sunpeak dev">
-    In sunpeak projects, the inspector is built into the dev server:
-
-    ```bash
-    sunpeak dev
-    ```
-  </Tab>
-</Tabs>
-
-## Why Use the Inspector?
+The inspector replicates the ChatGPT and Claude MCP App runtimes on your machine. Your MCP server's tools and resources render in the same iframe sandbox that production hosts use, with the same PostMessage protocol, the same CSS variables, and the same host context values.
 
 - **Instant feedback** — HMR means changes appear immediately. No cache issues, no reloading the host.
-- **Every host, theme, and device** — toggle ChatGPT/Claude, light/dark, mobile/tablet/desktop, inline/PiP/fullscreen from the sidebar or URL params.
-- **Automated testing** — the inspector is the test runtime for [E2E tests](/testing/e2e). Load simulations via URL, assert with Playwright.
-- **No deployment needed** — develop and test locally without tunnels or host accounts.
+- **Every host, theme, and device** — toggle ChatGPT/Claude, light/dark, mobile/tablet/desktop, inline/PiP/fullscreen from the sidebar.
+- **No deployment needed** — no tunnel, no host account, no API credits.
+- **Test runtime** — the inspector powers [E2E tests](/testing/e2e). Load simulations via URL, assert with Playwright.
 
 ## Simulations
 

--- a/docs/mcp-apps-testing.mdx
+++ b/docs/mcp-apps-testing.mdx
@@ -54,12 +54,32 @@ Four levels of automated testing:
 
 E2E tests are Playwright specs in `tests/e2e/*.spec.ts`. The dev server starts automatically — Playwright launches it before running tests. Tests run against both ChatGPT and Claude hosts via Playwright projects.
 
-```bash
-pnpm test                               # Run unit + e2e
-pnpm test:e2e                           # E2E only
-pnpm test:e2e -- --ui                   # Playwright UI mode
-pnpm test:e2e -- tests/e2e/albums.spec.ts  # Single file
-```
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm test                               # Run unit + e2e
+    pnpm test:e2e                           # E2E only
+    pnpm test:e2e -- --ui                   # Playwright UI mode
+    pnpm test:e2e -- tests/e2e/albums.spec.ts  # Single file
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm run test                               # Run unit + e2e
+    npm run test:e2e                           # E2E only
+    npm run test:e2e -- --ui                   # Playwright UI mode
+    npm run test:e2e -- tests/e2e/albums.spec.ts  # Single file
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn test                               # Run unit + e2e
+    yarn test:e2e                           # E2E only
+    yarn test:e2e --ui                      # Playwright UI mode
+    yarn test:e2e tests/e2e/albums.spec.ts  # Single file
+    ```
+  </Tab>
+</Tabs>
 
 ### Writing E2E Tests
 
@@ -179,10 +199,26 @@ Visual regression tests capture screenshots and compare them against saved basel
 
 Screenshot comparisons only run when you pass `--visual`. Without it, `result.screenshot()` calls are silently skipped, so you can include them in your regular e2e tests without affecting normal runs.
 
-```bash
-pnpm test:visual                           # Compare against baselines
-pnpm test:visual -- --update               # Update baselines
-```
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm test:visual                           # Compare against baselines
+    pnpm test:visual -- --update               # Update baselines
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm run test:visual                           # Compare against baselines
+    npm run test:visual -- --update               # Update baselines
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn test:visual                           # Compare against baselines
+    yarn test:visual --update                  # Update baselines
+    ```
+  </Tab>
+</Tabs>
 
 Use `result.screenshot()` in any e2e test:
 
@@ -240,13 +276,35 @@ This only needs to be done once per tunnel URL pattern.
 
 ### Running Live Tests
 
-```bash
-# Terminal 1: Start a tunnel to your MCP server
-ngrok http 8000
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    # Terminal 1: Start a tunnel to your MCP server
+    ngrok http 8000
 
-# Terminal 2: Run live tests
-pnpm test:live
-```
+    # Terminal 2: Run live tests
+    pnpm test:live
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    # Terminal 1: Start a tunnel to your MCP server
+    ngrok http 8000
+
+    # Terminal 2: Run live tests
+    npm run test:live
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    # Terminal 1: Start a tunnel to your MCP server
+    ngrok http 8000
+
+    # Terminal 2: Run live tests
+    yarn test:live
+    ```
+  </Tab>
+</Tabs>
 
 The test runner:
 1. Imports your ChatGPT session from your browser (Chrome, Arc, Brave, or Edge). Falls back to a manual login window if no session is found.
@@ -408,10 +466,26 @@ Three assertion levels:
 
 ### Running
 
-```bash
-pnpm test:eval                                   # Run all evals
-pnpm test:eval -- tests/evals/albums.eval.ts     # Run one eval file
-```
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm test:eval                                   # Run all evals
+    pnpm test:eval -- tests/evals/albums.eval.ts     # Run one eval file
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm run test:eval                                   # Run all evals
+    npm run test:eval -- tests/evals/albums.eval.ts     # Run one eval file
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn test:eval                                   # Run all evals
+    yarn test:eval tests/evals/albums.eval.ts        # Run one eval file
+    ```
+  </Tab>
+</Tabs>
 
 ### Output
 

--- a/docs/mcp-apps-testing.mdx
+++ b/docs/mcp-apps-testing.mdx
@@ -4,27 +4,43 @@ description: "Automated testing of MCP Apps using the inspector, simulations, li
 keywords: ["MCP app testing", "ChatGPT app testing", "MCP Apps", "ChatGPT Apps", "Playwright", "e2e testing", "live testing", "evals", "LLM testing"]
 ---
 
-## Overview
+## Quickstart
 
-sunpeak provides four levels of automated testing for MCP Apps:
+Scaffold tests for any MCP server. No sunpeak project required:
 
-1. **Unit tests** — Vitest with happy-dom for component and hook logic testing.
+```bash
+npx sunpeak test init --server http://localhost:8000/mcp
+npx sunpeak test
+```
 
-2. **E2E tests** against the [inspector](/mcp-apps-inspector) — the `mcp` and `inspector` fixtures from `sunpeak/test` call tools and render them in simulated ChatGPT and Claude runtimes. The `mcp` fixture provides protocol-level methods (`callTool`, `listTools`), and the `inspector` fixture renders tools and gives you a frame locator for the UI. [Simulations](/testing/simulations) (JSON fixtures) define reproducible tool states. Test every combination of host, theme, display mode, and device type without deploying or burning API credits.
+For stdio servers:
 
-3. **Live tests** against real hosts — `sunpeak/test/live` provides Playwright fixtures that open real ChatGPT (and future hosts), send messages, wait for app iframes, and let you assert against the rendered result. All host DOM interaction (auth, selectors, iframe access) is maintained by sunpeak — you only write resource assertions.
+```bash
+npx sunpeak test init --server "python my_server.py"
+```
 
-4. **Evals** against multiple LLM models — `sunpeak/eval` connects to any MCP server, discovers tools via MCP protocol, sends prompts to multiple models (GPT-4o, Claude, Gemini, etc.), and asserts that each model calls the right tools with the right arguments. Each eval runs multiple times per model to measure reliability across non-deterministic LLM responses.
+This generates E2E specs, visual regression tests, live host tests, and multi-model evals. The scaffolded smoke test verifies the inspector can connect to your server and load. See [Getting Started](/testing/getting-started) for the full setup walkthrough.
+
+## What it does
+
+MCP Apps render inside host iframes with host-specific themes, display modes, and capabilities. Standard browser testing can't replicate this because the runtime environment only exists inside ChatGPT and Claude. sunpeak replicates those runtimes so you can run CI-friendly tests without host accounts or API credits.
+
+Four levels of automated testing:
+
+1. **Unit tests** — Vitest with happy-dom for component and hook logic.
+2. **E2E tests** — Playwright specs against replicated ChatGPT and Claude runtimes via the [inspector](/mcp-apps-inspector). Test every combination of host, theme, display mode, and device type.
+3. **Live tests** — Playwright specs against real ChatGPT. sunpeak handles auth, message sending, and iframe access.
+4. **Evals** — Multi-model tool calling tests (GPT-4o, Claude, Gemini). Each eval runs N times per model to measure reliability.
 
 | Command | What it tests | Runtime |
 |---------|--------------|---------|
 | `sunpeak test` | Unit + e2e tests | Vitest + Playwright |
 | `sunpeak test --unit` | Unit tests only | Vitest + happy-dom |
 | `sunpeak test --e2e` | E2E tests only | Playwright + inspector |
-| `sunpeak test --visual` | E2E tests with visual regression | Playwright + inspector |
-| `sunpeak test --visual --update` | Update visual regression baselines | Playwright + inspector |
+| `sunpeak test --visual` | E2E with visual regression | Playwright + inspector |
+| `sunpeak test --visual --update` | Update visual baselines | Playwright + inspector |
 | `sunpeak test --live` | Live tests against real ChatGPT | Playwright + real host |
-| `sunpeak test --eval` | Evals against multiple LLM models | Vitest + Vercel AI SDK |
+| `sunpeak test --eval` | Evals against multiple models | Vitest + Vercel AI SDK |
 
 <Note>
   `--eval` and `--live` are not included in the default `sunpeak test` run because they require API keys and cost money. You must opt in explicitly.
@@ -39,10 +55,10 @@ sunpeak provides four levels of automated testing for MCP Apps:
 E2E tests are Playwright specs in `tests/e2e/*.spec.ts`. The dev server starts automatically — Playwright launches it before running tests. Tests run against both ChatGPT and Claude hosts via Playwright projects.
 
 ```bash
-sunpeak test                               # Run unit + e2e
-sunpeak test --e2e                         # E2E only
-sunpeak test --e2e --ui                    # Playwright UI mode
-sunpeak test --e2e tests/e2e/albums.spec.ts  # Single file
+pnpm test                               # Run unit + e2e
+pnpm test:e2e                           # E2E only
+pnpm test:e2e -- --ui                   # Playwright UI mode
+pnpm test:e2e -- tests/e2e/albums.spec.ts  # Single file
 ```
 
 ### Writing E2E Tests
@@ -164,8 +180,8 @@ Visual regression tests capture screenshots and compare them against saved basel
 Screenshot comparisons only run when you pass `--visual`. Without it, `result.screenshot()` calls are silently skipped, so you can include them in your regular e2e tests without affecting normal runs.
 
 ```bash
-sunpeak test --visual                  # Compare against baselines
-sunpeak test --visual --update         # Update baselines
+pnpm test:visual                           # Compare against baselines
+pnpm test:visual -- --update               # Update baselines
 ```
 
 Use `result.screenshot()` in any e2e test:
@@ -308,11 +324,11 @@ Evals test whether different LLMs call your tools correctly. A tool description 
 
 ### Prerequisites
 
-- **Vercel AI SDK**: `pnpm add ai`
+- **Vercel AI SDK**: install `ai`
 - **Provider packages** (install only what you need):
-  - `pnpm add @ai-sdk/openai` for GPT-4o, GPT-4o-mini, o4-mini
-  - `pnpm add @ai-sdk/anthropic` for Claude Sonnet, Claude Haiku
-  - `pnpm add @ai-sdk/google` for Gemini 2.0 Flash
+  - `@ai-sdk/openai` for GPT-4o, GPT-4o-mini, o4-mini
+  - `@ai-sdk/anthropic` for Claude Sonnet, Claude Haiku
+  - `@ai-sdk/google` for Gemini 2.0 Flash
 - **API keys** in `tests/evals/.env` (gitignored) or environment variables
 
 Evals are scaffolded automatically by `sunpeak new` and `sunpeak test init`.
@@ -393,8 +409,8 @@ Three assertion levels:
 ### Running
 
 ```bash
-sunpeak test --eval                          # Run all evals
-sunpeak test --eval tests/evals/albums.eval.ts  # Run one eval file
+pnpm test:eval                                   # Run all evals
+pnpm test:eval -- tests/evals/albums.eval.ts     # Run one eval file
 ```
 
 ### Output

--- a/docs/mcp-testing.mdx
+++ b/docs/mcp-testing.mdx
@@ -1,7 +1,7 @@
 ---
-title: "MCP App Testing Framework"
-description: "Automated testing of MCP Apps using the inspector, simulations, live host testing, and multi-model evals."
-keywords: ["MCP app testing", "ChatGPT app testing", "MCP Apps", "ChatGPT Apps", "Playwright", "e2e testing", "live testing", "evals", "LLM testing"]
+title: "MCP Testing Framework"
+description: "Automated testing of MCP servers using the inspector, simulations, live host testing, and multi-model evals."
+keywords: ["MCP app testing", "MCP testing", "ChatGPT app testing", "MCP Apps", "ChatGPT Apps", "Playwright", "e2e testing", "live testing", "evals", "LLM testing"]
 ---
 
 ## Quickstart
@@ -25,12 +25,13 @@ This generates E2E specs, visual regression tests, live host tests, and multi-mo
 
 MCP Apps render inside host iframes with host-specific themes, display modes, and capabilities. Standard browser testing can't replicate this because the runtime environment only exists inside ChatGPT and Claude. sunpeak replicates those runtimes so you can run CI-friendly tests without host accounts or API credits.
 
-Four levels of automated testing:
+Five levels of automated testing:
 
-1. **Unit tests** — Vitest with happy-dom for component and hook logic.
+1. **Unit tests** — Vitest with happy-dom for component and hook logic. Exclusively for the sunpeak MCP App framework. For testing-only use cases, your unit tests will already be in the same language as your server.
 2. **E2E tests** — Playwright specs against replicated ChatGPT and Claude runtimes via the [inspector](/mcp-apps-inspector). Test every combination of host, theme, display mode, and device type.
-3. **Live tests** — Playwright specs against real ChatGPT. sunpeak handles auth, message sending, and iframe access.
-4. **Evals** — Multi-model tool calling tests (GPT-4o, Claude, Gemini). Each eval runs N times per model to measure reliability.
+4. **Visual regression tests** — Playwright specs against saved images of your rendered UI via the [inspector](/mcp-apps-inspector).
+4. **Live tests** — Playwright specs against real ChatGPT. sunpeak handles auth, message sending, and iframe access.
+5. **Evals** — Multi-model tool calling tests (GPT-4o, mini, Claude, Gemini, etc.). Each eval runs N times per model to measure how reliably each model can use your tools.
 
 | Command | What it tests | Runtime |
 |---------|--------------|---------|
@@ -527,5 +528,5 @@ export default defineEval({
   createInspectorUrl parameters and Inspector component props.
 </Card>
 <Card horizontal title="MCP Testing Framework" icon="book" href="/testing/overview">
-  Complete documentation for all four testing levels.
+  Complete documentation for all five testing levels.
 </Card>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -16,45 +16,35 @@ keywords: ["MCP Apps", "ChatGPT Apps", "MCP app framework", "ChatGPT app framewo
 ## New projects
 
 <Steps>
-  <Step title="Install sunpeak">
+  <Step title="Create a project">
     **Requirements**: Node.js 20+
 
-    Install sunpeak globally:
-
-    <Tabs>
-      <Tab title="pnpm">
-        ```bash
-        pnpm add -g sunpeak
-        ```
-      </Tab>
-      <Tab title="npm">
-        ```bash
-        npm install -g sunpeak
-        ```
-      </Tab>
-      <Tab title="yarn">
-        ```bash
-        yarn global add sunpeak
-        ```
-      </Tab>
-    </Tabs>
-  </Step>
-
-  <Step title="Create a project">
-    Create a new project:
-
     ```bash
-    sunpeak new sunpeak-app
+    npx sunpeak new my-app
+    cd my-app
     ```
   </Step>
 
   <Step title="Develop locally">
-    Navigate to your project and run the development server:
+    Start the development server:
 
-    ```bash
-    cd sunpeak-app
-    sunpeak dev
-    ```
+    <Tabs>
+      <Tab title="pnpm">
+        ```bash
+        pnpm dev
+        ```
+      </Tab>
+      <Tab title="npm">
+        ```bash
+        npm run dev
+        ```
+      </Tab>
+      <Tab title="yarn">
+        ```bash
+        yarn dev
+        ```
+      </Tab>
+    </Tabs>
 
     This starts:
     - The MCP App inspector at `http://localhost:3000` for local development
@@ -78,9 +68,23 @@ keywords: ["MCP Apps", "ChatGPT Apps", "MCP app framework", "ChatGPT app framewo
   <Step title="Build & start for production">
     Build your [resources](/mcp-apps/mcp/resources) and [tools](/mcp-apps/mcp/tools), then start the production MCP server:
 
-    ```bash
-    pnpm build && pnpm start
-    ```
+    <Tabs>
+      <Tab title="pnpm">
+        ```bash
+        pnpm build && pnpm start
+        ```
+      </Tab>
+      <Tab title="npm">
+        ```bash
+        npm run build && npm run start
+        ```
+      </Tab>
+      <Tab title="yarn">
+        ```bash
+        yarn build && yarn start
+        ```
+      </Tab>
+    </Tabs>
 
     This compiles your tool handlers, Zod schemas, and optional auth from `src/server.ts`, then starts a production MCP server on port `8000`.
   </Step>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -20,7 +20,7 @@ keywords: ["MCP Apps", "ChatGPT Apps", "MCP app framework", "ChatGPT app framewo
     **Requirements**: Node.js 20+
 
     ```bash
-    npx sunpeak new
+    npx sunpeak new sunpeak-app
     cd sunpeak-app
     ```
   </Step>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -20,8 +20,8 @@ keywords: ["MCP Apps", "ChatGPT Apps", "MCP app framework", "ChatGPT app framewo
     **Requirements**: Node.js 20+
 
     ```bash
-    npx sunpeak new my-app
-    cd my-app
+    npx sunpeak new sunpeak-app
+    cd sunpeak-app
     ```
   </Step>
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -20,7 +20,7 @@ keywords: ["MCP Apps", "ChatGPT Apps", "MCP app framework", "ChatGPT app framewo
     **Requirements**: Node.js 20+
 
     ```bash
-    npx sunpeak new sunpeak-app
+    npx sunpeak new
     cd sunpeak-app
     ```
   </Step>

--- a/docs/snippets/inspector.mdx
+++ b/docs/snippets/inspector.mdx
@@ -1,7 +1,7 @@
 For projects using the sunpeak framework, simulations are auto-discovered. Just run:
 
 ```bash
-sunpeak dev
+pnpm dev
 ```
 
 For custom setups, you can manually configure the inspector:

--- a/docs/snippets/inspector.mdx
+++ b/docs/snippets/inspector.mdx
@@ -1,8 +1,22 @@
 For projects using the sunpeak framework, simulations are auto-discovered. Just run:
 
-```bash
-pnpm dev
-```
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm dev
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm run dev
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn dev
+    ```
+  </Tab>
+</Tabs>
 
 For custom setups, you can manually configure the inspector:
 

--- a/docs/testing/e2e.mdx
+++ b/docs/testing/e2e.mdx
@@ -9,10 +9,10 @@ keywords: ["MCP app testing", "e2e testing", "Playwright", "inspector", "simulat
 E2E tests are Playwright specs in `tests/e2e/*.spec.ts`. The dev server starts automatically — Playwright launches it before running tests. Tests run against both ChatGPT and Claude hosts via Playwright projects.
 
 ```bash
-sunpeak test                               # Run unit + e2e
-sunpeak test --e2e                         # E2E only
-sunpeak test --e2e --ui                    # Playwright UI mode
-sunpeak test --e2e tests/e2e/albums.spec.ts  # Single file
+pnpm test                               # Run unit + e2e
+pnpm test:e2e                           # E2E only
+pnpm test:e2e -- --ui                   # Playwright UI mode
+pnpm test:e2e -- tests/e2e/albums.spec.ts  # Single file
 ```
 
 ### Writing E2E Tests

--- a/docs/testing/e2e.mdx
+++ b/docs/testing/e2e.mdx
@@ -8,12 +8,32 @@ keywords: ["MCP app testing", "e2e testing", "Playwright", "inspector", "simulat
 
 E2E tests are Playwright specs in `tests/e2e/*.spec.ts`. The dev server starts automatically — Playwright launches it before running tests. Tests run against both ChatGPT and Claude hosts via Playwright projects.
 
-```bash
-pnpm test                               # Run unit + e2e
-pnpm test:e2e                           # E2E only
-pnpm test:e2e -- --ui                   # Playwright UI mode
-pnpm test:e2e -- tests/e2e/albums.spec.ts  # Single file
-```
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm test                               # Run unit + e2e
+    pnpm test:e2e                           # E2E only
+    pnpm test:e2e -- --ui                   # Playwright UI mode
+    pnpm test:e2e -- tests/e2e/albums.spec.ts  # Single file
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm run test                               # Run unit + e2e
+    npm run test:e2e                           # E2E only
+    npm run test:e2e -- --ui                   # Playwright UI mode
+    npm run test:e2e -- tests/e2e/albums.spec.ts  # Single file
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn test                               # Run unit + e2e
+    yarn test:e2e                           # E2E only
+    yarn test:e2e --ui                      # Playwright UI mode
+    yarn test:e2e tests/e2e/albums.spec.ts  # Single file
+    ```
+  </Tab>
+</Tabs>
 
 ### Writing E2E Tests
 

--- a/docs/testing/evals.mdx
+++ b/docs/testing/evals.mdx
@@ -132,11 +132,29 @@ Args use partial matching. Extra keys in the actual tool call are allowed. Vites
 
 ## Running Evals
 
-```bash
-pnpm test:eval                             # Run all evals
-pnpm test:eval -- albums                   # Filter by name
-pnpm test:eval -- --unit                   # Run evals + unit tests
-```
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm test:eval                             # Run all evals
+    pnpm test:eval -- albums                   # Filter by name
+    pnpm test:eval -- --unit                   # Run evals + unit tests
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm run test:eval                             # Run all evals
+    npm run test:eval -- albums                   # Filter by name
+    npm run test:eval -- --unit                   # Run evals + unit tests
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn test:eval                             # Run all evals
+    yarn test:eval albums                      # Filter by name
+    yarn test:eval --unit                      # Run evals + unit tests
+    ```
+  </Tab>
+</Tabs>
 
 ## Output
 

--- a/docs/testing/evals.mdx
+++ b/docs/testing/evals.mdx
@@ -14,11 +14,11 @@ Evals are not included in the default `sunpeak test` run because they cost money
 
 ## Prerequisites
 
-- **Vercel AI SDK**: `pnpm add ai`
+- **Vercel AI SDK**: install `ai`
 - **Provider packages**: Install only the ones you need:
-  - `pnpm add @ai-sdk/openai` for GPT-4o, GPT-4o-mini, o4-mini
-  - `pnpm add @ai-sdk/anthropic` for Claude Sonnet, Claude Haiku
-  - `pnpm add @ai-sdk/google` for Gemini 2.0 Flash
+  - `@ai-sdk/openai` for GPT-4o, GPT-4o-mini, o4-mini
+  - `@ai-sdk/anthropic` for Claude Sonnet, Claude Haiku
+  - `@ai-sdk/google` for Gemini 2.0 Flash
 - **API keys**: Set in `tests/evals/.env` (gitignored) or as environment variables
 
 ## Setup
@@ -133,9 +133,9 @@ Args use partial matching. Extra keys in the actual tool call are allowed. Vites
 ## Running Evals
 
 ```bash
-sunpeak test --eval                    # Run all evals
-sunpeak test --eval albums             # Filter by name
-sunpeak test --eval --unit             # Run evals + unit tests
+pnpm test:eval                             # Run all evals
+pnpm test:eval -- albums                   # Filter by name
+pnpm test:eval -- --unit                   # Run evals + unit tests
 ```
 
 ## Output

--- a/docs/testing/getting-started.mdx
+++ b/docs/testing/getting-started.mdx
@@ -114,7 +114,7 @@ The `mcp` and `inspector` fixtures handle all the plumbing: starting the inspect
 There are two fixtures: `mcp` for protocol-level testing (`callTool`, `listTools`, etc., returning raw MCP data) and `inspector` for UI testing (`renderTool`, which renders the result in the inspector). When you pass `input` to `renderTool`, the tool is called on your real server and the result is rendered. Without `input`, the tool uses pre-baked simulation fixture data (if available) for fast, deterministic tests. See [Simulations](/testing/simulations#simulations-vs-real-server-calls) for more on when to use each approach.
 
 <Tip>
-  Run `sunpeak inspect --server <url>` to browse your tools interactively and find the right tool names and arguments to use in tests.
+  Run `npx sunpeak inspect --server <url>` to browse your tools interactively and find the right tool names and arguments to use in tests.
 </Tip>
 
 ## 5. Add more test levels

--- a/docs/testing/getting-started.mdx
+++ b/docs/testing/getting-started.mdx
@@ -9,70 +9,50 @@ keywords: ["MCP testing", "MCP server testing", "test MCP server", "Python MCP t
 - **Node.js 20+** is required, even if your MCP server is written in Python, Go, or another language. The testing framework runs on Node.js and Playwright.
 - Your MCP server running locally (HTTP or stdio)
 
-## 1. Install sunpeak
-
-<Tabs>
-  <Tab title="pnpm">
-    ```bash
-    pnpm add -g sunpeak
-    ```
-  </Tab>
-  <Tab title="npm">
-    ```bash
-    npm install -g sunpeak
-    ```
-  </Tab>
-  <Tab title="yarn">
-    ```bash
-    yarn global add sunpeak
-    ```
-  </Tab>
-</Tabs>
-
-## 2. Try the inspector
+## 1. Try the inspector (optional)
 
 Before writing tests, try the inspector to verify sunpeak can connect to your server:
 
 <Tabs>
   <Tab title="HTTP server">
     ```bash
-    sunpeak inspect --server http://localhost:8000/mcp
+    npx sunpeak inspect --server http://localhost:8000/mcp
     ```
   </Tab>
   <Tab title="Python (stdio)">
     ```bash
-    sunpeak inspect --server "python server.py"
+    npx sunpeak inspect --server "python server.py"
 
     # With uv:
-    sunpeak inspect --server "uv run python server.py"
+    npx sunpeak inspect --server "uv run python server.py"
     ```
   </Tab>
   <Tab title="Go (stdio)">
     ```bash
-    sunpeak inspect --server "go run ./cmd/server"
+    npx sunpeak inspect --server "go run ./cmd/server"
     ```
   </Tab>
   <Tab title="Node.js (stdio)">
     ```bash
-    sunpeak inspect --server "node server.js"
+    npx sunpeak inspect --server "node server.js"
     ```
   </Tab>
 </Tabs>
 
 This opens the inspector at `http://localhost:3000`, where you can call your tools and see them rendered in simulated ChatGPT and Claude runtimes. Browse your tools, switch hosts and themes, and verify everything connects.
 
-## 3. Scaffold test infrastructure
+## 2. Scaffold test infrastructure
 
 Once the inspector works, scaffold automated tests:
 
 ```bash
-sunpeak test init --server http://localhost:8000/mcp
+npx sunpeak test init --server http://localhost:8000/mcp
 ```
 
 Or with a stdio command:
 
 ```bash
-sunpeak test init --server "python server.py"
+npx sunpeak test init --server "python server.py"
 ```
 
 This creates test files for all four testing levels. For non-JS projects, everything goes into a self-contained `tests/sunpeak/` directory with its own `package.json`.
@@ -95,17 +75,17 @@ Install dependencies:
   </Tab>
 </Tabs>
 
-## 4. Run the smoke test
+## 3. Run the smoke test
 
 ```bash
-sunpeak test
+npx sunpeak test
 ```
 
 For non-JS projects, `sunpeak test` auto-discovers `tests/sunpeak/playwright.config.ts` when no root-level config exists. You can run it from your project root without cd-ing into the test directory.
 
 The scaffolded smoke test verifies that the inspector can connect to your server and load. You should see one passing test.
 
-## 5. Write your first real test
+## 4. Write your first real test
 
 Open the scaffolded smoke test (`smoke.test.ts`) and add a test for one of your tools. Replace `your-tool` with an actual tool name from your server:
 
@@ -137,7 +117,7 @@ There are two fixtures: `mcp` for protocol-level testing (`callTool`, `listTools
   Run `sunpeak inspect --server <url>` to browse your tools interactively and find the right tool names and arguments to use in tests.
 </Tip>
 
-## 6. Add more test levels
+## 5. Add more test levels
 
 The scaffolded files include templates for all four testing levels:
 

--- a/docs/testing/live.mdx
+++ b/docs/testing/live.mdx
@@ -31,10 +31,28 @@ This only needs to be done once per tunnel URL pattern.
 ```bash
 # Terminal 1: Start a tunnel to your MCP server
 ngrok http 8000
-
-# Terminal 2: Run live tests
-pnpm test:live
 ```
+
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    # Terminal 2: Run live tests
+    pnpm test:live
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    # Terminal 2: Run live tests
+    npm run test:live
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    # Terminal 2: Run live tests
+    yarn test:live
+    ```
+  </Tab>
+</Tabs>
 
 The test runner:
 1. Imports your ChatGPT session from your browser (Chrome, Arc, Brave, or Edge). Falls back to a manual login window if no session is found. Sessions typically last a few hours — Cloudflare's HttpOnly `cf_clearance` cookie cannot be persisted, so re-authentication is needed when it expires.

--- a/docs/testing/overview.mdx
+++ b/docs/testing/overview.mdx
@@ -6,19 +6,16 @@ keywords: ["MCP testing", "MCP server testing", "ChatGPT app testing", "MCP Apps
 
 The sunpeak testing framework tests any MCP server, whether or not you use the sunpeak app framework. It provides four levels of automated testing that cover everything from fast unit checks to live host validation and multi-model eval runs.
 
-## Standalone Usage
+## Quickstart
 
-You do not need to build your MCP server with sunpeak to use the testing framework. Point it at any MCP server URL:
+No sunpeak project required. Scaffold tests for any running MCP server:
 
 ```bash
-# Scaffold test infrastructure for an existing MCP server
-sunpeak test init
-
-# Launch the inspector against any MCP server
-sunpeak inspect --server http://localhost:8000/mcp
+npx sunpeak test init --server http://localhost:8000/mcp
+npx sunpeak test
 ```
 
-`sunpeak test init` generates the test directory structure, Playwright configs, example specs, and eval boilerplate. From there, configure `defineConfig()` with your server URL and write tests against your tools and resources.
+This generates test infrastructure (Playwright configs, E2E specs, visual regression, eval boilerplate) and runs the scaffolded smoke test. See [Getting Started](/testing/getting-started) for the full setup walkthrough, including language-specific tips for Python, Go, and Rust servers.
 
 For sunpeak framework projects, the dev server starts automatically and no server URL is needed.
 

--- a/docs/testing/overview.mdx
+++ b/docs/testing/overview.mdx
@@ -79,10 +79,10 @@ Flags are additive: `--unit --e2e --live --eval` runs all four.
 
 ## Scaffolding
 
-For existing MCP servers (not built with sunpeak), run `sunpeak test init` to generate all the test infrastructure:
+For existing MCP servers (not built with sunpeak), run `npx sunpeak test init` to generate all the test infrastructure:
 
 ```bash
-sunpeak test init
+npx sunpeak test init
 ```
 
 For JS/TS projects, this creates files at the project root:

--- a/docs/testing/unit.mdx
+++ b/docs/testing/unit.mdx
@@ -8,10 +8,26 @@ keywords: ["MCP app testing", "unit testing", "Vitest", "happy-dom", "React test
 
 Unit tests run your component and hook logic in isolation using Vitest with happy-dom. They're fast, don't require the inspector or a browser, and are included in the default `sunpeak test` run.
 
-```bash
-pnpm test                    # Run unit + e2e tests
-pnpm test:unit               # Unit tests only
-```
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm test                    # Run unit + e2e tests
+    pnpm test:unit               # Unit tests only
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm run test                    # Run unit + e2e tests
+    npm run test:unit               # Unit tests only
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn test                    # Run unit + e2e tests
+    yarn test:unit               # Unit tests only
+    ```
+  </Tab>
+</Tabs>
 
 ## Setup
 
@@ -110,9 +126,23 @@ Unit tests and E2E tests are complementary. Unit tests catch logic bugs fast. [E
 
 <AccordionGroup>
   <Accordion title="Linting (ESLint)">
-    ```bash
-    pnpm add -D eslint @typescript-eslint/eslint-plugin
-    ```
+    <Tabs>
+      <Tab title="pnpm">
+        ```bash
+        pnpm add -D eslint @typescript-eslint/eslint-plugin
+        ```
+      </Tab>
+      <Tab title="npm">
+        ```bash
+        npm install -D eslint @typescript-eslint/eslint-plugin
+        ```
+      </Tab>
+      <Tab title="yarn">
+        ```bash
+        yarn add -D eslint @typescript-eslint/eslint-plugin
+        ```
+      </Tab>
+    </Tabs>
     Add `"lint": "eslint . --ext .ts,.tsx"` to package.json scripts.
   </Accordion>
 
@@ -124,9 +154,23 @@ Unit tests and E2E tests are complementary. Unit tests catch logic bugs fast. [E
   </Accordion>
 
   <Accordion title="Formatting (Prettier)">
-    ```bash
-    pnpm add -D prettier
-    ```
+    <Tabs>
+      <Tab title="pnpm">
+        ```bash
+        pnpm add -D prettier
+        ```
+      </Tab>
+      <Tab title="npm">
+        ```bash
+        npm install -D prettier
+        ```
+      </Tab>
+      <Tab title="yarn">
+        ```bash
+        yarn add -D prettier
+        ```
+      </Tab>
+    </Tabs>
     Add `"format": "prettier --write ."` to package.json scripts.
   </Accordion>
 </AccordionGroup>

--- a/docs/testing/unit.mdx
+++ b/docs/testing/unit.mdx
@@ -9,8 +9,8 @@ keywords: ["MCP app testing", "unit testing", "Vitest", "happy-dom", "React test
 Unit tests run your component and hook logic in isolation using Vitest with happy-dom. They're fast, don't require the inspector or a browser, and are included in the default `sunpeak test` run.
 
 ```bash
-sunpeak test                    # Run unit + e2e tests
-sunpeak test --unit             # Unit tests only
+pnpm test                    # Run unit + e2e tests
+pnpm test:unit               # Unit tests only
 ```
 
 ## Setup
@@ -19,9 +19,23 @@ Unit tests live in `tests/unit/` (or any `*.test.ts` / `*.spec.ts` file matched 
 
 For standalone usage, add Vitest to your project:
 
-```bash
-pnpm add -D vitest @vitest/coverage-v8
-```
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm add -D vitest @vitest/coverage-v8
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm install -D vitest @vitest/coverage-v8
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn add -D vitest @vitest/coverage-v8
+    ```
+  </Tab>
+</Tabs>
 
 ```typescript
 // vitest.config.ts

--- a/docs/testing/visual.mdx
+++ b/docs/testing/visual.mdx
@@ -12,10 +12,26 @@ Screenshot comparisons only run when you pass `--visual`. Without it, `result.sc
 
 ## Running Visual Tests
 
-```bash
-pnpm test:visual                           # Compare against baselines
-pnpm test:visual -- --update               # Update baselines
-```
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm test:visual                           # Compare against baselines
+    pnpm test:visual -- --update               # Update baselines
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm run test:visual                           # Compare against baselines
+    npm run test:visual -- --update               # Update baselines
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn test:visual                           # Compare against baselines
+    yarn test:visual --update                  # Update baselines
+    ```
+  </Tab>
+</Tabs>
 
 ## Writing Visual Tests
 

--- a/docs/testing/visual.mdx
+++ b/docs/testing/visual.mdx
@@ -13,8 +13,8 @@ Screenshot comparisons only run when you pass `--visual`. Without it, `result.sc
 ## Running Visual Tests
 
 ```bash
-sunpeak test --visual                  # Compare against baselines
-sunpeak test --visual --update         # Update baselines
+pnpm test:visual                           # Compare against baselines
+pnpm test:visual -- --update               # Update baselines
 ```
 
 ## Writing Visual Tests

--- a/examples/albums-example/README.md
+++ b/examples/albums-example/README.md
@@ -7,7 +7,7 @@ For an initial overview of your new app and a detailed API reference, refer to t
 ## Quickstart
 
 ```bash
-sunpeak dev
+pnpm dev
 ```
 
 That's it! Edit the resource files in [./src/resources/](./src/resources/) to build your resource UI.
@@ -17,22 +17,20 @@ That's it! Edit the resource files in [./src/resources/](./src/resources/) to bu
 **Testing:**
 
 ```bash
-sunpeak test                      # Run unit + e2e tests.
-sunpeak test --unit               # Run unit tests only (Vitest).
-sunpeak test --e2e                # Run e2e tests only (Playwright).
-sunpeak test --visual             # Run e2e tests with visual regression.
-sunpeak test --visual --update    # Update visual regression baselines.
-sunpeak test --live               # Run live tests against real ChatGPT.
-sunpeak test --eval               # Run evals against multiple LLM models.
+pnpm test                      # Run unit + e2e tests.
+pnpm test:unit                 # Run unit tests only (Vitest).
+pnpm test:e2e                  # Run e2e tests only (Playwright).
+pnpm test:visual               # Run e2e tests with visual regression.
+pnpm test:live                 # Run live tests against real ChatGPT.
+pnpm test:eval                 # Run evals against multiple LLM models.
 ```
 
 **Development and production:**
 
 ```bash
-sunpeak dev               # Start dev server + MCP endpoint.
-sunpeak build             # Build resources and compile tools for production.
-sunpeak start             # Start the production MCP server.
-sunpeak upgrade           # Upgrade sunpeak to latest version.
+pnpm dev               # Start dev server + MCP endpoint.
+pnpm build             # Build resources and compile tools for production.
+pnpm start             # Start the production MCP server.
 ```
 
 E2e tests use the `mcp` fixture from `sunpeak/test` to call tools and assert against rendered UI across ChatGPT and Claude hosts. Unit tests use Vitest with happy-dom.
@@ -42,7 +40,7 @@ E2e tests use the `mcp` fixture from `sunpeak/test` to call tools and assert aga
 1. Install the AI SDK and provider packages: `pnpm add ai @ai-sdk/openai`
 2. Copy `tests/evals/.env.example` to `tests/evals/.env` and add your API keys
 3. Uncomment models in `tests/evals/eval.config.ts`
-4. Run: `sunpeak test --eval`
+4. Run: `pnpm test:eval`
 
 The dev server starts automatically for evals. Each case runs multiple times per model to measure reliability. See the [Evals documentation](https://sunpeak.ai/docs/testing/evals) for details.
 
@@ -68,11 +66,11 @@ sunpeak-app/
 
 ## Testing in ChatGPT
 
-Test your app directly in ChatGPT using the built-in [MCP](https://sunpeak.ai/docs/mcp-apps/mcp/overview) endpoint (starts automatically with `sunpeak dev`):
+Test your app directly in ChatGPT using the built-in [MCP](https://sunpeak.ai/docs/mcp-apps/mcp/overview) endpoint (starts automatically with `pnpm dev`):
 
 ```bash
 # Start the dev server + MCP endpoint.
-sunpeak dev
+pnpm dev
 
 # In another terminal, run a tunnel. For example:
 ngrok http 8000
@@ -108,10 +106,10 @@ The test runner imports your browser session automatically, starts the dev serve
 Build and start your app for production:
 
 ```bash
-sunpeak build && sunpeak start
+pnpm build && pnpm start
 ```
 
-`sunpeak build` creates optimized builds in `dist/`:
+`pnpm build` creates optimized builds in `dist/`:
 
 ```bash
 dist/
@@ -125,12 +123,12 @@ dist/
 └── ...
 ```
 
-`sunpeak start` loads the compiled tools and resources, then starts a production MCP server with real handlers, Zod input validation, and optional auth.
+`pnpm start` loads the compiled tools and resources, then starts a production MCP server with real handlers, Zod input validation, and optional auth.
 
 ```bash
-sunpeak start --port 3000              # Custom port (default: 8000)
-sunpeak start --host 127.0.0.1         # Bind to localhost only
-sunpeak start --json-logs              # Structured JSON logging for production
+pnpm start -- --port 3000              # Custom port (default: 8000)
+pnpm start -- --host 127.0.0.1         # Bind to localhost only
+pnpm start -- --json-logs              # Structured JSON logging for production
 ```
 
 The server includes a `/health` endpoint for load balancer probes and monitoring. See the [Deployment Guide](https://sunpeak.ai/docs/app-framework/guides/deployment) for production operations details (reverse proxy, process management, Docker).
@@ -148,7 +146,7 @@ src/resources/NAME/
 
 Only the resource file (`.tsx`) is required to generate a production build and ship a UI. It must export a `resource` object (`ResourceConfig`) describing the resource metadata, and a React component that renders the UI. The resource name is auto-derived from the directory name.
 
-Then create a tool file in `src/tools/` and simulation file(s) in `tests/simulations/` to preview your resource in `sunpeak dev`.
+Then create a tool file in `src/tools/` and simulation file(s) in `tests/simulations/` to preview your resource in `pnpm dev`.
 
 ## Coding Agent Skills
 
@@ -163,7 +161,7 @@ pnpm dlx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@tes
 If your app doesn't render in ChatGPT or Claude:
 
 1. **Check your tunnel** is running and pointing to the correct port
-2. **Restart `sunpeak dev`** to clear stale connections
+2. **Restart `pnpm dev`** to clear stale connections
 3. **Refresh or re-add the MCP server** in the host's settings (Settings > MCP Servers)
 4. **Hard refresh** the host page (`Cmd+Shift+R` / `Ctrl+Shift+R`)
 5. **Open a new chat** in the host (cached iframes persist per-conversation)

--- a/examples/albums-example/package.json
+++ b/examples/albums-example/package.json
@@ -18,7 +18,7 @@
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",
     "embla-carousel-wheel-gestures": "^8.1.0",
-    "sunpeak": "^0.20.3",
+    "sunpeak": "^0.20.4",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"
   },

--- a/examples/albums-example/package.json
+++ b/examples/albums-example/package.json
@@ -11,7 +11,8 @@
     "test:unit": "sunpeak test --unit",
     "test:e2e": "sunpeak test --e2e",
     "test:visual": "sunpeak test --visual",
-    "test:live": "sunpeak test --live"
+    "test:live": "sunpeak test --live",
+    "test:eval": "sunpeak test --eval"
   },
   "dependencies": {
     "clsx": "^2.1.1",

--- a/examples/carousel-example/README.md
+++ b/examples/carousel-example/README.md
@@ -7,7 +7,7 @@ For an initial overview of your new app and a detailed API reference, refer to t
 ## Quickstart
 
 ```bash
-sunpeak dev
+pnpm dev
 ```
 
 That's it! Edit the resource files in [./src/resources/](./src/resources/) to build your resource UI.
@@ -17,22 +17,20 @@ That's it! Edit the resource files in [./src/resources/](./src/resources/) to bu
 **Testing:**
 
 ```bash
-sunpeak test                      # Run unit + e2e tests.
-sunpeak test --unit               # Run unit tests only (Vitest).
-sunpeak test --e2e                # Run e2e tests only (Playwright).
-sunpeak test --visual             # Run e2e tests with visual regression.
-sunpeak test --visual --update    # Update visual regression baselines.
-sunpeak test --live               # Run live tests against real ChatGPT.
-sunpeak test --eval               # Run evals against multiple LLM models.
+pnpm test                      # Run unit + e2e tests.
+pnpm test:unit                 # Run unit tests only (Vitest).
+pnpm test:e2e                  # Run e2e tests only (Playwright).
+pnpm test:visual               # Run e2e tests with visual regression.
+pnpm test:live                 # Run live tests against real ChatGPT.
+pnpm test:eval                 # Run evals against multiple LLM models.
 ```
 
 **Development and production:**
 
 ```bash
-sunpeak dev               # Start dev server + MCP endpoint.
-sunpeak build             # Build resources and compile tools for production.
-sunpeak start             # Start the production MCP server.
-sunpeak upgrade           # Upgrade sunpeak to latest version.
+pnpm dev               # Start dev server + MCP endpoint.
+pnpm build             # Build resources and compile tools for production.
+pnpm start             # Start the production MCP server.
 ```
 
 E2e tests use the `mcp` fixture from `sunpeak/test` to call tools and assert against rendered UI across ChatGPT and Claude hosts. Unit tests use Vitest with happy-dom.
@@ -42,7 +40,7 @@ E2e tests use the `mcp` fixture from `sunpeak/test` to call tools and assert aga
 1. Install the AI SDK and provider packages: `pnpm add ai @ai-sdk/openai`
 2. Copy `tests/evals/.env.example` to `tests/evals/.env` and add your API keys
 3. Uncomment models in `tests/evals/eval.config.ts`
-4. Run: `sunpeak test --eval`
+4. Run: `pnpm test:eval`
 
 The dev server starts automatically for evals. Each case runs multiple times per model to measure reliability. See the [Evals documentation](https://sunpeak.ai/docs/testing/evals) for details.
 
@@ -68,11 +66,11 @@ sunpeak-app/
 
 ## Testing in ChatGPT
 
-Test your app directly in ChatGPT using the built-in [MCP](https://sunpeak.ai/docs/mcp-apps/mcp/overview) endpoint (starts automatically with `sunpeak dev`):
+Test your app directly in ChatGPT using the built-in [MCP](https://sunpeak.ai/docs/mcp-apps/mcp/overview) endpoint (starts automatically with `pnpm dev`):
 
 ```bash
 # Start the dev server + MCP endpoint.
-sunpeak dev
+pnpm dev
 
 # In another terminal, run a tunnel. For example:
 ngrok http 8000
@@ -108,10 +106,10 @@ The test runner imports your browser session automatically, starts the dev serve
 Build and start your app for production:
 
 ```bash
-sunpeak build && sunpeak start
+pnpm build && pnpm start
 ```
 
-`sunpeak build` creates optimized builds in `dist/`:
+`pnpm build` creates optimized builds in `dist/`:
 
 ```bash
 dist/
@@ -125,12 +123,12 @@ dist/
 └── ...
 ```
 
-`sunpeak start` loads the compiled tools and resources, then starts a production MCP server with real handlers, Zod input validation, and optional auth.
+`pnpm start` loads the compiled tools and resources, then starts a production MCP server with real handlers, Zod input validation, and optional auth.
 
 ```bash
-sunpeak start --port 3000              # Custom port (default: 8000)
-sunpeak start --host 127.0.0.1         # Bind to localhost only
-sunpeak start --json-logs              # Structured JSON logging for production
+pnpm start -- --port 3000              # Custom port (default: 8000)
+pnpm start -- --host 127.0.0.1         # Bind to localhost only
+pnpm start -- --json-logs              # Structured JSON logging for production
 ```
 
 The server includes a `/health` endpoint for load balancer probes and monitoring. See the [Deployment Guide](https://sunpeak.ai/docs/app-framework/guides/deployment) for production operations details (reverse proxy, process management, Docker).
@@ -148,7 +146,7 @@ src/resources/NAME/
 
 Only the resource file (`.tsx`) is required to generate a production build and ship a UI. It must export a `resource` object (`ResourceConfig`) describing the resource metadata, and a React component that renders the UI. The resource name is auto-derived from the directory name.
 
-Then create a tool file in `src/tools/` and simulation file(s) in `tests/simulations/` to preview your resource in `sunpeak dev`.
+Then create a tool file in `src/tools/` and simulation file(s) in `tests/simulations/` to preview your resource in `pnpm dev`.
 
 ## Coding Agent Skills
 
@@ -163,7 +161,7 @@ pnpm dlx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@tes
 If your app doesn't render in ChatGPT or Claude:
 
 1. **Check your tunnel** is running and pointing to the correct port
-2. **Restart `sunpeak dev`** to clear stale connections
+2. **Restart `pnpm dev`** to clear stale connections
 3. **Refresh or re-add the MCP server** in the host's settings (Settings > MCP Servers)
 4. **Hard refresh** the host page (`Cmd+Shift+R` / `Ctrl+Shift+R`)
 5. **Open a new chat** in the host (cached iframes persist per-conversation)

--- a/examples/carousel-example/package.json
+++ b/examples/carousel-example/package.json
@@ -18,7 +18,7 @@
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",
     "embla-carousel-wheel-gestures": "^8.1.0",
-    "sunpeak": "^0.20.3",
+    "sunpeak": "^0.20.4",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"
   },

--- a/examples/carousel-example/package.json
+++ b/examples/carousel-example/package.json
@@ -11,7 +11,8 @@
     "test:unit": "sunpeak test --unit",
     "test:e2e": "sunpeak test --e2e",
     "test:visual": "sunpeak test --visual",
-    "test:live": "sunpeak test --live"
+    "test:live": "sunpeak test --live",
+    "test:eval": "sunpeak test --eval"
   },
   "dependencies": {
     "clsx": "^2.1.1",

--- a/examples/map-example/README.md
+++ b/examples/map-example/README.md
@@ -7,7 +7,7 @@ For an initial overview of your new app and a detailed API reference, refer to t
 ## Quickstart
 
 ```bash
-sunpeak dev
+pnpm dev
 ```
 
 That's it! Edit the resource files in [./src/resources/](./src/resources/) to build your resource UI.
@@ -17,22 +17,20 @@ That's it! Edit the resource files in [./src/resources/](./src/resources/) to bu
 **Testing:**
 
 ```bash
-sunpeak test                      # Run unit + e2e tests.
-sunpeak test --unit               # Run unit tests only (Vitest).
-sunpeak test --e2e                # Run e2e tests only (Playwright).
-sunpeak test --visual             # Run e2e tests with visual regression.
-sunpeak test --visual --update    # Update visual regression baselines.
-sunpeak test --live               # Run live tests against real ChatGPT.
-sunpeak test --eval               # Run evals against multiple LLM models.
+pnpm test                      # Run unit + e2e tests.
+pnpm test:unit                 # Run unit tests only (Vitest).
+pnpm test:e2e                  # Run e2e tests only (Playwright).
+pnpm test:visual               # Run e2e tests with visual regression.
+pnpm test:live                 # Run live tests against real ChatGPT.
+pnpm test:eval                 # Run evals against multiple LLM models.
 ```
 
 **Development and production:**
 
 ```bash
-sunpeak dev               # Start dev server + MCP endpoint.
-sunpeak build             # Build resources and compile tools for production.
-sunpeak start             # Start the production MCP server.
-sunpeak upgrade           # Upgrade sunpeak to latest version.
+pnpm dev               # Start dev server + MCP endpoint.
+pnpm build             # Build resources and compile tools for production.
+pnpm start             # Start the production MCP server.
 ```
 
 E2e tests use the `mcp` fixture from `sunpeak/test` to call tools and assert against rendered UI across ChatGPT and Claude hosts. Unit tests use Vitest with happy-dom.
@@ -42,7 +40,7 @@ E2e tests use the `mcp` fixture from `sunpeak/test` to call tools and assert aga
 1. Install the AI SDK and provider packages: `pnpm add ai @ai-sdk/openai`
 2. Copy `tests/evals/.env.example` to `tests/evals/.env` and add your API keys
 3. Uncomment models in `tests/evals/eval.config.ts`
-4. Run: `sunpeak test --eval`
+4. Run: `pnpm test:eval`
 
 The dev server starts automatically for evals. Each case runs multiple times per model to measure reliability. See the [Evals documentation](https://sunpeak.ai/docs/testing/evals) for details.
 
@@ -68,11 +66,11 @@ sunpeak-app/
 
 ## Testing in ChatGPT
 
-Test your app directly in ChatGPT using the built-in [MCP](https://sunpeak.ai/docs/mcp-apps/mcp/overview) endpoint (starts automatically with `sunpeak dev`):
+Test your app directly in ChatGPT using the built-in [MCP](https://sunpeak.ai/docs/mcp-apps/mcp/overview) endpoint (starts automatically with `pnpm dev`):
 
 ```bash
 # Start the dev server + MCP endpoint.
-sunpeak dev
+pnpm dev
 
 # In another terminal, run a tunnel. For example:
 ngrok http 8000
@@ -108,10 +106,10 @@ The test runner imports your browser session automatically, starts the dev serve
 Build and start your app for production:
 
 ```bash
-sunpeak build && sunpeak start
+pnpm build && pnpm start
 ```
 
-`sunpeak build` creates optimized builds in `dist/`:
+`pnpm build` creates optimized builds in `dist/`:
 
 ```bash
 dist/
@@ -125,12 +123,12 @@ dist/
 └── ...
 ```
 
-`sunpeak start` loads the compiled tools and resources, then starts a production MCP server with real handlers, Zod input validation, and optional auth.
+`pnpm start` loads the compiled tools and resources, then starts a production MCP server with real handlers, Zod input validation, and optional auth.
 
 ```bash
-sunpeak start --port 3000              # Custom port (default: 8000)
-sunpeak start --host 127.0.0.1         # Bind to localhost only
-sunpeak start --json-logs              # Structured JSON logging for production
+pnpm start -- --port 3000              # Custom port (default: 8000)
+pnpm start -- --host 127.0.0.1         # Bind to localhost only
+pnpm start -- --json-logs              # Structured JSON logging for production
 ```
 
 The server includes a `/health` endpoint for load balancer probes and monitoring. See the [Deployment Guide](https://sunpeak.ai/docs/app-framework/guides/deployment) for production operations details (reverse proxy, process management, Docker).
@@ -148,7 +146,7 @@ src/resources/NAME/
 
 Only the resource file (`.tsx`) is required to generate a production build and ship a UI. It must export a `resource` object (`ResourceConfig`) describing the resource metadata, and a React component that renders the UI. The resource name is auto-derived from the directory name.
 
-Then create a tool file in `src/tools/` and simulation file(s) in `tests/simulations/` to preview your resource in `sunpeak dev`.
+Then create a tool file in `src/tools/` and simulation file(s) in `tests/simulations/` to preview your resource in `pnpm dev`.
 
 ## Coding Agent Skills
 
@@ -163,7 +161,7 @@ pnpm dlx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@tes
 If your app doesn't render in ChatGPT or Claude:
 
 1. **Check your tunnel** is running and pointing to the correct port
-2. **Restart `sunpeak dev`** to clear stale connections
+2. **Restart `pnpm dev`** to clear stale connections
 3. **Refresh or re-add the MCP server** in the host's settings (Settings > MCP Servers)
 4. **Hard refresh** the host page (`Cmd+Shift+R` / `Ctrl+Shift+R`)
 5. **Open a new chat** in the host (cached iframes persist per-conversation)

--- a/examples/map-example/package.json
+++ b/examples/map-example/package.json
@@ -18,7 +18,7 @@
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",
     "mapbox-gl": "^3.21.0",
-    "sunpeak": "^0.20.3",
+    "sunpeak": "^0.20.4",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"
   },

--- a/examples/map-example/package.json
+++ b/examples/map-example/package.json
@@ -11,7 +11,8 @@
     "test:unit": "sunpeak test --unit",
     "test:e2e": "sunpeak test --e2e",
     "test:visual": "sunpeak test --visual",
-    "test:live": "sunpeak test --live"
+    "test:live": "sunpeak test --live",
+    "test:eval": "sunpeak test --eval"
   },
   "dependencies": {
     "clsx": "^2.1.1",

--- a/examples/review-example/README.md
+++ b/examples/review-example/README.md
@@ -7,7 +7,7 @@ For an initial overview of your new app and a detailed API reference, refer to t
 ## Quickstart
 
 ```bash
-sunpeak dev
+pnpm dev
 ```
 
 That's it! Edit the resource files in [./src/resources/](./src/resources/) to build your resource UI.
@@ -17,22 +17,20 @@ That's it! Edit the resource files in [./src/resources/](./src/resources/) to bu
 **Testing:**
 
 ```bash
-sunpeak test                      # Run unit + e2e tests.
-sunpeak test --unit               # Run unit tests only (Vitest).
-sunpeak test --e2e                # Run e2e tests only (Playwright).
-sunpeak test --visual             # Run e2e tests with visual regression.
-sunpeak test --visual --update    # Update visual regression baselines.
-sunpeak test --live               # Run live tests against real ChatGPT.
-sunpeak test --eval               # Run evals against multiple LLM models.
+pnpm test                      # Run unit + e2e tests.
+pnpm test:unit                 # Run unit tests only (Vitest).
+pnpm test:e2e                  # Run e2e tests only (Playwright).
+pnpm test:visual               # Run e2e tests with visual regression.
+pnpm test:live                 # Run live tests against real ChatGPT.
+pnpm test:eval                 # Run evals against multiple LLM models.
 ```
 
 **Development and production:**
 
 ```bash
-sunpeak dev               # Start dev server + MCP endpoint.
-sunpeak build             # Build resources and compile tools for production.
-sunpeak start             # Start the production MCP server.
-sunpeak upgrade           # Upgrade sunpeak to latest version.
+pnpm dev               # Start dev server + MCP endpoint.
+pnpm build             # Build resources and compile tools for production.
+pnpm start             # Start the production MCP server.
 ```
 
 E2e tests use the `mcp` fixture from `sunpeak/test` to call tools and assert against rendered UI across ChatGPT and Claude hosts. Unit tests use Vitest with happy-dom.
@@ -42,7 +40,7 @@ E2e tests use the `mcp` fixture from `sunpeak/test` to call tools and assert aga
 1. Install the AI SDK and provider packages: `pnpm add ai @ai-sdk/openai`
 2. Copy `tests/evals/.env.example` to `tests/evals/.env` and add your API keys
 3. Uncomment models in `tests/evals/eval.config.ts`
-4. Run: `sunpeak test --eval`
+4. Run: `pnpm test:eval`
 
 The dev server starts automatically for evals. Each case runs multiple times per model to measure reliability. See the [Evals documentation](https://sunpeak.ai/docs/testing/evals) for details.
 
@@ -68,11 +66,11 @@ sunpeak-app/
 
 ## Testing in ChatGPT
 
-Test your app directly in ChatGPT using the built-in [MCP](https://sunpeak.ai/docs/mcp-apps/mcp/overview) endpoint (starts automatically with `sunpeak dev`):
+Test your app directly in ChatGPT using the built-in [MCP](https://sunpeak.ai/docs/mcp-apps/mcp/overview) endpoint (starts automatically with `pnpm dev`):
 
 ```bash
 # Start the dev server + MCP endpoint.
-sunpeak dev
+pnpm dev
 
 # In another terminal, run a tunnel. For example:
 ngrok http 8000
@@ -108,10 +106,10 @@ The test runner imports your browser session automatically, starts the dev serve
 Build and start your app for production:
 
 ```bash
-sunpeak build && sunpeak start
+pnpm build && pnpm start
 ```
 
-`sunpeak build` creates optimized builds in `dist/`:
+`pnpm build` creates optimized builds in `dist/`:
 
 ```bash
 dist/
@@ -125,12 +123,12 @@ dist/
 └── ...
 ```
 
-`sunpeak start` loads the compiled tools and resources, then starts a production MCP server with real handlers, Zod input validation, and optional auth.
+`pnpm start` loads the compiled tools and resources, then starts a production MCP server with real handlers, Zod input validation, and optional auth.
 
 ```bash
-sunpeak start --port 3000              # Custom port (default: 8000)
-sunpeak start --host 127.0.0.1         # Bind to localhost only
-sunpeak start --json-logs              # Structured JSON logging for production
+pnpm start -- --port 3000              # Custom port (default: 8000)
+pnpm start -- --host 127.0.0.1         # Bind to localhost only
+pnpm start -- --json-logs              # Structured JSON logging for production
 ```
 
 The server includes a `/health` endpoint for load balancer probes and monitoring. See the [Deployment Guide](https://sunpeak.ai/docs/app-framework/guides/deployment) for production operations details (reverse proxy, process management, Docker).
@@ -148,7 +146,7 @@ src/resources/NAME/
 
 Only the resource file (`.tsx`) is required to generate a production build and ship a UI. It must export a `resource` object (`ResourceConfig`) describing the resource metadata, and a React component that renders the UI. The resource name is auto-derived from the directory name.
 
-Then create a tool file in `src/tools/` and simulation file(s) in `tests/simulations/` to preview your resource in `sunpeak dev`.
+Then create a tool file in `src/tools/` and simulation file(s) in `tests/simulations/` to preview your resource in `pnpm dev`.
 
 ## Coding Agent Skills
 
@@ -163,7 +161,7 @@ pnpm dlx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@tes
 If your app doesn't render in ChatGPT or Claude:
 
 1. **Check your tunnel** is running and pointing to the correct port
-2. **Restart `sunpeak dev`** to clear stale connections
+2. **Restart `pnpm dev`** to clear stale connections
 3. **Refresh or re-add the MCP server** in the host's settings (Settings > MCP Servers)
 4. **Hard refresh** the host page (`Cmd+Shift+R` / `Ctrl+Shift+R`)
 5. **Open a new chat** in the host (cached iframes persist per-conversation)

--- a/examples/review-example/package.json
+++ b/examples/review-example/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
-    "sunpeak": "^0.20.3",
+    "sunpeak": "^0.20.4",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"
   },

--- a/examples/review-example/package.json
+++ b/examples/review-example/package.json
@@ -11,7 +11,8 @@
     "test:unit": "sunpeak test --unit",
     "test:e2e": "sunpeak test --e2e",
     "test:visual": "sunpeak test --visual",
-    "test:live": "sunpeak test --live"
+    "test:live": "sunpeak test --live",
+    "test:eval": "sunpeak test --eval"
   },
   "dependencies": {
     "clsx": "^2.1.1",

--- a/packages/sunpeak/README.md
+++ b/packages/sunpeak/README.md
@@ -16,7 +16,13 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue?style=flat&logo=typescript&label=ts&color=FFB800&logoColor=white&labelColor=000035)](https://www.typescriptlang.org/)
 [![React](https://img.shields.io/badge/React-19-blue?style=flat&logo=react&label=react&color=FFB800&logoColor=white&labelColor=000035)](https://reactjs.org/)
 
-Inspector, testing framework, and runtime framework for MCP servers and MCP Apps.
+Inspector, testing framework, and App framework for MCP servers and MCP Apps.
+
+Build cross-platform: MCP App framework, ChatGPT App framework, and Claude Connector framework.
+
+```bash
+npx sunpeak new
+```
 
 [Demo (Hosted)](https://sunpeak.ai/inspector) ~
 [Demo (Video)](https://cdn.sunpeak.ai/sunpeak-demo-prod.mp4) ~
@@ -28,10 +34,12 @@ Inspector, testing framework, and runtime framework for MCP servers and MCP Apps
 
 ### 1. Inspector
 
-Manually test any MCP server in replicated ChatGPT and Claude runtimes.
+MCP servers are opaque. You can call tools and read the JSON responses, but you can't see how your app actually looks and behaves inside ChatGPT or Claude without deploying to each host, setting up a tunnel, paying for accounts, and manually refreshing through a multi-step cycle on every code change.
+
+The sunpeak inspector replicates the ChatGPT and Claude app runtimes locally. Point it at any MCP server and see your tools and resources rendered the same way they appear in production hosts.
 
 ```bash
-sunpeak inspect --server http://localhost:8000/mcp
+npx sunpeak inspect --server http://localhost:8000/mcp
 ```
 
 <div align="center">
@@ -42,110 +50,71 @@ sunpeak inspect --server http://localhost:8000/mcp
   </a>
 </div>
 
-- Multi-host inspector replicating ChatGPT and Claude runtimes
-- Toggle themes, display modes, device types from the sidebar or URL params
-- Call real tool handlers or use simulation fixtures for mock data
+Toggle between hosts, themes, display modes, and device types from the sidebar. Call real tool handlers or load simulation fixtures for deterministic mock data. Changes reflect instantly via HMR. Works with any MCP server in any language.
+
+[Inspector documentation →](https://sunpeak.ai/docs/mcp-apps-inspector)
+
+---
 
 ### 2. Testing Framework
 
-Automatically test any MCP server against replicated ChatGPT and Claude runtimes.
+MCP Apps render inside host iframes with host-specific themes, display modes, and capabilities. Standard browser testing can't replicate this because the runtime environment only exists inside ChatGPT and Claude. Each app also has many dimensions of state: tool inputs, tool results, server tool responses, host context, and display configuration. Testing all combinations manually is slow and error-prone.
+
+sunpeak replicates these host runtimes and provides simulation fixtures (JSON files that define reproducible tool states) so you can test every combination of host, theme, and data in CI without accounts or API credits.
+
+```bash
+npx sunpeak test
+```
+
+This scaffolds **E2E tests, visual regression, live host tests, and multi-model evals**. Then run them:
+
+```bash
+npx sunpeak test
+```
+
+Playwright fixtures handle inspector startup, MCP connection, iframe traversal, and host switching. Works with Python, Go, TypeScript, Rust, or any language.
 
 ```ts
 import { test, expect } from 'sunpeak/test';
 
-test('review tool renders title', async ({ inspector }) => {
-  const result = await inspector.renderTool('review-diff');
-  const app = result.app();
-  await expect(app.locator('h1:has-text("Refactor")')).toBeVisible();
+test('search tool returns results', async ({ mcp }) => {
+  const result = await mcp.callTool('search', { query: 'headphones' });
+  expect(result.isError).toBeFalsy();
+});
+
+test('album cards render', async ({ inspector }) => {
+  const result = await inspector.renderTool('show-albums');
+  await expect(result.app().locator('button:has-text("Summer Slice")')).toBeVisible();
 });
 ```
 
-- **Works for any MCP server**: `sunpeak test init` scaffolds tests for Python, Go, TS, or any language
-- **MCP-native assertions**: `toBeError()`, `toHaveTextContent()`, `toHaveStructuredContent()`
-- **Multi-host**: Tests run against ChatGPT and Claude hosts automatically
-- **Live tests**: Automated browser tests against real ChatGPT via `sunpeak/test/live`
-- **Evals**: Test your tool interface design against multiple LLMs (GPT-4o, Claude, Gemini, etc.) via `sunpeak/eval`
+[Testing documentation →](https://sunpeak.ai/docs/testing/overview)
+
+---
 
 ### 3. App Framework
 
-Next.js for MCP Apps. Convention-over-configuration project structure with the inspector and testing built in.
+Building an MCP App from scratch means wiring up an MCP server, handling protocol message routing, managing resource HTML bundles, and setting up a dev environment with hot reload. Each host has different capabilities and CSS variables, so you end up writing platform-specific code without a clear structure.
+
+sunpeak gives you a convention-over-configuration framework with the inspector and testing built in.
 
 ```bash
-sunpeak-app/
-├── src/
-│   ├── resources/
-│   │   └── review/
-│   │       └── review.tsx            # Review UI component + resource metadata.
-│   ├── tools/
-│   │   ├── review-diff.ts            # Tool with handler, schema, and optional resource link.
-│   │   ├── review-post.ts            # Multiple tools can share one resource.
-│   │   └── review.ts                 # Backend-only tool (no resource, no UI).
-│   └── server.ts                     # Optional: auth, server config.
-├── tests/simulations/
-│   ├── review-diff.json              # Mock state for testing (includes serverTools).
-│   ├── review-post.json              # Mock state for testing (includes serverTools).
-│   └── review-purchase.json          # Mock state for testing (includes serverTools).
+npx sunpeak new
+```
+
+This creates a project, starts a dev server with HMR, and opens the inspector at `localhost:3000`:
+
+```
+my-app/
+├── src/resources/review/review.tsx    # UI component (React)
+├── src/tools/review-diff.ts           # Tool handler, schema, resource link
+├── tests/simulations/review-diff.json # Mock data for the inspector
 └── package.json
 ```
 
-- **Runtime APIs**: Strongly typed React hooks (`useToolData`, `useAppState`, `useHostContext`, etc.)
-- **Convention over configuration**: Resources, tools, and simulations are auto-discovered
-- **Multi-platform**: Build once, deploy to ChatGPT, Claude, and future hosts
+Tools, resources, and simulations are auto-discovered from the file system. Multi-platform React hooks (`useToolData`, `useAppState`, `useTheme`, `useDisplayMode`) let you write your app logic once and deploy it across ChatGPT, Claude, and future hosts.
 
-## Quickstart
-
-Requirements: Node (20+), pnpm (10+)
-
-```bash
-pnpm add -g sunpeak
-sunpeak new
-```
-
-## CLI
-
-**Testing** (works with any MCP server):
-
-| Command                               | Description                                 |
-| ------------------------------------- | ------------------------------------------- |
-| `sunpeak inspect --server <url\|cmd>` | Inspect any MCP server in the inspector     |
-| `sunpeak test`                        | Run unit + e2e tests                        |
-| `sunpeak test --unit`                 | Run unit tests only (Vitest)                |
-| `sunpeak test --e2e`                  | Run e2e tests only (Playwright)             |
-| `sunpeak test --visual`               | Run e2e tests with visual regression        |
-| `sunpeak test --visual --update`      | Update visual regression baselines          |
-| `sunpeak test --live`                 | Run live tests against real hosts           |
-| `sunpeak test --eval`                 | Run evals against multiple LLM models       |
-| `sunpeak test init`                   | Scaffold test infrastructure into a project |
-
-**App framework** (for sunpeak projects):
-
-| Command                          | Description                                 |
-| -------------------------------- | ------------------------------------------- |
-| `sunpeak new [name] [resources]` | Create a new project                        |
-| `sunpeak dev`                    | Start dev server + inspector + MCP endpoint |
-| `sunpeak build`                  | Build resources + tools for production      |
-| `sunpeak start`                  | Start production MCP server                 |
-| `sunpeak upgrade`                | Upgrade sunpeak to latest version           |
-
-## Coding Agent Skills
-
-Install the sunpeak skills to give your coding agent (Claude Code, Cursor, etc.) built-in knowledge of sunpeak patterns, hooks, and testing:
-
-```bash
-pnpm dlx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@test-mcp-server
-```
-
-## Troubleshooting
-
-If your app doesn't render in ChatGPT or Claude:
-
-1. **Check your tunnel** is running and pointing to the correct port
-2. **Restart `sunpeak dev`** to clear stale connections
-3. **Refresh or re-add the MCP server** in the host's settings (Settings > MCP Servers)
-4. **Hard refresh** the host page (`Cmd+Shift+R` / `Ctrl+Shift+R`)
-5. **Open a new chat** in the host (cached iframes persist per-conversation)
-
-Full guide: [sunpeak.ai/docs/app-framework/guides/troubleshooting](https://sunpeak.ai/docs/app-framework/guides/troubleshooting)
+[App framework documentation →](https://sunpeak.ai/docs/mcp-apps-framework)
 
 ## Resources
 
@@ -153,3 +122,4 @@ Full guide: [sunpeak.ai/docs/app-framework/guides/troubleshooting](https://sunpe
 - [MCP Overview](https://sunpeak.ai/docs/mcp-apps/mcp/overview) · [Tools](https://sunpeak.ai/docs/mcp-apps/mcp/tools) · [Resources](https://sunpeak.ai/docs/mcp-apps/mcp/resources)
 - [MCP Apps SDK](https://github.com/modelcontextprotocol/ext-apps)
 - [ChatGPT Apps SDK Design Guidelines](https://developers.openai.com/apps-sdk/concepts/design-guidelines)
+- [Troubleshooting](https://sunpeak.ai/docs/app-framework/guides/troubleshooting)

--- a/packages/sunpeak/README.md
+++ b/packages/sunpeak/README.md
@@ -16,7 +16,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue?style=flat&logo=typescript&label=ts&color=FFB800&logoColor=white&labelColor=000035)](https://www.typescriptlang.org/)
 [![React](https://img.shields.io/badge/React-19-blue?style=flat&logo=react&label=react&color=FFB800&logoColor=white&labelColor=000035)](https://reactjs.org/)
 
-Inspector, testing framework, and App framework for MCP servers and MCP Apps.
+App framework, testing framework, and inspector for MCP servers and MCP Apps.
 
 Build cross-platform: MCP App framework, ChatGPT App framework, and Claude Connector framework.
 
@@ -32,27 +32,29 @@ npx sunpeak new
 
 ## sunpeak is three things
 
-### 1. Inspector
+### 1. App Framework
 
-MCP servers are opaque. You can call tools and read the JSON responses, but you can't see how your app actually looks and behaves inside ChatGPT or Claude without deploying to each host, setting up a tunnel, paying for accounts, and manually refreshing through a multi-step cycle on every code change.
+Building an MCP App from scratch means wiring up an MCP server, handling protocol message routing, managing resource HTML bundles, and setting up a dev environment with hot reload. Each host has different capabilities and CSS variables, so you end up writing platform-specific code without a clear structure.
 
-The sunpeak inspector replicates the ChatGPT and Claude app runtimes locally. Point it at any MCP server and see your tools and resources rendered the same way they appear in production hosts.
+sunpeak gives you a convention-over-configuration framework with the inspector and testing built in.
 
 ```bash
-npx sunpeak inspect --server http://localhost:8000/mcp
+npx sunpeak new
 ```
 
-<div align="center">
-  <a href="https://sunpeak.ai/docs/mcp-apps-inspector">
-    <picture>
-      <img alt="Inspector" src="https://cdn.sunpeak.ai/chatgpt-simulator.png">
-    </picture>
-  </a>
-</div>
+This creates a project, starts a dev server with HMR, and opens the inspector at `localhost:3000`:
 
-Toggle between hosts, themes, display modes, and device types from the sidebar. Call real tool handlers or load simulation fixtures for deterministic mock data. Changes reflect instantly via HMR. Works with any MCP server in any language.
+```
+sunpeak-app/
+├── src/resources/review/review.tsx    # UI component (React)
+├── src/tools/review-diff.ts           # Tool handler, schema, resource link
+├── tests/simulations/review-diff.json # Mock data for the inspector
+└── package.json
+```
 
-[Inspector documentation →](https://sunpeak.ai/docs/mcp-apps-inspector)
+Tools, resources, and simulations are auto-discovered from the file system. Multi-platform React hooks (`useToolData`, `useAppState`, `useTheme`, `useDisplayMode`) let you write your app logic once and deploy it across ChatGPT, Claude, and future hosts.
+
+[App framework documentation →](https://sunpeak.ai/docs/mcp-apps-framework)
 
 ---
 
@@ -63,10 +65,10 @@ MCP Apps render inside host iframes with host-specific themes, display modes, an
 sunpeak replicates these host runtimes and provides simulation fixtures (JSON files that define reproducible tool states) so you can test every combination of host, theme, and data in CI without accounts or API credits.
 
 ```bash
-npx sunpeak test
+npx sunpeak test init --server http://localhost:8000/mcp
 ```
 
-This scaffolds **E2E tests, visual regression, live host tests, and multi-model evals**. Then run them:
+This scaffolds E2E tests, visual regression, live host tests, and multi-model evals. Then run them:
 
 ```bash
 npx sunpeak test
@@ -92,29 +94,27 @@ test('album cards render', async ({ inspector }) => {
 
 ---
 
-### 3. App Framework
+### 3. Inspector
 
-Building an MCP App from scratch means wiring up an MCP server, handling protocol message routing, managing resource HTML bundles, and setting up a dev environment with hot reload. Each host has different capabilities and CSS variables, so you end up writing platform-specific code without a clear structure.
+MCP servers are opaque. You can call tools and read the JSON responses, but you can't see how your app actually looks and behaves inside ChatGPT or Claude without deploying to each host, setting up a tunnel, paying for accounts, and manually refreshing through a multi-step cycle on every code change.
 
-sunpeak gives you a convention-over-configuration framework with the inspector and testing built in.
+The sunpeak inspector replicates the ChatGPT and Claude app runtimes locally. Point it at any MCP server and see your tools and resources rendered the same way they appear in production hosts.
 
 ```bash
-npx sunpeak new
+npx sunpeak inspect --server http://localhost:8000/mcp
 ```
 
-This creates a project, starts a dev server with HMR, and opens the inspector at `localhost:3000`:
+<div align="center">
+  <a href="https://sunpeak.ai/docs/mcp-apps-inspector">
+    <picture>
+      <img alt="Inspector" src="https://cdn.sunpeak.ai/chatgpt-simulator.png">
+    </picture>
+  </a>
+</div>
 
-```
-sunpeak-app/
-├── src/resources/review/review.tsx    # UI component (React)
-├── src/tools/review-diff.ts           # Tool handler, schema, resource link
-├── tests/simulations/review-diff.json # Mock data for the inspector
-└── package.json
-```
+Toggle between hosts, themes, display modes, and device types from the sidebar. Call real tool handlers or load simulation fixtures for deterministic mock data. Changes reflect instantly via HMR. Works with any MCP server in any language.
 
-Tools, resources, and simulations are auto-discovered from the file system. Multi-platform React hooks (`useToolData`, `useAppState`, `useTheme`, `useDisplayMode`) let you write your app logic once and deploy it across ChatGPT, Claude, and future hosts.
-
-[App framework documentation →](https://sunpeak.ai/docs/mcp-apps-framework)
+[Inspector documentation →](https://sunpeak.ai/docs/mcp-apps-inspector)
 
 ## Resources
 

--- a/packages/sunpeak/README.md
+++ b/packages/sunpeak/README.md
@@ -16,9 +16,9 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue?style=flat&logo=typescript&label=ts&color=FFB800&logoColor=white&labelColor=000035)](https://www.typescriptlang.org/)
 [![React](https://img.shields.io/badge/React-19-blue?style=flat&logo=react&label=react&color=FFB800&logoColor=white&labelColor=000035)](https://reactjs.org/)
 
-App framework, testing framework, and inspector for MCP servers and MCP Apps.
+MCP App framework, MCP testing framework, and inspector for MCP servers and MCP Apps.
 
-Build cross-platform: MCP App framework, ChatGPT App framework, and Claude Connector framework.
+Build cross-platform: sunpeak is a ChatGPT App framework, Claude Connector framework, and more.
 
 ```bash
 npx sunpeak new

--- a/packages/sunpeak/README.md
+++ b/packages/sunpeak/README.md
@@ -105,7 +105,7 @@ npx sunpeak new
 This creates a project, starts a dev server with HMR, and opens the inspector at `localhost:3000`:
 
 ```
-my-app/
+sunpeak-app/
 ├── src/resources/review/review.tsx    # UI component (React)
 ├── src/tools/review-diff.ts           # Tool handler, schema, resource link
 ├── tests/simulations/review-diff.json # Mock data for the inspector

--- a/packages/sunpeak/bin/commands/new.mjs
+++ b/packages/sunpeak/bin/commands/new.mjs
@@ -316,7 +316,7 @@ export async function init(projectName, resourcesArg, deps = defaultDeps) {
       readme = readme.replace(/pnpm test:visual\b/g, `${run} test:visual`);
       readme = readme.replace(/pnpm test:live\b/g, `${run} test:live`);
       readme = readme.replace(/pnpm test:eval\b/g, `${run} test:eval`);
-      readme = readme.replace(/pnpm add\b/g, `${pm} add`);
+      readme = readme.replace(/pnpm add\b/g, pm === 'npm' ? 'npm install' : `${pm} add`);
       readme = readme.replace(/pnpm dlx\b/g, dlx);
       d.writeFileSync(readmePath, readme);
     }

--- a/packages/sunpeak/bin/commands/new.mjs
+++ b/packages/sunpeak/bin/commands/new.mjs
@@ -299,6 +299,28 @@ export async function init(projectName, resourcesArg, deps = defaultDeps) {
 
   // Install dependencies with spinner
   const pm = d.detectPackageManager();
+
+  // Replace package manager references in README
+  if (pm !== 'pnpm') {
+    const readmePath = join(targetDir, 'README.md');
+    if (d.existsSync(readmePath)) {
+      const run = pm === 'npm' ? 'npm run' : pm;
+      const dlx = pm === 'npm' ? 'npx' : 'yarn dlx';
+      let readme = d.readFileSync(readmePath, 'utf-8');
+      readme = readme.replace(/pnpm dev\b/g, `${run} dev`);
+      readme = readme.replace(/pnpm build\b/g, `${run} build`);
+      readme = readme.replace(/pnpm start\b/g, `${run} start`);
+      readme = readme.replace(/pnpm test\b/g, `${run} test`);
+      readme = readme.replace(/pnpm test:unit\b/g, `${run} test:unit`);
+      readme = readme.replace(/pnpm test:e2e\b/g, `${run} test:e2e`);
+      readme = readme.replace(/pnpm test:visual\b/g, `${run} test:visual`);
+      readme = readme.replace(/pnpm test:live\b/g, `${run} test:live`);
+      readme = readme.replace(/pnpm test:eval\b/g, `${run} test:eval`);
+      readme = readme.replace(/pnpm add\b/g, `${pm} add`);
+      readme = readme.replace(/pnpm dlx\b/g, dlx);
+      d.writeFileSync(readmePath, readme);
+    }
+  }
   const s = d.spinner();
   s.start(`Installing dependencies with ${pm}...`);
 
@@ -366,30 +388,32 @@ export async function init(projectName, resourcesArg, deps = defaultDeps) {
       initialValue: true,
     });
     if (!clack.isCancel(installSkill) && installSkill) {
+      const dlx = pm === 'yarn' ? 'yarn dlx' : pm === 'npm' ? 'npx' : 'pnpm dlx';
       try {
-        d.execSync('pnpm dlx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@test-mcp-server', {
+        d.execSync(`${dlx} skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@test-mcp-server`, {
           cwd: targetDir,
           stdio: 'inherit',
         });
       } catch {
-        d.console.log('Skill install skipped. You can install later with: pnpm dlx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@test-mcp-server');
+        d.console.log(`Skill install skipped. You can install later with: ${dlx} skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@test-mcp-server`);
       }
     }
   }
 
+  const run = pm === 'npm' ? 'npm run' : pm;
   d.outro(`Done! To get started:
 
   cd ${projectName}
-  sunpeak dev
+  ${run} dev
 
 Your project commands:
 
-  sunpeak dev                # Start dev server + MCP endpoint
-  sunpeak build              # Build for production
-  sunpeak test               # Run unit + e2e tests
-  sunpeak test --eval        # Run LLM evals (configure models in tests/evals/eval.config.ts)
-  sunpeak test --visual      # Run visual regression tests
-  sunpeak test --live        # Run live tests against real AI hosts`);
+  ${run} dev              # Start dev server + MCP endpoint
+  ${run} build            # Build for production
+  ${run} test             # Run unit + e2e tests
+  ${run} test:eval        # Run LLM evals (configure models in tests/evals/eval.config.ts)
+  ${run} test:visual      # Run visual regression tests
+  ${run} test:live        # Run live tests against real AI hosts`);
 }
 
 // Allow running directly

--- a/packages/sunpeak/bin/commands/test-init.mjs
+++ b/packages/sunpeak/bin/commands/test-init.mjs
@@ -153,13 +153,15 @@ export async function testInit(args = [], deps = defaultDeps) {
       initialValue: true,
     });
     if (!d.isCancel(installSkill) && installSkill) {
+      const pm = d.detectPackageManager();
+      const dlx = pm === 'yarn' ? 'yarn dlx' : pm === 'npm' ? 'npx' : 'pnpm dlx';
       try {
-        d.execSync('pnpm dlx skills add Sunpeak-AI/sunpeak@test-mcp-server', {
+        d.execSync(`${dlx} skills add Sunpeak-AI/sunpeak@test-mcp-server`, {
           cwd: d.cwd(),
           stdio: 'inherit',
         });
       } catch {
-        d.log.info('Skill install skipped. Install later: pnpm dlx skills add Sunpeak-AI/sunpeak@test-mcp-server');
+        d.log.info(`Skill install skipped. Install later: ${dlx} skills add Sunpeak-AI/sunpeak@test-mcp-server`);
       }
     }
   }
@@ -357,7 +359,7 @@ function scaffoldEvals(evalsDir, { server, isSunpeak, d: deps } = {}) {
  * 2. Install the AI SDK and provider packages (e.g. pnpm add ai @ai-sdk/openai)
  * 3. Copy .env.example to .env and add your API keys
  * 4. Replace this file with evals for your own tools
- * 5. Run: sunpeak test --eval
+ * 5. Run: npx sunpeak test --eval
  *
  * Each case sends a prompt to every configured model and checks
  * that the model calls the expected tool with the expected arguments.
@@ -403,10 +405,10 @@ function scaffoldVisualTest(filePath, d) {
 /**
  * Visual regression tests — compare screenshots against saved baselines.
  *
- * Screenshots only run with: sunpeak test --visual
- * Update baselines with:     sunpeak test --visual --update
+ * Screenshots only run with: npx sunpeak test --visual
+ * Update baselines with:     npx sunpeak test --visual --update
  *
- * During normal \`sunpeak test\` runs, screenshot() calls are silently
+ * During normal \`npx sunpeak test\` runs, screenshot() calls are silently
  * skipped so these tests still pass without baselines.
  *
  * Uncomment the tests below and replace 'your-tool' with your tool name.
@@ -465,7 +467,7 @@ function scaffoldLiveTests(liveDir, { isSunpeak, server, d } = {}) {
  * Prerequisites:
  * 1. Your MCP server must be accessible via a public URL (e.g., ngrok tunnel)
  * 2. The server must be registered as an MCP action in the host
- * 3. Run: sunpeak test --live
+ * 3. Run: npx sunpeak test --live
  *
  * On first run, a browser window opens for you to log in to the host.
  * The session is saved for subsequent runs (typically lasts a few hours).
@@ -508,9 +510,9 @@ export default defineLiveConfig({${serverOption}
  * - live.setColorScheme('dark', app) — switch theme while app is visible
  * - live.page — the underlying Playwright page
  *
- * Run with: sunpeak test --live
+ * Run with: npx sunpeak test --live
  *
- * These tests are excluded from normal \`sunpeak test\` runs because
+ * These tests are excluded from normal \`npx sunpeak test\` runs because
  * they require host accounts and cost API credits.
  */
 
@@ -553,7 +555,7 @@ function scaffoldUnitTest(filePath, d) {
  * Import your tool handler directly and test its input/output
  * without starting the MCP server or inspector.
  *
- * Run with: sunpeak test --unit
+ * Run with: npx sunpeak test --unit
  *
  * To set up vitest, add it to your devDependencies:
  *   npm install -D vitest
@@ -701,10 +703,10 @@ test('server exposes tools', async ({ mcp }) => {
   }
 
   d.log.step('Ready! Run tests with:');
-  d.log.message('  sunpeak test              # E2E tests');
-  d.log.message('  sunpeak test --visual      # Visual regression (generates baselines on first run)');
-  d.log.message('  sunpeak test --live         # Live tests against real hosts (requires login)');
-  d.log.message('  sunpeak test --eval         # Multi-model evals (configure models in evals/eval.config.ts)');
+  d.log.message('  npx sunpeak test              # E2E tests');
+  d.log.message('  npx sunpeak test --visual      # Visual regression (generates baselines on first run)');
+  d.log.message('  npx sunpeak test --live         # Live tests against real hosts (requires login)');
+  d.log.message('  npx sunpeak test --eval         # Multi-model evals (configure models in evals/eval.config.ts)');
 }
 
 async function initJsProject(cliServer, d) {
@@ -784,11 +786,11 @@ test('server exposes tools', async ({ mcp }) => {
   d.log.message(`  ${pkgMgr} add -D sunpeak @playwright/test vitest`);
   d.log.message(`  ${pkgMgr} exec playwright install chromium`);
   d.log.message('');
-  d.log.message('  sunpeak test              # E2E tests');
-  d.log.message('  sunpeak test --unit        # Unit tests (vitest)');
-  d.log.message('  sunpeak test --visual      # Visual regression');
-  d.log.message('  sunpeak test --live         # Live tests against real hosts');
-  d.log.message('  sunpeak test --eval         # Multi-model evals');
+  d.log.message('  npx sunpeak test              # E2E tests');
+  d.log.message('  npx sunpeak test --unit        # Unit tests (vitest)');
+  d.log.message('  npx sunpeak test --visual      # Visual regression');
+  d.log.message('  npx sunpeak test --live         # Live tests against real hosts');
+  d.log.message('  npx sunpeak test --eval         # Multi-model evals');
 }
 
 async function initSunpeakProject(d) {
@@ -835,10 +837,10 @@ export default defineConfig();
   scaffoldUnitTest(join(cwd, 'tests', 'unit', 'example.test.ts'), d);
 
   d.log.step('Scaffolded test types:');
-  d.log.message('  tests/e2e/visual.test.ts    — Visual regression (sunpeak test --visual)');
-  d.log.message('  tests/live/                 — Live host tests (sunpeak test --live)');
-  d.log.message('  tests/evals/                — Multi-model evals (sunpeak test --eval)');
-  d.log.message('  tests/unit/example.test.ts  — Unit tests (sunpeak test --unit)');
+  d.log.message('  tests/e2e/visual.test.ts    — Visual regression (npx sunpeak test --visual)');
+  d.log.message('  tests/live/                 — Live host tests (npx sunpeak test --live)');
+  d.log.message('  tests/evals/                — Multi-model evals (npx sunpeak test --eval)');
+  d.log.message('  tests/unit/example.test.ts  — Unit tests (npx sunpeak test --unit)');
   d.log.message('');
   d.log.message('  Migrate existing e2e tests:');
   d.log.message('  Replace: import { test, expect } from "@playwright/test"');

--- a/packages/sunpeak/bin/sunpeak.js
+++ b/packages/sunpeak/bin/sunpeak.js
@@ -104,8 +104,7 @@ function getVersion() {
         console.log(`
 ☀️ 🏔️ sunpeak - Inspector, testing framework, and app framework for MCP Apps
 
-Install:
-  pnpm add -g sunpeak
+Usage: npx sunpeak <command>
 
 Testing (works with any MCP server):
   sunpeak inspect          Inspect any MCP server in the inspector

--- a/packages/sunpeak/bin/sunpeak.js
+++ b/packages/sunpeak/bin/sunpeak.js
@@ -102,21 +102,11 @@ function getVersion() {
       {
         const resources = discoverResources();
         console.log(`
-☀️ 🏔️ sunpeak - Inspector, testing framework, and app framework for MCP Apps
+☀️ 🏔️ sunpeak - App framework, testing framework, and inspector for MCP Apps
 
 Usage: npx sunpeak <command>
 
-Testing (works with any MCP server):
-  sunpeak inspect          Inspect any MCP server in the inspector
-    --server, -s <url|cmd> MCP server URL or stdio command (required)
-    --simulations <dir>    Simulation JSON directory
-  sunpeak test             Run e2e tests against the inspector
-    init                   Scaffold test infrastructure into a project
-    --unit                 Run unit tests (vitest)
-    --live                 Run live tests against real hosts
-    --eval                 Run evals against LLM models
-
-App framework (for sunpeak projects):
+App framework:
   sunpeak new [name] [resources]  Create a new project
   sunpeak dev              Start dev server + inspector + MCP endpoint
     --no-begging           Suppress GitHub star message
@@ -124,8 +114,20 @@ App framework (for sunpeak projects):
   sunpeak start            Start production MCP server
     --port, -p             Server port (default: 8000, or PORT env)
   sunpeak upgrade          Upgrade sunpeak to latest version
-  sunpeak --version        Show version number
 
+Testing (works with any MCP server):
+  sunpeak test             Run e2e tests against the inspector
+    init                   Scaffold test infrastructure into a project
+    --unit                 Run unit tests (vitest)
+    --live                 Run live tests against real hosts
+    --eval                 Run evals against LLM models
+
+Inspector (works with any MCP server):
+  sunpeak inspect          Inspect any MCP server in the inspector
+    --server, -s <url|cmd> MCP server URL or stdio command (required)
+    --simulations <dir>    Simulation JSON directory
+
+  sunpeak --version        Show version number
   Resources: ${resources.join(', ')} (comma/space separated)
   Example: sunpeak new sunpeak-app "${resources.slice(0, 2).join(',')}"
 `);

--- a/packages/sunpeak/package.json
+++ b/packages/sunpeak/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sunpeak",
   "version": "0.20.4",
-  "description": "Inspector, testing framework, and app framework for MCP Apps.",
+  "description": "App framework, testing framework, and inspector for MCP Apps.",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/sunpeak/src/cli/commands.test.ts
+++ b/packages/sunpeak/src/cli/commands.test.ts
@@ -159,7 +159,7 @@ describe('CLI Commands', () => {
       });
 
       expect(execSyncMock).toHaveBeenCalledWith(
-        'pnpm dlx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@test-mcp-server',
+        'npx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@test-mcp-server',
         expect.objectContaining({ cwd: '/test/my-project', stdio: 'inherit' })
       );
     });

--- a/packages/sunpeak/template/README.md
+++ b/packages/sunpeak/template/README.md
@@ -7,7 +7,7 @@ For an initial overview of your new app and a detailed API reference, refer to t
 ## Quickstart
 
 ```bash
-sunpeak dev
+pnpm dev
 ```
 
 That's it! Edit the resource files in [./src/resources/](./src/resources/) to build your resource UI.
@@ -17,22 +17,20 @@ That's it! Edit the resource files in [./src/resources/](./src/resources/) to bu
 **Testing:**
 
 ```bash
-sunpeak test                      # Run unit + e2e tests.
-sunpeak test --unit               # Run unit tests only (Vitest).
-sunpeak test --e2e                # Run e2e tests only (Playwright).
-sunpeak test --visual             # Run e2e tests with visual regression.
-sunpeak test --visual --update    # Update visual regression baselines.
-sunpeak test --live               # Run live tests against real ChatGPT.
-sunpeak test --eval               # Run evals against multiple LLM models.
+pnpm test                      # Run unit + e2e tests.
+pnpm test:unit                 # Run unit tests only (Vitest).
+pnpm test:e2e                  # Run e2e tests only (Playwright).
+pnpm test:visual               # Run e2e tests with visual regression.
+pnpm test:live                 # Run live tests against real ChatGPT.
+pnpm test:eval                 # Run evals against multiple LLM models.
 ```
 
 **Development and production:**
 
 ```bash
-sunpeak dev               # Start dev server + MCP endpoint.
-sunpeak build             # Build resources and compile tools for production.
-sunpeak start             # Start the production MCP server.
-sunpeak upgrade           # Upgrade sunpeak to latest version.
+pnpm dev               # Start dev server + MCP endpoint.
+pnpm build             # Build resources and compile tools for production.
+pnpm start             # Start the production MCP server.
 ```
 
 E2e tests use the `mcp` fixture from `sunpeak/test` to call tools and assert against rendered UI across ChatGPT and Claude hosts. Unit tests use Vitest with happy-dom.
@@ -42,7 +40,7 @@ E2e tests use the `mcp` fixture from `sunpeak/test` to call tools and assert aga
 1. Install the AI SDK and provider packages: `pnpm add ai @ai-sdk/openai`
 2. Copy `tests/evals/.env.example` to `tests/evals/.env` and add your API keys
 3. Uncomment models in `tests/evals/eval.config.ts`
-4. Run: `sunpeak test --eval`
+4. Run: `pnpm test:eval`
 
 The dev server starts automatically for evals. Each case runs multiple times per model to measure reliability. See the [Evals documentation](https://sunpeak.ai/docs/testing/evals) for details.
 
@@ -68,11 +66,11 @@ sunpeak-app/
 
 ## Testing in ChatGPT
 
-Test your app directly in ChatGPT using the built-in [MCP](https://sunpeak.ai/docs/mcp-apps/mcp/overview) endpoint (starts automatically with `sunpeak dev`):
+Test your app directly in ChatGPT using the built-in [MCP](https://sunpeak.ai/docs/mcp-apps/mcp/overview) endpoint (starts automatically with `pnpm dev`):
 
 ```bash
 # Start the dev server + MCP endpoint.
-sunpeak dev
+pnpm dev
 
 # In another terminal, run a tunnel. For example:
 ngrok http 8000
@@ -108,10 +106,10 @@ The test runner imports your browser session automatically, starts the dev serve
 Build and start your app for production:
 
 ```bash
-sunpeak build && sunpeak start
+pnpm build && pnpm start
 ```
 
-`sunpeak build` creates optimized builds in `dist/`:
+`pnpm build` creates optimized builds in `dist/`:
 
 ```bash
 dist/
@@ -125,12 +123,12 @@ dist/
 └── ...
 ```
 
-`sunpeak start` loads the compiled tools and resources, then starts a production MCP server with real handlers, Zod input validation, and optional auth.
+`pnpm start` loads the compiled tools and resources, then starts a production MCP server with real handlers, Zod input validation, and optional auth.
 
 ```bash
-sunpeak start --port 3000              # Custom port (default: 8000)
-sunpeak start --host 127.0.0.1         # Bind to localhost only
-sunpeak start --json-logs              # Structured JSON logging for production
+pnpm start -- --port 3000              # Custom port (default: 8000)
+pnpm start -- --host 127.0.0.1         # Bind to localhost only
+pnpm start -- --json-logs              # Structured JSON logging for production
 ```
 
 The server includes a `/health` endpoint for load balancer probes and monitoring. See the [Deployment Guide](https://sunpeak.ai/docs/app-framework/guides/deployment) for production operations details (reverse proxy, process management, Docker).
@@ -148,7 +146,7 @@ src/resources/NAME/
 
 Only the resource file (`.tsx`) is required to generate a production build and ship a UI. It must export a `resource` object (`ResourceConfig`) describing the resource metadata, and a React component that renders the UI. The resource name is auto-derived from the directory name.
 
-Then create a tool file in `src/tools/` and simulation file(s) in `tests/simulations/` to preview your resource in `sunpeak dev`.
+Then create a tool file in `src/tools/` and simulation file(s) in `tests/simulations/` to preview your resource in `pnpm dev`.
 
 ## Coding Agent Skills
 
@@ -163,7 +161,7 @@ pnpm dlx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@tes
 If your app doesn't render in ChatGPT or Claude:
 
 1. **Check your tunnel** is running and pointing to the correct port
-2. **Restart `sunpeak dev`** to clear stale connections
+2. **Restart `pnpm dev`** to clear stale connections
 3. **Refresh or re-add the MCP server** in the host's settings (Settings > MCP Servers)
 4. **Hard refresh** the host page (`Cmd+Shift+R` / `Ctrl+Shift+R`)
 5. **Open a new chat** in the host (cached iframes persist per-conversation)

--- a/packages/sunpeak/template/package.json
+++ b/packages/sunpeak/template/package.json
@@ -11,7 +11,8 @@
     "test:unit": "sunpeak test --unit",
     "test:e2e": "sunpeak test --e2e",
     "test:visual": "sunpeak test --visual",
-    "test:live": "sunpeak test --live"
+    "test:live": "sunpeak test --live",
+    "test:eval": "sunpeak test --eval"
   },
   "dependencies": {
     "clsx": "^2.1.1",

--- a/packages/sunpeak/template/tests/e2e/visual.spec.ts
+++ b/packages/sunpeak/template/tests/e2e/visual.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from 'sunpeak/test';
 
-// Visual regression tests. Screenshot comparisons only run with `sunpeak test --visual`.
-// Update baselines with `sunpeak test --visual --update`.
+// Visual regression tests. Screenshot comparisons only run with `pnpm test:visual`.
+// Update baselines with `pnpm test:visual -- --update`.
 
 test('albums renders correctly in light mode', async ({ inspector }) => {
   const result = await inspector.renderTool('show-albums', undefined, { theme: 'light' });


### PR DESCRIPTION
## Summary

- Rewrites the three-layer sections (inspector, testing, app framework) across README, docs landing page, and layer overview pages. Each section leads with the problem it solves, a zero-install quickstart command, and a link to deeper docs.
- Removes all global install recommendations. Bootstrap commands use `npx sunpeak`, in-project commands use package manager scripts (`pnpm dev`, `npm run dev`, etc.).
- Adds pnpm/npm/yarn tabs in quickstart and lifecycle pages. `sunpeak new` and `sunpeak test init` now detect the user's package manager and adapt their output (CLI messages, README replacements, skills install commands).
- Removes CLI reference tables and troubleshooting section from the root README to keep it focused on the three layers.
- Adds `test:eval` npm script to the template alongside existing `test:unit`, `test:e2e`, `test:visual`, `test:live`.