### PR TITLE
docs: surface live tests as a primary value prop in README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,9 @@ The value proposition of the sunpeak framework is to help developers and their a
    3. Cancel all the $20 per person per host per month testing accounts.
    4. Avoid burning host credits on every test and code change.
 2. Verify MCP tools work across multiple LLM models via the eval framework. Evals connect to the MCP server, discover tools, and send prompts to multiple models (GPT-4o, GPT-4o-mini, o4-mini, Claude Sonnet, Gemini 2.0 Flash) via the Vercel AI SDK. Each case runs N times per model and reports pass/fail counts, so developers can confirm that tool descriptions and schemas work reliably on smaller and cheaper models, not just flagship ones. Opt-in via `sunpeak test --eval` because evals cost money.
-3. Build multi-platform MCP Apps in a structured way that's easy to understand and get started.
-4. Test their MCPs in ChatGPT with HMR and Claude with automatic rebuilds and refresh notifications.
+3. Automate the real-host testing loop with **live tests** (`sunpeak test --live`): scripts that drive a real browser into ChatGPT (and other hosts as they're supported), send prompts that trigger MCP tool calls against the developer's server, and assert against the actually-rendered app via Playwright. Live tests catch what the inspector can't (real MCP connection behavior, real LLM tool invocation, host-specific iframe rendering, production resource loading) and replace the manual prompt-and-click loop. Opt-in because they hit real accounts.
+4. Build multi-platform MCP Apps in a structured way that's easy to understand and get started.
+5. Test their MCPs in ChatGPT with HMR and Claude with automatic rebuilds and refresh notifications.
 
 ## Quick Reference
 

--- a/packages/sunpeak/README.md
+++ b/packages/sunpeak/README.md
@@ -39,6 +39,7 @@ sunpeak replicates the ChatGPT and Claude runtimes locally so you can:
 - Run e2e and visual tests in CI across every host, theme, and data combo, without accounts or API credits.
 - Iterate with HMR in ChatGPT and automatic rebuilds in Claude, instead of manual refreshes.
 - Pin tool states with simulation fixtures so UI regressions can't ship.
+- Automate the real-host loop with live tests: scripts that open your browser, prompt ChatGPT, and assert against the rendered app so you stop click-testing by hand.
 
 sunpeak also runs evals against your MCP server across multiple models (GPT-4o, GPT-4o-mini, o4-mini, Claude Sonnet, Gemini 2.0 Flash) via the Vercel AI SDK. Each case runs N times per model, so you can prove your tool descriptions and schemas hold up on cheaper models, not just the flagship ones.
 
@@ -90,7 +91,7 @@ sunpeak replicates these host runtimes and provides simulation fixtures (JSON fi
 npx sunpeak test init --server http://localhost:8000/mcp
 ```
 
-This scaffolds E2E tests, visual regression, live host tests, and multi-model evals. Then run them:
+This scaffolds E2E tests, visual regression, live tests, and multi-model evals. Then run them:
 
 ```bash
 npx sunpeak test


### PR DESCRIPTION
## Summary
- Adds a fourth bullet to the README "Why sunpeak" section describing live tests as scripts that open a browser, prompt ChatGPT, and assert against the rendered app
- Adds live tests as value-prop #3 in CLAUDE.md (alongside local replica testing and evals), noting `sunpeak test --live` and what they catch that the inspector can't
- Tightens the test scaffolding paragraph in the README to call out live tests explicitly