### PR TITLE
Fix test init: remove unit tests, add ESM compat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,7 +237,7 @@ Automated testing powered by the inspector. Works with any MCP server in any lan
 
 **Test types**: E2E (`sunpeak/test`), Visual regression (`result.screenshot()` on `InspectorResult`), Live tests (`sunpeak/test/live` for real ChatGPT/Claude), Evals (`sunpeak/eval` for multi-model tool calling via Vercel AI SDK).
 
-**CLI**: `sunpeak test` runs unit + e2e tests, `sunpeak test --unit` runs only vitest, `sunpeak test --e2e` runs only Playwright e2e tests, `sunpeak test --visual` runs e2e with visual regression comparison, `sunpeak test --visual --update` updates visual baselines, `sunpeak test --live` runs live tests against real hosts, `sunpeak test --eval` runs multi-model evals, `sunpeak test init` scaffolds test infrastructure (including eval boilerplate). Flags are additive: `--unit --e2e --live --eval` runs all four. `--update` implies `--visual`. `--eval` and `--live` are never included in the default run (they cost money).
+**CLI**: `sunpeak test` runs unit + e2e tests by default (unit tests only run if vitest is configured, i.e. app framework projects), `sunpeak test --e2e` runs only Playwright e2e tests, `sunpeak test --visual` runs e2e with visual regression comparison, `sunpeak test --visual --update` updates visual baselines, `sunpeak test --live` runs live tests against real hosts, `sunpeak test --eval` runs multi-model evals, `sunpeak test --unit` runs vitest unit tests (app framework projects only, not scaffolded by `test init`), `sunpeak test init` scaffolds test infrastructure (e2e, visual, live, eval — no unit tests). Flags are additive. `--update` implies `--visual`. `--eval` and `--live` are never included in the default run (they cost money).
 
 #### 3. Inspector
 

--- a/docs/testing/cli/test.mdx
+++ b/docs/testing/cli/test.mdx
@@ -1,31 +1,33 @@
 ---
 title: "sunpeak test"
-description: "Run unit tests, E2E tests, visual regression, live host tests, and multi-model evals."
-keywords: ["MCP testing", "sunpeak test", "e2e testing", "visual regression", "live testing", "evals", "unit testing"]
+description: "Run E2E tests, visual regression, live host tests, and multi-model evals."
+keywords: ["MCP testing", "sunpeak test", "e2e testing", "visual regression", "live testing", "evals"]
 ---
 
 ## Overview
 
-The `sunpeak test` command runs automated tests for your MCP server. It supports unit tests, E2E tests against the inspector, visual regression, live tests against real hosts, and multi-model evals.
+The `sunpeak test` command runs automated tests for your MCP server. It supports E2E tests against the inspector, visual regression, live tests against real hosts, and multi-model evals.
 
 ```bash
 sunpeak test
 ```
 
-With no flags, `sunpeak test` runs unit tests (Vitest) and E2E tests (Playwright). Live tests and evals are never included in the default run because they require API keys and cost money.
+With no flags, `sunpeak test` runs unit tests (Vitest, if configured) and E2E tests (Playwright). For standalone testing framework projects, only E2E tests run because unit tests aren't scaffolded. For sunpeak app framework projects, both unit and E2E tests run by default.
+
+Live tests and evals are never included in the default run because they require API keys and cost money.
 
 ## Options
 
 | Flag | Description |
 |------|-------------|
-| `--unit` | Run unit tests only (Vitest + happy-dom) |
 | `--e2e` | Run E2E tests only (Playwright + inspector) |
 | `--visual` | Run E2E tests with visual regression comparison |
 | `--visual --update` | Update visual regression baselines |
 | `--live` | Run live tests against real hosts (ChatGPT) |
 | `--eval` | Run evals against multiple LLM models |
+| `--unit` | Run unit tests (sunpeak app framework only, Vitest + happy-dom) |
 
-Flags are additive: `--unit --e2e --live --eval` runs all four. `--visual` implies `--e2e`. `--update` implies `--visual`.
+Flags are additive: `--e2e --live --eval` runs all three. `--visual` implies `--e2e`. `--update` implies `--visual`.
 
 Extra arguments are passed through to the underlying test runner (Playwright or Vitest):
 
