### PR TITLE
test: make CLI tests cross-platform on Windows

### DIFF
--- a/packages/sunpeak/src/cli/commands.test.ts
+++ b/packages/sunpeak/src/cli/commands.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck - CLI command modules are .mjs files without TypeScript declarations
 import { describe, it, expect, vi } from 'vitest';
+import path from 'node:path';
 
 // Helper functions to import CLI modules dynamically
 const importUpgrade = () => import('../../bin/commands/upgrade.mjs');
@@ -160,7 +161,7 @@ describe('CLI Commands', () => {
 
       expect(execSyncMock).toHaveBeenCalledWith(
         'npx skills add Sunpeak-AI/sunpeak@create-sunpeak-app Sunpeak-AI/sunpeak@test-mcp-server',
-        expect.objectContaining({ cwd: '/test/my-project', stdio: 'inherit' })
+        expect.objectContaining({ cwd: path.join('/test', 'my-project'), stdio: 'inherit' })
       );
     });
 
@@ -281,8 +282,8 @@ describe('CLI Commands', () => {
 
       // Verify dotfiles were renamed
       expect(renamedFiles).toContainEqual({
-        from: '/test/my-project/_gitignore',
-        to: '/test/my-project/.gitignore',
+        from: path.join('/test/my-project', '_gitignore'),
+        to: path.join('/test/my-project', '.gitignore'),
       });
 
       // Verify outro was called
@@ -737,7 +738,7 @@ describe('CLI Commands', () => {
       pathSuffix: string
     ): string | undefined {
       const call = mock.mock.calls.find((c: [string, string]) =>
-        (c[0] as string).endsWith(pathSuffix)
+        (c[0] as string).replace(/\\/g, '/').endsWith(pathSuffix)
       );
       return call ? (call[1] as string) : undefined;
     }
@@ -755,7 +756,9 @@ describe('CLI Commands', () => {
         })
       );
 
-      const writtenPaths = writeFileSync.mock.calls.map((c: [string, string]) => c[0]);
+      const writtenPaths = writeFileSync.mock.calls.map((c: [string, string]) =>
+        (c[0] as string).replace(/\\/g, '/')
+      );
 
       // All expected files
       expect(writtenPaths).toContainEqual(expect.stringContaining('smoke.test.ts'));
@@ -798,7 +801,9 @@ describe('CLI Commands', () => {
         })
       );
 
-      const writtenPaths = writeFileSync.mock.calls.map((c: [string, string]) => c[0]);
+      const writtenPaths = writeFileSync.mock.calls.map((c: [string, string]) =>
+        (c[0] as string).replace(/\\/g, '/')
+      );
 
       // 4 test types (no unit tests — those are app-framework-only)
       expect(writtenPaths).toContainEqual(expect.stringContaining('e2e/smoke.test.ts'));
@@ -848,7 +853,9 @@ describe('CLI Commands', () => {
         })
       );
 
-      const writtenPaths = writeFileSync.mock.calls.map((c: [string, string]) => c[0]);
+      const writtenPaths = writeFileSync.mock.calls.map((c: [string, string]) =>
+        (c[0] as string).replace(/\\/g, '/')
+      );
 
       // All test types (no unit tests — those come from sunpeak new)
       expect(writtenPaths).toContainEqual(expect.stringContaining('playwright.config.ts'));
@@ -877,10 +884,11 @@ describe('CLI Commands', () => {
       await testInit(
         ['--server', 'http://localhost:8000/mcp'],
         createTestInitDeps({
-          existsSync: (path: string) => {
-            if (path.includes('package.json')) return true;
-            if (path.includes('visual.test.ts')) return true;
-            if (path.includes('live/playwright.config.ts')) return true;
+          existsSync: (p: string) => {
+            const normalized = p.replace(/\\/g, '/');
+            if (normalized.includes('package.json')) return true;
+            if (normalized.includes('visual.test.ts')) return true;
+            if (normalized.includes('live/playwright.config.ts')) return true;
             return false;
           },
           readFileSync: () => JSON.stringify({ dependencies: { express: '*' } }),
@@ -888,7 +896,9 @@ describe('CLI Commands', () => {
         })
       );
 
-      const writtenPaths = writeFileSync.mock.calls.map((c: [string, string]) => c[0]);
+      const writtenPaths = writeFileSync.mock.calls.map((c: [string, string]) =>
+        (c[0] as string).replace(/\\/g, '/')
+      );
 
       // Should NOT have written visual or live config (they already exist)
       expect(writtenPaths).not.toContainEqual(expect.stringContaining('visual.test.ts'));
@@ -949,7 +959,9 @@ describe('CLI Commands', () => {
       expect(liveUncommented.join('\n')).not.toContain('live.invoke');
 
       // Unit tests are not scaffolded for standalone testing framework
-      const writtenPaths = writeFileSync.mock.calls.map((c: [string, string]) => c[0]);
+      const writtenPaths = writeFileSync.mock.calls.map((c: [string, string]) =>
+        (c[0] as string).replace(/\\/g, '/')
+      );
       expect(writtenPaths).not.toContainEqual(expect.stringContaining('unit/'));
     });
 


### PR DESCRIPTION
Path assertions in commands.test.ts assumed POSIX separators, so 9 tests failed on Windows where path.join produces backslashes. Use path.join for expected literals and normalize backslashes to forward slashes when matching mock-call paths. Runtime code unchanged.

## BEFORE

The failures

  All paths in the test file use /, but on Windows path.join('/test', 'my-project', ...) returns
  \test\my-project\..., so the matchers don't find a match.

  #: 1
  Test: should create project with selected resources
  Expected: { from: '/test/my-project/_gitignore', to: '/test/my-project/.gitignore' }
  Actual on Windows: \test\my-project\_gitignore
  ────────────────────────────────────────
  #: 2
  Test: should scaffold e2e, visual, live, and eval tests for external projects
  Expected: stringContaining('live/playwright.config.ts')
  Actual on Windows: …\sunpeak\live\playwright.config.ts
  ────────────────────────────────────────
  #: 3
  Test: should scaffold 4 test types for JS projects
  Expected: stringContaining('e2e/smoke.test.ts')
  Actual on Windows: …\tests\e2e\smoke.test.ts
  ────────────────────────────────────────
  #: 4
  Test: should scaffold all test types for sunpeak projects without NOTE in live config
  Expected: stringContaining('live/playwright.config.ts')
  Actual on Windows: …\tests\live\playwright.config.ts
  ────────────────────────────────────────
  #: 5
  Test: should skip existing files without overwriting
  Expected: stringContaining('evals/eval.config.ts')
  Actual on Windows: …\tests\evals\eval.config.ts
  ────────────────────────────────────────
  #: 6
  Test: should parse command-based server into command and args
  Expected: getWrittenContent(…, 'sunpeak/playwright.config.ts')
  Actual on Windows: endsWith() returns false → config is undefined
  ────────────────────────────────────────
  #: 7
  Test: should not scaffold test bodies that would fail on missing tools
  Expected: getWrittenContent(…, 'live/example.test.ts')
  Actual on Windows: same as above
  ────────────────────────────────────────
  #: 8
  Test: should include multi-language hints in "configure later" config
  Expected: getWrittenContent(…, 'sunpeak/playwright.config.ts')
  Actual on Windows: same as above
  
  ## AFTER FIXES
all `pnpm --filter sunpeak validate` - all checks pass.