### PR TITLE
fix: Windows ESM import errors in sunpeak CLI

### DIFF
--- a/packages/sunpeak/bin/commands/dev.mjs
+++ b/packages/sunpeak/bin/commands/dev.mjs
@@ -4,7 +4,7 @@ import * as path from 'path';
 const { existsSync, readFileSync, watch: fsWatch } = fs;
 const { join, resolve, basename, dirname } = path;
 import { createRequire } from 'module';
-import { pathToFileURL } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { spawn } from 'child_process';
 import { getPort } from '../lib/get-port.mjs';
 import { startSandboxServer } from '../lib/sandbox-server.mjs';
@@ -68,7 +68,7 @@ async function importFromProject(require, moduleName) {
  */
 function startBuildWatcher(projectRoot, resourcesDir, mcpHandle, { skipInitialBuild = false } = {}) {
   let activeChild = null;
-  const sunpeakBin = join(dirname(new URL(import.meta.url).pathname), '..', 'sunpeak.js');
+  const sunpeakBin = join(dirname(fileURLToPath(import.meta.url)), '..', 'sunpeak.js');
 
   const runBuild = () => {
     // Kill any in-progress build and start fresh
@@ -205,7 +205,7 @@ export async function dev(projectRoot = process.cwd(), args = []) {
   // --prod-resources: Run initial production build so dist/ is ready before server starts
   if (isProdResources) {
     console.log('Building production resources...');
-    const sunpeakBin = join(dirname(new URL(import.meta.url).pathname), '..', 'sunpeak.js');
+    const sunpeakBin = join(dirname(fileURLToPath(import.meta.url)), '..', 'sunpeak.js');
     const { execSync } = await import('child_process');
     try {
       execSync(`${process.execPath} ${sunpeakBin} build`, {

--- a/packages/sunpeak/bin/sunpeak.js
+++ b/packages/sunpeak/bin/sunpeak.js
@@ -2,11 +2,16 @@
 
 import { existsSync, readFileSync } from 'fs';
 import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { discoverResources } from './lib/patterns.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const COMMANDS_DIR = join(__dirname, 'commands');
+
+// On Windows, absolute paths like "C:\..." can't be passed directly to dynamic
+// import() — Node's ESM loader parses "C:" as a URL scheme and rejects it.
+// Wrap with pathToFileURL().href to produce a valid file:// URL.
+const commandUrl = (file) => pathToFileURL(join(COMMANDS_DIR, file)).href;
 
 function checkPackageJson() {
   const pkgPath = join(process.cwd(), 'package.json');
@@ -46,49 +51,49 @@ function getVersion() {
   switch (command) {
     case 'new':
       {
-        const { init } = await import(join(COMMANDS_DIR, 'new.mjs'));
+        const { init } = await import(commandUrl('new.mjs'));
         await init(args[0], args[1]);
       }
       break;
 
     case 'dev':
       {
-        const { dev } = await import(join(COMMANDS_DIR, 'dev.mjs'));
+        const { dev } = await import(commandUrl('dev.mjs'));
         await dev(process.cwd(), args);
       }
       break;
 
     case 'build':
       {
-        const { build } = await import(join(COMMANDS_DIR, 'build.mjs'));
+        const { build } = await import(commandUrl('build.mjs'));
         await build(process.cwd());
       }
       break;
 
     case 'start':
       {
-        const { start } = await import(join(COMMANDS_DIR, 'start.mjs'));
+        const { start } = await import(commandUrl('start.mjs'));
         await start(process.cwd(), args);
       }
       break;
 
     case 'inspect':
       {
-        const { inspect } = await import(join(COMMANDS_DIR, 'inspect.mjs'));
+        const { inspect } = await import(commandUrl('inspect.mjs'));
         await inspect(args);
       }
       break;
 
     case 'test':
       {
-        const { runTest } = await import(join(COMMANDS_DIR, 'test.mjs'));
+        const { runTest } = await import(commandUrl('test.mjs'));
         await runTest(args);
       }
       break;
 
     case 'upgrade':
       {
-        const { upgrade } = await import(join(COMMANDS_DIR, 'upgrade.mjs'));
+        const { upgrade } = await import(commandUrl('upgrade.mjs'));
         const options = {
           check: args.includes('--check') || args.includes('-c'),
           help: args.includes('--help') || args.includes('-h'),


### PR DESCRIPTION
## About Issue

Node's ESM loader rejects Windows absolute paths like 'C:\...' because it parses the drive letter as a URL scheme. Convert paths to file:// URLs before passing them to dynamic import() and child_process.spawn().

- bin/sunpeak.js: wrap command imports with pathToFileURL().href so 'sunpeak dev', 'inspect', 'build', etc. load on Windows.
- bin/commands/dev.mjs: replace 'new URL(import.meta.url).pathname' with 'fileURLToPath(import.meta.url)' to avoid the doubled drive letter ('C:\C:\...') that broke the build watcher and the --prod-resources initial build.


## BEFORE

```
 $ pnpm --filter sunpeak dev                                                                 
                                                                                              
  > sunpeak@0.20.12 dev D:\work\sunpeak\packages\sunpeak                                      
  > pnpm -C template dev                                                                      
                                                                                              
                                                                                              
  > sunpeak-app@0.1.0 dev D:\work\sunpeak\packages\sunpeak\template                           
  > sunpeak dev                                                                               
                                                                                              
  Error: Only URLs with a scheme in: file, data, and node are supported by the default ESM    
  loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:'       
   ELIFECYCLE  Command failed with exit code 1.                                               
  D:\work\sunpeak\packages\sunpeak:                                                           
   ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  sunpeak@0.20.12 dev: pnpm -C template dev             
  Exit status 1
```

## AFTER FIX

```
$ pnpm --filter sunpeak dev  

> sunpeak@0.20.15 dev C:\Users\jayka\OneDrive\Desktop\sunpeak\packages\sunpeak
> pnpm -C template dev


> sunpeak-app@0.1.0 dev C:\Users\jayka\OneDrive\Desktop\sunpeak\packages\sunpeak\template
> sunpeak dev

Starting dev server...

Starting MCP server with 7 simulation(s) (Vite HMR)...
Sunpeak MCP server listening on http://localhost:8000
  MCP endpoint: http://localhost:8000/mcp
  Vite HMR: enabled (source files served with hot reload)
[build] Building resources for the MCP server for non-ChatGPT hosts...
[build] Watching src/resources/ for changes...
Connecting to MCP server: http://localhost:8000/mcp
[MCP] ← initialize
[MCP] Registered 7 tool(s) (6 UI, 1 plain), 4 resource(s)
[MCP] Session started: daa286e4... (local, 1 active)
[MCP] ← notifications/initialized (daa286e4...)
Connected. Discovering tools and resources...
[MCP] ← tools/list (daa286e4...)
[MCP] ← resources/list (daa286e4...)
Found 7 tool(s), 6 resource(s).
10:34:40 pm [vite] (client) Re-optimizing dependencies because vite config has changed
  ➜  Local:   http://localhost:3000/
  ➜  Network: http://10.239.70.135:3000/
  ➜  press h + enter to show help
```