@@ -56,11 +58,8 @@ For sunpeak framework projects, `sunpeak new` scaffolds all of this automaticall
 ## Examples
 
 ```bash
-# Default: unit + e2e
+# Default: unit (if configured) + e2e
 sunpeak test
-
-# Unit tests only
-sunpeak test --unit
 
 # E2E tests only
 sunpeak test --e2e
@@ -78,15 +77,12 @@ sunpeak test --live
 sunpeak test --eval
 
 # Run everything
-sunpeak test --unit --e2e --live --eval
+sunpeak test --e2e --live --eval
 ```
 
 ## See Also
 
 <CardGroup cols={2}>
-  <Card horizontal title="Unit Testing" icon="vial" href="/testing/unit">
-    Fast component and hook tests with Vitest.
-  </Card>
   <Card horizontal title="E2E Testing" icon="flask" href="/testing/e2e">
     Write Playwright tests against simulated hosts.
   </Card>

--- a/docs/testing/getting-started.mdx
+++ b/docs/testing/getting-started.mdx
@@ -69,7 +69,7 @@ Install dependencies:
   </Tab>
   <Tab title="JS/TS project">
     ```bash
-    npm add -D sunpeak @playwright/test vitest
+    npm add -D sunpeak @playwright/test
     npx playwright install chromium
     ```
   </Tab>

--- a/docs/testing/overview.mdx
+++ b/docs/testing/overview.mdx
@@ -21,15 +21,7 @@ For sunpeak framework projects, the dev server starts automatically and no serve
 
 ## Testing Levels
 
-### 1. Unit Tests
-
-Standard Vitest with happy-dom for component and hook logic testing. No special framework integration required.
-
-<Card horizontal title="Unit Testing" icon="vial" href="/testing/unit">
-  Fast component and hook tests with Vitest.
-</Card>
-
-### 2. E2E Tests
+### 1. E2E Tests
 
 Playwright specs that call your MCP tools and render them in simulated ChatGPT and Claude runtimes. The `mcp` fixture from `sunpeak/test` handles inspector navigation, iframe traversal, and host switching. [Simulations](/testing/simulations) (JSON fixtures) define reproducible tool states so you can test every combination of host, theme, display mode, and device without deploying or burning API credits.
 
@@ -43,7 +35,7 @@ Visual regression is built in. Pass `--visual` to compare screenshots against ba
   Screenshot comparison across themes, display modes, and hosts.
 </Card>
 
-### 3. Live Tests
+### 2. Live Tests
 
 Playwright specs that run against real ChatGPT (and future hosts). They open a browser, send messages that trigger tool calls against your MCP server, and verify the rendered app. This catches issues that inspector tests cannot: real MCP connection behavior, actual LLM tool invocation, host-specific iframe rendering, and production resource loading.
 
@@ -51,7 +43,7 @@ Playwright specs that run against real ChatGPT (and future hosts). They open a b
   Validate your MCP Apps inside real AI chat hosts.
 </Card>
 
-### 4. Evals
+### 3. Evals
 
 Multi-model tool calling tests. Evals connect to your MCP server via the MCP protocol, discover its tools, and send prompts to multiple LLM models (GPT-4o, Claude, Gemini, etc.). Each eval case runs N times per model and reports statistical pass/fail counts, so you can measure whether your tool descriptions work reliably across models.
 
@@ -63,15 +55,15 @@ Multi-model tool calling tests. Evals connect to your MCP server via the MCP pro
 
 | Command | What it runs | Runtime |
 |---------|-------------|---------|
-| `sunpeak test` | Unit + E2E tests | Vitest + Playwright |
-| `sunpeak test --unit` | Unit tests only | Vitest + happy-dom |
+| `sunpeak test` | Unit (if configured) + E2E tests | Vitest + Playwright |
 | `sunpeak test --e2e` | E2E tests only | Playwright + inspector |
 | `sunpeak test --visual` | E2E with visual regression | Playwright + inspector |
 | `sunpeak test --visual --update` | Update visual baselines | Playwright + inspector |
 | `sunpeak test --live` | Live tests against real hosts | Playwright + real host |
 | `sunpeak test --eval` | Evals against multiple models | Vitest + Vercel AI SDK |
