### PR TITLE
docs: add "Why sunpeak" section and surface evals as primary value prop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,9 @@ The value proposition of the sunpeak framework is to help developers and their a
    2. Protect developers from 4-click manual refreshes on every code change in each host.
    3. Cancel all the $20 per person per host per month testing accounts.
    4. Avoid burning host credits on every test and code change.
-2. Build multi-platform MCP Apps in a structured way that's easy to understand and get started.
-3. Test their MCPs in ChatGPT with HMR and Claude with automatic rebuilds and refresh notifications.
+2. Verify MCP tools work across multiple LLM models via the eval framework. Evals connect to the MCP server, discover tools, and send prompts to multiple models (GPT-4o, GPT-4o-mini, o4-mini, Claude Sonnet, Gemini 2.0 Flash) via the Vercel AI SDK. Each case runs N times per model and reports pass/fail counts, so developers can confirm that tool descriptions and schemas work reliably on smaller and cheaper models, not just flagship ones. Opt-in via `sunpeak test --eval` because evals cost money.
+3. Build multi-platform MCP Apps in a structured way that's easy to understand and get started.
+4. Test their MCPs in ChatGPT with HMR and Claude with automatic rebuilds and refresh notifications.
 
 ## Quick Reference
 
@@ -217,6 +218,8 @@ Convention-over-configuration for building MCP Apps. The inspector and testing a
 #### 2. Testing Framework
 
 Automated testing powered by the inspector. Works with any MCP server in any language. sunpeak's long-term goal is to be the generic testing framework for all MCP servers, not just MCP Apps. MCP Apps (interactive UIs in chat) are the current specialty, but the testing framework should work for any server that implements the MCP protocol. Keep MCP protocol primitives as a clean, 1:1 layer that can evolve with the spec. Layer sunpeak-specific functionality (inspector rendering, visual regression, simulations, MCP Apps features) on top without mixing it into the protocol layer.
+
+The framework covers two distinct testing needs: (1) **runtime correctness** via e2e, visual, and live tests that exercise the replicated ChatGPT and Claude runtimes, and (2) **model compatibility** via the eval framework (`sunpeak/eval`), which connects to your MCP server, discovers tools via MCP protocol, and sends prompts to multiple models (GPT-4o, GPT-4o-mini, o4-mini, Claude Sonnet, Gemini 2.0 Flash) via the Vercel AI SDK. Each case runs N times per model and reports pass/fail counts so developers can confirm tool descriptions and schemas work reliably on smaller and cheaper models, not just flagship ones. Evals are opt-in (`--eval`) because they cost money.
 
 **`mcp` fixture** (`sunpeak/test`) — protocol-only methods:
 - `callTool(name, input?)` — call a tool, return the MCP result

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Overview"
-description: "MCP App framework, MCP testing framework, and inspector for MCP servers and MCP Apps."
+description: "Server-agnostic MCP testing framework and full-stack MCP App framework."
 keywords: ["MCP Apps", "ChatGPT Apps", "MCP app framework", "ChatGPT app framework", "Claude Apps", "Claude Connectors", "sunpeak"]
 ---
 

--- a/packages/sunpeak/README.md
+++ b/packages/sunpeak/README.md
@@ -16,9 +16,9 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue?style=flat&logo=typescript&label=ts&color=FFB800&logoColor=white&labelColor=000035)](https://www.typescriptlang.org/)
 [![React](https://img.shields.io/badge/React-19-blue?style=flat&logo=react&label=react&color=FFB800&logoColor=white&labelColor=000035)](https://reactjs.org/)
 
-MCP App framework, MCP testing framework, and inspector for MCP servers and MCP Apps.
+Server-agnostic MCP testing framework and full-stack MCP App framework.
 
-Build cross-platform: sunpeak is a ChatGPT App framework, Claude Connector framework, and more.
+MCP Apps are cross-platform, meaning sunpeak is a ChatGPT App framework, Claude Connector framework, and more.
 
 ```bash
 npx sunpeak new
@@ -30,7 +30,29 @@ npx sunpeak new
 [Documentation](https://sunpeak.ai/docs) ~
 [GitHub](https://github.com/Sunpeak-AI/sunpeak)
 
-## sunpeak is three things
+## Why sunpeak
+
+Building an MCP App today means testing in ChatGPT and Claude by hand. Every code change costs a 4-click refresh in each host, every teammate needs a $20/month account per host, and every test burns credits.
+
+sunpeak replicates the ChatGPT and Claude runtimes locally so you can:
+
+- Run e2e and visual tests in CI across every host, theme, and data combo, without accounts or API credits.
+- Iterate with HMR in ChatGPT and automatic rebuilds in Claude, instead of manual refreshes.
+- Pin tool states with simulation fixtures so UI regressions can't ship.
+
+sunpeak also runs evals against your MCP server across multiple models (GPT-4o, GPT-4o-mini, o4-mini, Claude Sonnet, Gemini 2.0 Flash) via the Vercel AI SDK. Each case runs N times per model, so you can prove your tool descriptions and schemas hold up on cheaper models, not just the flagship ones.
+
+<div align="center">
+  <a href="https://sunpeak.ai/docs/testing/evals">
+    <picture>
+      <img alt="Sunpeak logo" src="https://cdn.sunpeak.ai/sunpeak-eval.png">
+    </picture>
+  </a>
+</div>
+
+The same foundation powers an app framework for multi-platform MCP Apps and a standalone inspector that works with any MCP server in any language.
+
+## sunpeak has three use cases
 
 ### 1. App Framework
 
@@ -75,6 +97,8 @@ npx sunpeak test
 ```
 
 Playwright fixtures handle inspector startup, MCP connection, iframe traversal, and host switching. Works with Python, Go, TypeScript, Rust, or any language.
+
+Evals add a second dimension: model compatibility. The eval framework connects to your MCP server via the MCP protocol, discovers its tools, and sends prompts to multiple models (GPT-4o, GPT-4o-mini, o4-mini, Claude Sonnet, Gemini 2.0 Flash) via the Vercel AI SDK. Each case runs N times per model and reports pass/fail counts, so you can measure whether your tool descriptions and schemas work reliably across smaller and cheaper models, not just the flagship ones.
 
 ```ts
 import { test, expect } from 'sunpeak/test';


### PR DESCRIPTION
## Summary

- Adds a "Why sunpeak" problem-framing section to `packages/sunpeak/README.md` above the use cases, covering the manual-testing pain points (4-click refreshes, per-host accounts, burned credits) sunpeak solves.
- Positions multi-model evals (GPT-4o, GPT-4o-mini, o4-mini, Claude Sonnet, Gemini 2.0 Flash via the Vercel AI SDK) as a primary value prop alongside the runtime replica, in both the new section and the Testing Framework use case.
- Updates `CLAUDE.md` value props and the Testing Framework subsection to match, splitting coverage into runtime correctness vs. model compatibility.
- Aligns `docs/index.mdx` tagline with the README.

## Test plan

- [x] Render `packages/sunpeak/README.md` on GitHub and confirm the new section, bullets, and eval image display correctly.
- [x] Confirm `docs/index.mdx` description matches the README tagline on the docs site.