+| `sunpeak test --unit` | Unit tests (app framework only) | Vitest + happy-dom |
 
-Flags are additive: `--unit --e2e --live --eval` runs all four.
+Flags are additive: `--e2e --live --eval` runs all three.
 
 <Note>
   `--eval` and `--live` are not included in the default `sunpeak test` run because they require API keys and cost money. You must opt in explicitly.
@@ -89,7 +81,6 @@ For JS/TS projects, this creates files at the project root:
 - `tests/e2e/` with smoke and visual regression test specs
 - `tests/evals/` with eval config, `.env.example`, and example eval specs
 - `tests/live/` with live test config and example specs
-- `tests/unit/` with unit test example
 
 For non-JS projects (Python, Go, Rust, etc.), everything goes into a self-contained `tests/sunpeak/` directory with its own `package.json`.
 
@@ -103,9 +94,6 @@ For sunpeak framework projects, `sunpeak new` scaffolds all of this automaticall
   </Card>
   <Card title="Simulations" icon="folder" href="/testing/simulations">
     JSON fixtures for reproducible tool states.
-  </Card>
-  <Card title="Unit Testing" icon="vial" href="/testing/unit">
-    Fast component and hook tests with Vitest.
   </Card>
   <Card title="E2E Testing" icon="flask" href="/testing/e2e">
     Playwright specs against simulated hosts.

--- a/docs/testing/unit.mdx
+++ b/docs/testing/unit.mdx
@@ -6,7 +6,11 @@ keywords: ["MCP app testing", "unit testing", "Vitest", "happy-dom", "React test
 
 ## Overview
 
-Unit tests run your component and hook logic in isolation using Vitest with happy-dom. They're fast, don't require the inspector or a browser, and are included in the default `sunpeak test` run.
+<Note>
+  Unit tests are for **sunpeak app framework projects** (created with `sunpeak new`). If you're using sunpeak as a standalone testing framework for an existing MCP server, use [E2E tests](/testing/e2e) instead, which test your server over the wire via the MCP protocol.
+</Note>
+
+Unit tests run your component and hook logic in isolation using Vitest with happy-dom. They're fast, don't require the inspector or a browser, and test tool handlers, React components, and data transformations directly.
 
 <Tabs>
   <Tab title="pnpm">

--- a/packages/sunpeak/bin/commands/test-init.mjs
+++ b/packages/sunpeak/bin/commands/test-init.mjs
@@ -61,12 +61,14 @@ export const defaultDeps = {
  * - JS/TS projects: root-level config + test files
  * - sunpeak projects: migrate to defineConfig()
  *
- * Scaffolds all 5 test types:
+ * Scaffolds 4 test types:
  * 1. E2E tests — Playwright-based inspector tests (mcp fixture)
  * 2. Visual regression — Screenshot comparison via result.screenshot()
  * 3. Live tests — Test against real ChatGPT/Claude hosts
  * 4. Evals — Multi-model tool calling reliability tests
- * 5. Unit tests — Direct tool handler tests (JS/TS projects only)
+ *
+ * Unit tests are not scaffolded here — they're part of the sunpeak app
+ * framework (`sunpeak new`) where tool handlers can be imported directly.
  */
 export async function testInit(args = [], deps = defaultDeps) {
   const d = { ...defaultDeps, ...deps };
@@ -532,56 +534,6 @@ export default defineLiveConfig({${serverOption}
   d.log.success(`Created ${liveDir}/ with live test config and example.`);
 }
 
-/**
- * Scaffold a unit test example for JS/TS projects.
- * @param {string} filePath - Full path to the unit test file
- * @param {object} d - Dependencies
- */
-function scaffoldUnitTest(filePath, d) {
-  if (d.existsSync(filePath)) {
-    d.log.info('Unit test already exists. Skipping.');
-    return;
-  }
-
-  d.mkdirSync(dirname(filePath), { recursive: true });
-
-  d.writeFileSync(
-    filePath,
-    `import { describe, it, expect } from 'vitest';
-
-/**
- * Unit tests for your MCP tool handlers.
- *
- * Import your tool handler directly and test its input/output
- * without starting the MCP server or inspector.
- *
- * Run with: npx sunpeak test --unit
- *
- * To set up vitest, add it to your devDependencies:
- *   npm install -D vitest
- *
- * Uncomment and customize the tests below for your tools.
- */
-
-// import handler, { tool, schema } from '../../src/tools/your-tool';
-// const extra = {} as Parameters<typeof handler>[1];
-
-// describe('your tool', () => {
-//   it('returns expected output', async () => {
-//     const result = await handler({ key: 'value' }, extra);
-//     expect(result.structuredContent).toBeDefined();
-//   });
-//
-//   it('exports correct tool config', () => {
-//     expect(tool.title).toBe('Your Tool');
-//     expect(tool.annotations?.readOnlyHint).toBe(true);
-//   });
-// });
-`
-  );
-  d.log.success(`Created ${filePath}`);
-}
-
 async function initExternalProject(cliServer, d) {
   d.log.info('Detected non-JS project. Creating self-contained test directory.');
 
@@ -715,6 +667,22 @@ async function initJsProject(cliServer, d) {
   const server = await getServerConfig(cliServer, d);
   const cwd = d.cwd();
 
+  // Ensure "type": "module" — sunpeak exports are ESM-only and Playwright's
+  // CJS resolver won't find them without it.
+  const pkgPath = join(cwd, 'package.json');
+  if (d.existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(d.readFileSync(pkgPath, 'utf-8'));
+      if (pkg.type !== 'module') {
+        pkg.type = 'module';
+        d.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+        d.log.success('Set "type": "module" in package.json (required for sunpeak imports)');
+      }
+    } catch {
+      d.log.warn('Could not read package.json. Make sure "type": "module" is set.');
+    }
+  }
+
   // Create playwright.config.ts
   const configPath = join(cwd, 'playwright.config.ts');
   if (d.existsSync(configPath)) {
@@ -775,19 +743,15 @@ test('server exposes tools', async ({ mcp }) => {
   // 4. Eval boilerplate
   scaffoldEvals(join(cwd, 'tests', 'evals'), { server, d });
 
-  // 5. Unit test
-  scaffoldUnitTest(join(cwd, 'tests', 'unit', 'example.test.ts'), d);
-
   if (server.type === 'later') {
     d.log.warn('Server not configured. Edit playwright.config.ts before running tests.');
   }
   const pkgMgr = d.detectPackageManager();
   d.log.step('Next steps:');
-  d.log.message(`  ${pkgMgr} add -D sunpeak @playwright/test vitest`);
+  d.log.message(`  ${pkgMgr} add -D sunpeak @playwright/test`);
   d.log.message(`  ${pkgMgr} exec playwright install chromium`);
   d.log.message('');
   d.log.message('  npx sunpeak test              # E2E tests');
-  d.log.message('  npx sunpeak test --unit        # Unit tests (vitest)');
   d.log.message('  npx sunpeak test --visual      # Visual regression');
   d.log.message('  npx sunpeak test --live         # Live tests against real hosts');
   d.log.message('  npx sunpeak test --eval         # Multi-model evals');
@@ -833,14 +797,10 @@ export default defineConfig();
   // 3. Eval boilerplate
   scaffoldEvals(join(cwd, 'tests', 'evals'), { isSunpeak: true, d });
 
-  // 4. Unit test
-  scaffoldUnitTest(join(cwd, 'tests', 'unit', 'example.test.ts'), d);
-
   d.log.step('Scaffolded test types:');
   d.log.message('  tests/e2e/visual.test.ts    — Visual regression (npx sunpeak test --visual)');
   d.log.message('  tests/live/                 — Live host tests (npx sunpeak test --live)');
   d.log.message('  tests/evals/                — Multi-model evals (npx sunpeak test --eval)');
-  d.log.message('  tests/unit/example.test.ts  — Unit tests (npx sunpeak test --unit)');
   d.log.message('');
   d.log.message('  Migrate existing e2e tests:');
   d.log.message('  Replace: import { test, expect } from "@playwright/test"');

--- a/packages/sunpeak/bin/commands/test.mjs
+++ b/packages/sunpeak/bin/commands/test.mjs
@@ -59,8 +59,17 @@ export async function runTest(args) {
   const results = [];
 
   if (runUnit) {
-    const code = await runChild('pnpm', ['exec', 'vitest', 'run', ...filteredArgs]);
-    results.push({ suite: 'unit', code });
+    // Only run unit tests if vitest is available (app framework projects have it,
+    // standalone testing framework projects don't).
+    const hasVitest = existsSync(join(process.cwd(), 'node_modules', '.bin', 'vitest'));
+    if (hasVitest) {
+      const code = await runChild('pnpm', ['exec', 'vitest', 'run', ...filteredArgs]);
+      results.push({ suite: 'unit', code });
+    } else if (isUnit) {
+      // Only warn if the user explicitly asked for --unit
+      console.error('vitest is not installed. Install it with: npm add -D vitest');
+      results.push({ suite: 'unit', code: 1 });
+    }
   }
 
   if (runE2e) {

--- a/packages/sunpeak/scripts/validate.mjs
+++ b/packages/sunpeak/scripts/validate.mjs
@@ -377,13 +377,17 @@ function runTestInitSmokeTest() {
         'tests/evals/eval.config.ts',
         'tests/evals/example.eval.ts',
         'tests/evals/.env.example',
-        'tests/unit/example.test.ts',
       ];
 
       for (const file of expected) {
         if (!existsSync(join(dir, file))) {
           return { ok: false, step: `test-init js: missing ${file}`, output: allOutput.join('\n') };
         }
+      }
+
+      // Unit tests should NOT be scaffolded (they're app-framework-only)
+      if (existsSync(join(dir, 'tests/unit/example.test.ts'))) {
+        return { ok: false, step: 'test-init js: tests/unit/ should not be scaffolded', output: allOutput.join('\n') };
       }
 
       // Verify correct imports in scaffolded files
@@ -400,11 +404,6 @@ function runTestInitSmokeTest() {
       const liveTest = readFileSync(join(dir, 'tests/live/example.test.ts'), 'utf-8');
       if (!liveTest.includes("from 'sunpeak/test/live'") || !liveTest.includes('live.invoke')) {
         return { ok: false, step: 'test-init js: live test missing expected content', output: allOutput.join('\n') };
-      }
-
-      const unitTest = readFileSync(join(dir, 'tests/unit/example.test.ts'), 'utf-8');
-      if (!unitTest.includes("from 'vitest'")) {
-        return { ok: false, step: 'test-init js: unit test missing vitest import', output: allOutput.join('\n') };
       }
 
       const evalExample = readFileSync(join(dir, 'tests/evals/example.eval.ts'), 'utf-8');
@@ -450,13 +449,17 @@ function runTestInitSmokeTest() {
         'tests/evals/eval.config.ts',
         'tests/evals/example.eval.ts',
         'tests/evals/.env.example',
-        'tests/unit/example.test.ts',
       ];
 
       for (const file of expected) {
         if (!existsSync(join(dir, file))) {
           return { ok: false, step: `test-init sunpeak: missing ${file}`, output: allOutput.join('\n') };
         }
+      }
+
+      // Unit tests should NOT be scaffolded by test init (they come from sunpeak new)
+      if (existsSync(join(dir, 'tests/unit/example.test.ts'))) {
+        return { ok: false, step: 'test-init sunpeak: tests/unit/ should not be scaffolded by test init', output: allOutput.join('\n') };
       }
 
       // Verify playwright.config uses defineConfig() (no server arg)

--- a/packages/sunpeak/src/cli/commands.test.ts
+++ b/packages/sunpeak/src/cli/commands.test.ts
@@ -785,7 +785,7 @@ describe('CLI Commands', () => {
       expect(liveConfig).toContain("from 'sunpeak/test/live/config'");
     });
 
-    it('should scaffold all 5 test types for JS projects with correct imports', async () => {
+    it('should scaffold 4 test types for JS projects (no unit tests)', async () => {
       const { testInit } = await importTestInit();
       const writeFileSync = vi.fn();
 
@@ -800,13 +800,14 @@ describe('CLI Commands', () => {
 
       const writtenPaths = writeFileSync.mock.calls.map((c: [string, string]) => c[0]);
 
-      // All 5 test types
+      // 4 test types (no unit tests — those are app-framework-only)
       expect(writtenPaths).toContainEqual(expect.stringContaining('e2e/smoke.test.ts'));
       expect(writtenPaths).toContainEqual(expect.stringContaining('e2e/visual.test.ts'));
       expect(writtenPaths).toContainEqual(expect.stringContaining('live/playwright.config.ts'));
       expect(writtenPaths).toContainEqual(expect.stringContaining('live/example.test.ts'));
       expect(writtenPaths).toContainEqual(expect.stringContaining('evals/eval.config.ts'));
-      expect(writtenPaths).toContainEqual(expect.stringContaining('unit/example.test.ts'));
+      expect(writtenPaths).not.toContainEqual(expect.stringContaining('unit/example.test.ts'));
+      expect(writtenPaths).not.toContainEqual(expect.stringContaining('vitest.config.ts'));
 
       // Verify correct imports
       const smoke = getWrittenContent(writeFileSync, 'e2e/smoke.test.ts');
@@ -820,12 +821,13 @@ describe('CLI Commands', () => {
       expect(liveTest).toContain("from 'sunpeak/test/live'");
       expect(liveTest).toContain('live.invoke');
 
-      const unit = getWrittenContent(writeFileSync, 'unit/example.test.ts');
-      expect(unit).toContain("from 'vitest'");
-
       const evalTest = getWrittenContent(writeFileSync, 'evals/example.eval.ts');
       expect(evalTest).toContain("from 'sunpeak/eval'");
       expect(evalTest).toContain('defineEval');
+
+      // Sets "type": "module" in package.json
+      const pkgJson = getWrittenContent(writeFileSync, 'package.json');
+      expect(JSON.parse(pkgJson).type).toBe('module');
     });
 
     it('should scaffold all test types for sunpeak projects without NOTE in live config', async () => {
@@ -848,12 +850,12 @@ describe('CLI Commands', () => {
 
       const writtenPaths = writeFileSync.mock.calls.map((c: [string, string]) => c[0]);
 
-      // All test types
+      // All test types (no unit tests — those come from sunpeak new)
       expect(writtenPaths).toContainEqual(expect.stringContaining('playwright.config.ts'));
       expect(writtenPaths).toContainEqual(expect.stringContaining('visual.test.ts'));
       expect(writtenPaths).toContainEqual(expect.stringContaining('live/playwright.config.ts'));
       expect(writtenPaths).toContainEqual(expect.stringContaining('evals/eval.config.ts'));
-      expect(writtenPaths).toContainEqual(expect.stringContaining('unit/example.test.ts'));
+      expect(writtenPaths).not.toContainEqual(expect.stringContaining('unit/example.test.ts'));
 
       // Config uses defineConfig() with no args (root config, not live/)
       const config = getWrittenContent(writeFileSync, 'project/playwright.config.ts');
@@ -879,7 +881,6 @@ describe('CLI Commands', () => {
             if (path.includes('package.json')) return true;
             if (path.includes('visual.test.ts')) return true;
             if (path.includes('live/playwright.config.ts')) return true;
-            if (path.includes('unit/example.test.ts')) return true;
             return false;
           },
           readFileSync: () => JSON.stringify({ dependencies: { express: '*' } }),
@@ -889,11 +890,10 @@ describe('CLI Commands', () => {
 
       const writtenPaths = writeFileSync.mock.calls.map((c: [string, string]) => c[0]);
 
-      // Should NOT have written visual, live config, or unit test (they already exist)
+      // Should NOT have written visual or live config (they already exist)
       expect(writtenPaths).not.toContainEqual(expect.stringContaining('visual.test.ts'));
       expect(writtenPaths).not.toContainEqual(expect.stringContaining('live/playwright.config.ts'));
       expect(writtenPaths).not.toContainEqual(expect.stringContaining('live/example.test.ts'));
-      expect(writtenPaths).not.toContainEqual(expect.stringContaining('unit/example.test.ts'));
 
       // Should still have written smoke test and evals (they don't exist in the mock)
       expect(writtenPaths).toContainEqual(expect.stringContaining('smoke.test.ts'));
@@ -948,18 +948,9 @@ describe('CLI Commands', () => {
         );
       expect(liveUncommented.join('\n')).not.toContain('live.invoke');
 
-      // Unit test: handler import and test bodies should be commented
-      const unit = getWrittenContent(writeFileSync, 'unit/example.test.ts');
-      expect(unit).toBeDefined();
-      const unitUncommented = unit!
-        .split('\n')
-        .filter(
-          (l) =>
-            !l.trim().startsWith('//') && !l.trim().startsWith('*') && !l.trim().startsWith('/**')
-        );
-      // The vitest import is OK uncommented, but actual test logic should be commented
-      expect(unitUncommented.join('\n')).not.toContain('handler');
-      expect(unitUncommented.join('\n')).not.toContain('expect(tool');
+      // Unit tests are not scaffolded for standalone testing framework
+      const writtenPaths = writeFileSync.mock.calls.map((c: [string, string]) => c[0]);
+      expect(writtenPaths).not.toContainEqual(expect.stringContaining('unit/'));
     });
 
     it('should include multi-language hints in "configure later" config', async () => {

--- a/skills/test-mcp-server/SKILL.md
+++ b/skills/test-mcp-server/SKILL.md
@@ -36,17 +36,17 @@ Test examples live at `/tmp/sunpeak/packages/sunpeak/template/tests/`. This incl
 
 ```bash
 sunpeak inspect              # Inspect any MCP server in the inspector (standalone)
-sunpeak test                 # Run unit + e2e tests
-sunpeak test --unit          # Run unit tests only (vitest)
+sunpeak test                 # Run unit (if configured) + e2e tests
 sunpeak test --e2e           # Run e2e tests only (Playwright)
 sunpeak test --visual        # Run e2e tests with visual regression comparison
 sunpeak test --visual --update  # Update visual regression baselines
 sunpeak test init            # Scaffold test infrastructure into a project
 sunpeak test --live          # Run live tests against real ChatGPT (requires tunnel + browser session)
 sunpeak test --eval          # Run evals against multiple LLM models (requires API keys)
+sunpeak test --unit          # Run unit tests (sunpeak app framework only, not standalone)
 ```
 
-Flags are additive: `--unit --e2e --live --eval` runs all four. `--update` implies `--visual`. `--eval` and `--live` are never included in the default run (they cost money).
+Flags are additive: `--e2e --live --eval` runs all three. `--update` implies `--visual`. `--eval` and `--live` are never included in the default run (they cost money). `--unit` is only for sunpeak app framework projects (created with `sunpeak new`), not standalone testing.
 
 ## E2E Tests with the `mcp` and `inspector` Fixtures
 


### PR DESCRIPTION
## Summary

- **`sunpeak test init` no longer scaffolds unit tests** — unit tests are app-framework-only (provided by `sunpeak new`). Standalone testing framework users get e2e, visual, live, and eval tests. Removed the `scaffoldUnitTest` function and vitest from the suggested install deps.
- **Auto-sets `"type": "module"` in package.json** for JS projects during `test init`, so Playwright can resolve sunpeak's ESM-only exports (previously failed with `ERR_PACKAGE_PATH_NOT_EXPORTED` in CJS projects).
- **`sunpeak test` skips unit tests gracefully** when vitest isn't installed, instead of failing. Only errors when `--unit` is explicitly passed.
- Updated docs, CLAUDE.md, and skills to clarify that `--unit` is for sunpeak app framework projects only.

## Test plan

- [x] All 362 unit tests pass
- [x] Lint and typecheck pass
- [ ] Verify `sunpeak test init` on a fresh JS project no longer creates `tests/unit/` or `vitest.config.ts`
- [ ] Verify `sunpeak new` still scaffolds unit tests with full vitest setup
- [ ] Verify `sunpeak test` (no flags) succeeds in a project without vitest installed