### PR TITLE
feat: support embedding the Inspector as a React component

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,28 @@ The value proposition of the sunpeak framework is to help developers and their a
 3. Automate the real-host testing loop with **live tests** (`sunpeak test --live`): scripts that drive a real browser into ChatGPT (and other hosts as they're supported), send prompts that trigger MCP tool calls against the developer's server, and assert against the actually-rendered app via Playwright. Live tests catch what the inspector can't (real MCP connection behavior, real LLM tool invocation, host-specific iframe rendering, production resource loading) and replace the manual prompt-and-click loop. Opt-in because they hit real accounts.
 4. Build multi-platform MCP Apps in a structured way that's easy to understand and get started.
 5. Test their MCPs in ChatGPT with HMR and Claude with automatic rebuilds and refresh notifications.
+6. **Embed the Inspector as a React component** inside any third-party React app to render arbitrary MCP Apps. The `<Inspector app={...} onCallTool={...} />` shape exposes the same double-iframe runtime, host shells, and conversation chrome as the CLI inspector, but without any sunpeak-owned servers or `/__sunpeak/*` runtime dependencies. Tool calls flow through a callback the embedder owns; resource HTML is passed as a string. Embedders host the static sandbox proxy (`dist/sandbox-proxy.html`) on a separate origin from their own app — or fall back to the same-origin `srcdoc` variant for zero deployment. This is a first-class use case; treat it as load-bearing when designing changes.
+
+## Embedded Inspector — design constraints
+
+Maintain these properties when changing the Inspector or its supporting code:
+
+- **Public hierarchical API**: the `app` prop on `<Inspector />` is the public input shape for embedders (`InspectorApp` → resources + tools → simulations). Flatten internally; never require embedders to learn the legacy flat `simulations` map.
+- **No `/__sunpeak/*` runtime dependencies in the React component**: the bundled Inspector must not assume any sunpeak-owned HTTP endpoints exist in the embedder's origin. Health checks, tool calls, simulation discovery, and OAuth all flow through props (`onCallTool`, `app.resources[].html`) or are gated off in embedded mode.
+- **Two CSS entries — keep them aligned**: `sunpeak/style.css` ships full Tailwind preflight (used by resources loading into iframe documents — `pnpm dev` and the CLI / template path). `sunpeak/embed.css` ships the same Tailwind utilities + theme, but with preflight scoped under `.sunpeak-inspector-root` (used by embedders hosting the Inspector inside another React app). When changing the scoped preflight rules, update both files — `src/inspector/globals.css` (for style.css, full preflight via `@import "tailwindcss"`) and `src/embed.css` (scoped preflight, theme + utilities only). Embed mode invariant: the host page's `<button>`, `<input>`, typography, and `data-theme` attribute must be untouched. The one acknowledged document-level injection is host `@font-face` (inert to host pages).
+- **Theme + host-context application stays root-scoped**: variables, color-scheme, `data-theme` go on the Inspector's root ref, not `document.documentElement`. The `ThemeProvider` default still targets the document for callers using it outside the bundled Inspector — the Inspector overrides with a no-op.
+- **Sizing follows the parent in embedded mode**: when `app` is provided, the root uses `h-full w-full` (fills the container the embedder gives it) instead of `h-screen w-screen` (fills the viewport). Don't reintroduce viewport-relative sizing in the embedded path.
+- **Sandbox proxy is delivered three ways**: hosted static file (`dist/sandbox-proxy.html`, ~7KB, runtime-configurable via URL params), CLI dev server (`startSandboxServer`), and `srcdoc` fallback (same-origin, lower fidelity). All three must stay behaviorally identical — see `src/inspector/sandbox-static.test.ts` for the drift guard.
+- **Mutually exclusive props**: `app` and `simulations` are mutually exclusive; `app` wins and emits a one-time `console.warn`. Don't add a third way in.
+- **Simulation `name` vs `displayName`**: `Simulation.name` is the unique internal key (`<toolName>__<userSimName>` for the embed path); `Simulation.displayName` is the user-facing sidebar label (the embedder's raw `sim.name`). Don't collapse them — `name` is what URL deep-links and state indexing rely on; `displayName` is purely cosmetic. Sidebar code falls back to `name` when `displayName` is absent.
+- **Security invariants (don't regress these)**:
+  - The inline helper script (`src/inspector/inline-helper-script.ts`) must keep its `ev.source === window.parent` guard on incoming messages. Sibling iframes and extension content scripts could otherwise forge `ui/notifications/tool-result` and drive the embedder's callbacks with attacker-controlled data.
+  - `sandboxUrl` validation rejects non-http(s) URLs — match this precedent if adding any new URL-accepting prop.
+  - The Inspector does **no** sanitization of `app.resources[].html`. Don't add accidental innerHTML paths that read from resources, tool results, or other embedder-supplied strings — React's text-node escaping is the only XSS defense.
+  - Tool result JSON is escaped (`<` → `<`) when injected into the `<script id="__tool-result">` data island. Don't switch to a less-escaped serialization.
+  - The mock `openExternal` runtime in `mock-openai-runtime.ts` rejects non-http(s) URLs and uses `noopener,noreferrer`. Preserve both when changing the runtime.
+  - The `srcdoc` fallback is documented as **not safe for untrusted HTML** (runs in the host's origin via `allow-same-origin` + same-origin srcdoc). Keep the separate-origin sandbox file as the recommended production path.
+- **Data-source agnostic**: the same `app` + `onCallTool` API covers three patterns and the Inspector renders identically in all of them. (a) Live MCP server — `app.resources[].html` comes from `mcpClient.readResource(...)` and `onCallTool` forwards to `mcpClient.callTool(...)`. (b) Static / no-server — HTML is a string literal and `onCallTool` returns canned responses (or simulations carry pre-canned `toolResult`s so it's never called). (c) Hybrid — live MCP discovery plus saved simulations per tool, letting users flip between "None" (live call) and saved states (canned result). Don't add branches that assume one mode over the others; the Inspector should never know which it's in. Embedders proxying live MCP through their own backend (typical: `/api/mcp/...`) is the embedder's concern, not sunpeak's — the React component never makes outbound MCP calls itself.
 
 ## Quick Reference
 
@@ -114,7 +136,8 @@ packages/sunpeak/
 - `sunpeak/test/live/chatgpt/config` — ChatGPT-specific Playwright config factory
 - `sunpeak/test/inspect/config` — Inspect config factory for external MCP servers (`defineInspectConfig`; supports `env`, `cwd`, `timeout`, `visual` options)
 - `sunpeak/inspect` — Programmatic inspector server (`inspectServer` — start the inspector from code instead of CLI; accepts `server`, `port`, `env`, `cwd`, etc.)
-- `sunpeak/style.css` — Main stylesheet
+- `sunpeak/style.css` — Full-preflight stylesheet for resources rendered inside iframe documents (CLI dev / template path)
+- `sunpeak/embed.css` — Scoped-preflight stylesheet for embedders hosting the Inspector inside their own React app
 
 ## Key Types
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -251,6 +251,7 @@
             "group": "Inspector & Simulations",
             "pages": [
               "testing/inspector",
+              "testing/inspector-embedding",
               "testing/simulations"
             ]
           },

--- a/docs/testing/inspector-embedding.mdx
+++ b/docs/testing/inspector-embedding.mdx
@@ -1,0 +1,493 @@
+---
+title: "Embedding the Inspector"
+description: "Drop the sunpeak Inspector into your own React app and point it at any MCP App."
+keywords: ["MCP Apps", "sunpeak", "Inspector", "React component", "embed"]
+---
+
+<Badge color="yellow">sunpeak API</Badge>
+
+The `Inspector` component is also shipped as a standalone React component. You
+can drop it into any React app and render any MCP App — the rest of the
+testing framework, the CLI dev server, and the simulation file layout are not
+required.
+
+This page covers the embedding path. For the CLI-driven usage that ships with
+the framework, see [Inspector](/testing/inspector).
+
+## Install
+
+```bash
+npm install sunpeak
+```
+
+`react` and `react-dom` are peer dependencies (`>=18`). The Inspector ships
+two stylesheets:
+
+- **`sunpeak/embed.css`** — what you want for embedded use. Same Tailwind
+  utilities and theme as the full stylesheet, but preflight is scoped under
+  `.sunpeak-inspector-root` so it doesn't reset your host page's `<button>`,
+  `<input>`, headings, or list defaults.
+- `sunpeak/style.css` — used internally by the sunpeak CLI / template path,
+  where resources need full Tailwind preflight applied to their iframe
+  documents. Importing this in a host React app will reset your own page's
+  element styles.
+
+Import the embed stylesheet once anywhere in your app.
+
+## Minimum integration
+
+Pass an `app` prop describing the MCP App and an `onCallTool` callback that
+forwards tool invocations to the MCP server. That's the whole API.
+
+```tsx
+import { Inspector } from 'sunpeak/inspector';
+import 'sunpeak/embed.css';
+
+<Inspector
+  app={{
+    name: 'Albums',
+    resources: [
+      { uri: 'ui://albums', html: '<html>…</html>' },
+    ],
+    tools: [
+      {
+        tool: {
+          name: 'show_albums',
+          inputSchema: { type: 'object', properties: {}, required: [] },
+          _meta: { openai: { outputTemplate: 'ui://albums' } },
+        },
+        simulations: [
+          { name: 'two-albums', toolInput: { count: 2 }, toolResult: {/*…*/} },
+        ],
+      },
+    ],
+  }}
+  onCallTool={({ name, arguments: args }) =>
+    mcpClient.callTool({ name, arguments: args })
+  }
+/>
+```
+
+The Inspector flattens the hierarchy internally and renders the resource in
+its double-iframe sandbox with the conversation chrome around it. Users get
+the tool/simulation pickers, theme + host-context controls, and the run
+button — everything the CLI inspector has.
+
+## Data model
+
+The `app` prop mirrors the MCP App data model:
+
+- One **App** with a name and icon.
+- One or more **resources**, each identified by a `uri` and carrying the
+  resource HTML as a string.
+- One or more **tools**. Each tool's `_meta.openai.outputTemplate` URI links
+  it to the resource it renders.
+- Each tool has zero or more **simulations** — saved input/output states for
+  testing UI variants.
+
+```ts
+interface InspectorApp {
+  name?: string;
+  icon?: string;
+  resources: InspectorAppResource[];
+  tools: InspectorAppTool[];
+}
+
+interface InspectorAppResource {
+  uri: string;
+  html: string;
+  mimeType?: string;
+  _meta?: Record<string, unknown>;
+}
+
+interface InspectorAppTool {
+  tool: Tool; // MCP Tool with _meta.openai.outputTemplate
+  simulations?: InspectorAppSimulation[];
+}
+
+interface InspectorAppSimulation {
+  name: string;
+  userMessage?: string;
+  toolInput?: Record<string, unknown>;
+  toolResult?: CallToolResult;
+  serverTools?: Record<string, ServerToolMock>;
+}
+```
+
+## Where your data comes from
+
+The Inspector doesn't care where the resource HTML, tool definitions, or
+results come from — it renders what you hand it via `app` and forwards
+interactions through `onCallTool`. Three patterns fall out of that:
+
+### Live MCP server
+
+Build `app` from `listTools` + `listResources` + `readResource` against a
+real MCP server. Forward `onCallTool` to the server. Clicking **Run** in the
+sidebar hits the real server and renders the real result.
+
+```tsx
+const tools = await mcpClient.listTools();
+const resources = await Promise.all(
+  (await mcpClient.listResources()).resources.map(async (r) => ({
+    uri: r.uri,
+    html: (await mcpClient.readResource({ uri: r.uri })).contents[0].text,
+  })),
+);
+
+<Inspector
+  app={{
+    name: 'Live',
+    resources,
+    tools: tools.tools.map((tool) => ({ tool })),
+  }}
+  onCallTool={({ name, arguments: args }) =>
+    mcpClient.callTool({ name, arguments: args })
+  }
+/>
+```
+
+### Static / no-server
+
+Inject any HTML you want and either supply pre-canned `toolResult`s on
+simulations (so no callback fires) or stub `onCallTool` to return canned
+responses. Useful for demos, prototypes, fixtures from your own database,
+or rendering an app whose server isn't running yet.
+
+```tsx
+<Inspector
+  app={{
+    name: 'Static',
+    resources: [{ uri: 'ui://x', html: '<html>…</html>' }],
+    tools: [{
+      tool: {
+        name: 'show_x',
+        inputSchema: { type: 'object', properties: {}, required: [] },
+        _meta: { openai: { outputTemplate: 'ui://x' } },
+      },
+      simulations: [{ name: 'demo', toolResult: { content: [], structuredContent: {} } }],
+    }],
+  }}
+  onCallTool={() => ({ content: [{ type: 'text', text: 'no server' }] })}
+/>
+```
+
+### Hybrid — live tools plus saved states
+
+The most common production pattern. Build the `app` shape from MCP discovery
+**and** attach saved fixtures to each tool. Users flip between "None" in the
+Simulation picker (which calls the live server) and saved states (which
+short-circuit to the canned result) for regression testing.
+
+```tsx
+const app = {
+  name: 'My App',
+  resources: liveResources,
+  tools: liveTools.tools.map((tool) => ({
+    tool,
+    simulations: savedFixturesByToolName[tool.name] ?? [],
+  })),
+};
+
+<Inspector
+  app={app}
+  onCallTool={({ name, arguments: args }) =>
+    mcpClient.callTool({ name, arguments: args })
+  }
+/>
+```
+
+Switching modes is a one-line change: where the HTML in `app.resources[].html`
+came from (a `readResource` call or a string literal), and what `onCallTool`
+actually does (call a server or return canned data). The Inspector renders
+identically in all three cases.
+
+### Receiving tool inputs and results inside the iframe
+
+Resource HTML can subscribe to tool updates two ways:
+
+**Option A — `window.sunpeak` (no bundle).** The Inspector auto-injects a
+small helper into every resource you pass via `app.resources[].html`. The
+helper performs the MCP Apps `ui/initialize` handshake on your behalf and
+exposes a callback API. Plain HTML resources can use it directly:
+
+```html
+<script>
+  window.sunpeak.onToolResult((result) => {
+    // result is the standard MCP CallToolResult
+    const albums = result.structuredContent?.albums ?? [];
+    document.getElementById('list').textContent = albums.join(', ');
+  });
+  window.sunpeak.onToolInput((args) => {
+    // args is the tool's arguments object
+  });
+  window.sunpeak.onHostContextChange((ctx) => {
+    // ctx contains theme, displayMode, locale, etc.
+  });
+</script>
+```
+
+The full callback surface:
+
+- `onToolInput(cb)` — fires when the user invokes a tool; `cb` receives the
+  arguments object.
+- `onToolInputPartial(cb)` — fires for streamed/partial argument updates.
+- `onToolResult(cb)` — fires when a tool returns; `cb` receives the
+  `CallToolResult`.
+- `onToolCancelled(cb)` — fires when tool execution is interrupted.
+- `onHostContextChange(cb)` — fires when the host context (theme,
+  displayMode, locale, viewport, etc.) updates.
+
+Each subscription returns an unsubscribe function. Late subscribers get the
+last delivered value replayed immediately, so registration order doesn't
+matter.
+
+**Option B — `@modelcontextprotocol/ext-apps` directly.** Real MCP Apps
+typically bundle the SDK and use the `useApp()` hook (or its vanilla
+equivalent) to drive the handshake. To suppress the auto-injected helper
+in this case, add this to your resource HTML's `<head>`:
+
+```html
+<meta name="sunpeak-helper" content="off" />
+```
+
+Without the opt-out, both the helper and the SDK send `ui/initialize`. The
+host bridge tolerates the double-init (logs a warning), so the resource
+still works — but the warning is noisy. The opt-out is the clean path.
+
+The Inspector's **sidebar** doesn't depend on the iframe handshake — the
+Tool Input, Tool Result, and Host Context panels show the simulation's data
+either way. You'll still see saved fixtures and tool results in the sidebar
+even if the resource HTML itself doesn't render them.
+
+### A note on the live-server case
+
+Browsers can't directly hit an arbitrary MCP server from a third-party
+origin — cross-origin requests are blocked unless the server explicitly
+allows them, and most MCP servers don't. The MCP client in your React app
+will typically point at a proxy route on your own backend
+(`/api/mcp/...`), which forwards to the upstream MCP server with whatever
+auth, routing, and rate-limiting your product needs. This isn't a sunpeak
+constraint — any browser-side MCP client hits the same wall. The Inspector
+itself doesn't care; it only sees whatever the MCP client returns.
+
+## Building `app` from MCP calls
+
+If your app already has an MCP SDK `Client`, build the `app` object from
+`listTools` + `listResources`:
+
+```ts
+const [tools, resources] = await Promise.all([
+  mcpClient.listTools(),
+  mcpClient.listResources(),
+]);
+
+const resolvedResources = await Promise.all(
+  resources.resources.map(async (r) => ({
+    uri: r.uri,
+    html: (await mcpClient.readResource({ uri: r.uri })).contents[0].text,
+  })),
+);
+
+const app = {
+  name: 'My App',
+  resources: resolvedResources,
+  tools: tools.tools.map((tool) => ({
+    tool,
+    simulations: fixturesByToolName[tool.name] ?? [],
+  })),
+};
+```
+
+Resource HTML is passed as a **string** — the Inspector forwards it to the
+sandbox iframe via PostMessage. You don't need to host the HTML at a URL.
+
+## Tool calls
+
+The `onCallTool` callback fires when the user clicks **Run** with no
+simulation selected, and when an app inside the iframe makes a
+`callServerTool` request without a matching `serverTools` mock. Return a
+`CallToolResult`; the Inspector renders it.
+
+```tsx
+<Inspector
+  app={app}
+  onCallTool={({ name, arguments: args }) =>
+    mcpClient.callTool({ name, arguments: args })
+  }
+/>
+```
+
+The MCP connection, authentication, and per-user routing all live in your
+code — sunpeak only sees the result of each call.
+
+## The sandbox proxy
+
+The Inspector renders apps inside a **double-iframe**: an outer sandbox proxy
+on a different origin from your host page, and an inner iframe loading the
+app HTML. The cross-origin boundary matches how production hosts (ChatGPT,
+Claude) render MCP Apps, so apps tested in the Inspector behave the same way
+they will in production.
+
+There are two ways to provide the sandbox proxy:
+
+### 1. Static file on a different origin (recommended)
+
+A self-contained proxy is shipped at `sunpeak/dist/sandbox-proxy.html`. Host
+this file on any CDN at a different origin from your main app — a subdomain
+works (`sandbox.example.com` if your app is on `app.example.com`) — and
+point the Inspector at it:
+
+```tsx
+<Inspector
+  app={app}
+  onCallTool={…}
+  sandboxUrl="https://sandbox.example.com/sandbox-proxy.html"
+/>
+```
+
+The file is ~7KB, fully static, and reads its configuration from URL query
+params at runtime. One copy serves all your users.
+
+### 2. `srcdoc` fallback (zero deployment)
+
+If you omit `sandboxUrl`, the Inspector embeds the proxy HTML via `srcdoc`
+on the same origin. This works out of the box but doesn't replicate the
+cross-origin isolation production hosts apply. Fine for trying things out;
+prefer option 1 for production.
+
+## Security considerations
+
+A few constraints to know before deploying. Most of these aren't sunpeak
+bugs — they're properties of how the Inspector renders untrusted HTML — but
+they shape what's safe to put in your `app` prop and how you set up the
+sandbox.
+
+<Warning>
+The `srcdoc` fallback is **not safe for untrusted resource HTML**. When
+`sandboxUrl` is omitted, the Inspector wraps the resource in a same-origin
+sandboxed iframe. The `allow-same-origin` flag combined with `srcdoc`
+means scripts inside the resource run in your host page's origin and can
+reach `window.parent.parent`, read cookies for that origin, and walk the
+DOM. Use srcdoc only for resources you fully control (your own HTML, your
+own SDK builds). For anything else — anything that came from a user or
+through a network boundary — serve the static
+`sandbox-proxy.html` from a separate origin (a subdomain you own) and
+pass it via `sandboxUrl`.
+</Warning>
+
+### Trust boundaries
+
+- **`sandboxUrl` is part of your trust boundary.** The Inspector loads
+  whatever URL you supply (http(s) only, validated). Code running in the
+  outer sandbox iframe can `postMessage` arbitrary JSON-RPC to the host
+  page, and the host will dispatch it. Host the sandbox file on
+  infrastructure you control with the same care as the rest of your
+  static assets.
+- **`app.resources[].html` is rendered as-is.** sunpeak does no
+  sanitization on the document you pass — it's the resource's HTML
+  exactly. Inside the sandboxed iframe this is contained, but the
+  resource can still show phishing UI to its own users, link out to
+  malicious URLs, etc. If you're rendering content from one user to
+  another, treat it like any other UGC.
+- **`html`-mode resources don't get a sunpeak-supplied Content-Security
+  Policy.** Production builds via `scriptSrc` get a strict CSP `<meta>`
+  injected. If you want a CSP on your `html`-mode resources, include one
+  in the document yourself.
+- **`onCallTool` receives user-edited arguments.** The user can edit the
+  Tool Input JSON in the sidebar and click Run. The arguments handed to
+  your callback come straight from that textarea — anyone with access to
+  your Inspector can issue any tool call with any payload. Enforce
+  authorization in your backend; the Inspector does not gate calls.
+
+### What's safe by default
+
+- Cross-origin isolation when `sandboxUrl` is set: the resource iframe
+  cannot reach the host page's window or storage.
+- The inline `window.sunpeak` helper only accepts messages from its actual
+  parent — sibling iframes and extension content scripts can't forge tool
+  results.
+- The mock `openExternal` runtime rejects non-http(s) URLs and opens links
+  with `noopener,noreferrer`.
+- Tool result JSON is escaped before injection into the host page's
+  `<script id="__tool-result">` data island; `<` is encoded so resource
+  output can't break out of the tag.
+- The host shells discriminate `appIcon` between safe image URLs and text
+  via an allowlist; user-supplied icon strings can't load arbitrary
+  scripts via `<img onerror>` attribute injection (React handles attribute
+  escaping; the allowlist limits which origins can be referenced).
+
+## Styling and CSS isolation
+
+`sunpeak/embed.css` scopes preflight, form-element resets, and the
+inspector's color variables under a `.sunpeak-inspector-root` class. They
+apply only inside the Inspector's subtree — your host page's `<button>`,
+`<input>`, headings, and typography are untouched. Don't import
+`sunpeak/style.css` in a host React app; it ships full Tailwind preflight
+intended for resource iframe documents and will reset your page's defaults.
+
+Two caveats:
+
+- **Host fonts** (`@font-face` rules for ChatGPT/Claude conversation chrome)
+  are injected at document level. `@font-face` can't be scoped to a subtree
+  per the CSS spec. The font is only referenced inside the Inspector, so
+  your host page sees a defined-but-unused face — harmless.
+- **Theme variables** (`--color-text-primary`, etc.) are written onto the
+  Inspector's root element, not `document.documentElement`. If your host
+  app defines variables with the same names elsewhere, they coexist
+  without conflict.
+
+## Performance: memoize `app` if you construct it inline
+
+The Inspector flattens the `app` prop into its internal simulation map via
+`useMemo` on the `app` reference. If your parent component constructs `app`
+inline on every render (`<Inspector app={{ resources, tools }} />`), each
+parent render produces a new object identity, the memo recomputes, and the
+Inspector goes through one extra render to sync. The component eventually
+stabilizes (no infinite loop), but you're paying for a re-render per parent
+update.
+
+For production embeds, memoize:
+
+```tsx
+const app = useMemo(
+  () => ({ name: 'My App', resources, tools }),
+  [resources, tools],
+);
+
+<Inspector app={app} onCallTool={…} />
+```
+
+If you're constructing `app` from async data (the typical case — `listTools`
+plus `readResource`), it's already stable across renders and nothing extra
+is needed.
+
+## Reference
+
+### `<Inspector>` props
+
+<ResponseField name="app" type="InspectorApp">
+  The MCP App to render — its resources, tools, and saved simulations.
+  When provided, the Inspector switches to embedded mode: the MCP Server URL
+  input, Authentication section, and Prod Resources checkbox are hidden, and
+  no `/__sunpeak/*` requests are made.
+</ResponseField>
+
+<ResponseField name="onCallTool" type="(params: { name: string; arguments?: Record<string, unknown> }) => Promise<CallToolResult> | CallToolResult">
+  Called when the user clicks **Run** with no simulation selected, and when
+  apps inside the iframe call `callServerTool` without a matching
+  `serverTools` mock. Return a `CallToolResult`.
+</ResponseField>
+
+<ResponseField name="sandboxUrl" type="string">
+  URL of the sandbox proxy on a different origin. Pass the full URL to your
+  hosted `sandbox-proxy.html` (e.g. `https://sandbox.example.com/sandbox-proxy.html`).
+  When omitted, the Inspector falls back to a same-origin `srcdoc` proxy.
+</ResponseField>
+
+<ResponseField name="defaultHost" type="'chatgpt' | 'claude'" default="'chatgpt'">
+  Which host shell to render initially. The user can switch from the sidebar.
+</ResponseField>
+
+See [Inspector](/testing/inspector) for the rest of the props — they all
+work in embedded mode too (with the noted exceptions above).

--- a/docs/testing/inspector.mdx
+++ b/docs/testing/inspector.mdx
@@ -12,6 +12,12 @@ import InspectorSnippet from '/snippets/inspector.mdx';
 
 The `Inspector` component provides a local development environment that replicates the MCP App runtime used by hosts like ChatGPT and Claude. It renders your resources inside iframes, matching the production hosting behavior. The inspector supports multiple host shells — switch between ChatGPT and Claude conversation chrome, theming, and reported capabilities from the sidebar or via URL parameters.
 
+<Note>
+Dropping the Inspector into your own React app? See [Embedding the
+Inspector](/testing/inspector-embedding) for the `app` prop, the static
+sandbox file you host on your CDN, and the CSS isolation story.
+</Note>
+
 ## CLI Usage
 
 ```bash
@@ -59,9 +65,19 @@ import { Inspector } from 'sunpeak/inspector';
 
 ## Props
 
+<ResponseField name="app" type="InspectorApp">
+  Hierarchical input for [embedding the Inspector](/testing/inspector-embedding)
+  in your own React app: an MCP App with its resources, tools, and saved
+  simulations. When provided, the Inspector switches to embedded mode — the
+  MCP Server URL input, Authentication section, and Prod Resources checkbox
+  are hidden, and no `/__sunpeak/*` network calls are made. Mutually exclusive
+  with `simulations`.
+</ResponseField>
+
 <ResponseField name="simulations" type="Record<string, Simulation>">
-  Object mapping simulation names to their definitions. See
-  [Simulation API Reference](/testing/simulations) for details.
+  Flat simulation map (the CLI codepath's input). Object mapping simulation
+  names to their definitions. See [Simulation API Reference](/testing/simulations)
+  for details.
 </ResponseField>
 
 <ResponseField name="appName" type="string" default="Sunpeak App">

--- a/examples/albums-example/package.json
+++ b/examples/albums-example/package.json
@@ -18,7 +18,7 @@
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",
     "embla-carousel-wheel-gestures": "^8.1.0",
-    "sunpeak": "^0.20.25",
+    "sunpeak": "^0.20.26",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },

--- a/examples/carousel-example/package.json
+++ b/examples/carousel-example/package.json
@@ -18,7 +18,7 @@
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",
     "embla-carousel-wheel-gestures": "^8.1.0",
-    "sunpeak": "^0.20.25",
+    "sunpeak": "^0.20.26",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },

--- a/examples/map-example/package.json
+++ b/examples/map-example/package.json
@@ -18,7 +18,7 @@
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",
     "mapbox-gl": "^3.23.1",
-    "sunpeak": "^0.20.25",
+    "sunpeak": "^0.20.26",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },

--- a/examples/review-example/package.json
+++ b/examples/review-example/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
-    "sunpeak": "^0.20.25",
+    "sunpeak": "^0.20.26",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },

--- a/packages/sunpeak/package.json
+++ b/packages/sunpeak/package.json
@@ -36,6 +36,7 @@
       }
     },
     "./style.css": "./dist/style.css",
+    "./embed.css": "./dist/embed.css",
     "./mcp": {
       "import": {
         "types": "./dist/mcp/index.d.ts",
@@ -131,7 +132,8 @@
     "**/claude-host.*"
   ],
   "scripts": {
-    "build": "vite build",
+    "build": "vite build && node scripts/generate-sandbox-html.mjs && pnpm run build:embed-css",
+    "build:embed-css": "tailwindcss -i src/embed.css -o dist/embed.css --minify && node scripts/scope-embed-theme.mjs",
     "dev": "pnpm -C template dev",
     "format": "prettier --write --list-different \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "lint": "eslint . --ext .ts,.tsx --fix",
@@ -194,6 +196,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
+    "@tailwindcss/cli": "^4.3.0",
     "@tailwindcss/vite": "^4.3.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/packages/sunpeak/scripts/generate-sandbox-html.mjs
+++ b/packages/sunpeak/scripts/generate-sandbox-html.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+/**
+ * Generate a self-contained static sandbox proxy HTML for embedders to host
+ * on a different origin from their main React app. The Inspector's
+ * `sandboxUrl` prop points at the file's URL.
+ *
+ * The proxy logic is the same as `src/inspector/sandbox-proxy.ts` and the
+ * `bin/lib/sandbox-server.mjs` dynamic server — but the platform decision
+ * (whether to inject the mock `window.openai` runtime) happens at runtime
+ * by reading `?platform=chatgpt` from the iframe's own URL, so a single
+ * static file serves all hosts.
+ *
+ * Output: `dist/sandbox-proxy.html`
+ */
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = resolve(__dirname, '..');
+const OUT_PATH = resolve(PKG_ROOT, 'dist', 'sandbox-proxy.html');
+
+// Kept in sync by hand with `src/inspector/mock-openai-runtime.ts`. We can't
+// import the TS source from this Node script, but the runtime is short and
+// rarely changes. `src/inspector/sandbox-static.test.ts` compares the shipped
+// HTML against the live module to catch drift.
+const MOCK_OPENAI_SCRIPT = [
+  'window.openai={',
+  'uploadFile:function(f){console.log("[Inspector] uploadFile:",f.name);',
+  'return Promise.resolve({fileId:"sim_file_"+Date.now()})},',
+  'getFileDownloadUrl:function(p){console.log("[Inspector] getFileDownloadUrl:",p.fileId);',
+  'return Promise.resolve({downloadUrl:"https://inspector.local/files/"+p.fileId})},',
+  'requestModal:function(p){console.log("[Inspector] requestModal:",JSON.stringify(p));',
+  'return Promise.resolve()},',
+  'requestCheckout:function(s){console.log("[Inspector] requestCheckout:",JSON.stringify(s));',
+  'return Promise.resolve({id:"sim_order_"+Date.now(),checkout_session_id:s.id||"sim_session",status:"completed"})},',
+  'requestClose:function(){console.log("[Inspector] requestClose")},',
+  'requestDisplayMode:function(p){console.log("[Inspector] requestDisplayMode:",p.mode);',
+  'return Promise.resolve()},',
+  'sendFollowUpMessage:function(p){console.log("[Inspector] sendFollowUpMessage:",p.prompt)},',
+  'openExternal:function(p){console.log("[Inspector] openExternal:",p.href);try{var u=new URL(p.href);if(u.protocol!=="http:"&&u.protocol!=="https:"){console.warn("[Inspector] openExternal blocked non-http(s) URL:",p.href);return}window.open(p.href,"_blank","noopener,noreferrer")}catch(e){console.warn("[Inspector] openExternal blocked invalid URL:",p.href)}}',
+  '};',
+].join('');
+
+const HTML = `<!DOCTYPE html>
+<html style="color-scheme:dark">
+<head>
+<meta charset="UTF-8" />
+<meta name="color-scheme" content="dark" />
+<title>sunpeak sandbox proxy</title>
+<style>
+html, body { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; background: transparent; }
+iframe { border: none; width: 100%; height: 100%; display: block; }
+</style>
+</head>
+<body>
+<script>
+(function() {
+  var innerFrame = null;
+  var innerWindow = null;
+
+  // Read platform at runtime from the iframe's own URL. The Inspector sets
+  // ?platform=chatgpt on the sandboxUrl when the ChatGPT host is selected so
+  // the mock window.openai runtime is available inside the app.
+  var params = new URLSearchParams(window.location.search);
+  var platform = params.get('platform') || '';
+  var platformScript = platform === 'chatgpt'
+    ? ${JSON.stringify(MOCK_OPENAI_SCRIPT)}
+    : null;
+
+  window.addEventListener('message', function(event) {
+    var data = event.data;
+    if (!data || typeof data !== 'object') return;
+
+    if (event.source === window.parent) {
+      if (data.method === 'ui/notifications/sandbox-resource-ready' && data.params) {
+        createInnerFrame(data.params);
+        return;
+      }
+      if (data.method === 'sunpeak/sandbox-load-src' && data.params) {
+        createInnerFrameWithSrc(data.params);
+        return;
+      }
+      if (data.method === 'sunpeak/fence' && data.params) {
+        var fenceId = data.params.fenceId;
+        var acked = false;
+        var onAck = function(e) {
+          if (e.source !== innerWindow) return;
+          if (e.data && e.data.method === 'sunpeak/fence-ack' &&
+              e.data.params && e.data.params.fenceId === fenceId) {
+            acked = true;
+            window.removeEventListener('message', onAck);
+            window.parent.postMessage(e.data, '*');
+          }
+        };
+        window.addEventListener('message', onAck);
+        if (innerWindow) {
+          try { innerWindow.postMessage(data, '*'); } catch (e) {}
+        }
+        setTimeout(function() {
+          if (!acked) {
+            window.removeEventListener('message', onAck);
+            window.parent.postMessage({
+              jsonrpc: '2.0',
+              method: 'sunpeak/fence-ack',
+              params: { fenceId: fenceId }
+            }, '*');
+          }
+        }, 150);
+        return;
+      }
+      if (data.method === 'ui/notifications/host-context-changed' && data.params && data.params.theme) {
+        if (innerFrame) innerFrame.style.colorScheme = data.params.theme;
+      }
+      if (innerWindow) {
+        try { innerWindow.postMessage(data, '*'); } catch (e) {}
+      }
+    } else if (innerWindow && event.source === innerWindow) {
+      try { window.parent.postMessage(data, '*'); } catch (e) {}
+    }
+  });
+
+  function createInnerFrame(p) {
+    clearInterval(readyInterval);
+    if (innerFrame) innerFrame.remove();
+    innerFrame = document.createElement('iframe');
+    innerFrame.sandbox = p.sandbox ||
+      'allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox';
+    if (p.allow) innerFrame.allow = p.allow;
+    document.body.appendChild(innerFrame);
+    innerWindow = innerFrame.contentWindow;
+    var doc = innerFrame.contentDocument;
+    if (doc && p.html) {
+      doc.open();
+      doc.write(p.html);
+      doc.close();
+    }
+  }
+
+  function createInnerFrameWithSrc(p) {
+    clearInterval(readyInterval);
+    if (innerFrame) innerFrame.remove();
+    innerFrame = document.createElement('iframe');
+    innerFrame.sandbox =
+      'allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox';
+    if (p.allow) innerFrame.allow = p.allow;
+    innerFrame.src = p.src;
+    innerFrame.style.height = '100%';
+    if (p.theme) innerFrame.style.colorScheme = p.theme;
+
+    innerFrame.addEventListener('load', function() {
+      innerWindow = innerFrame.contentWindow;
+      if (platformScript && innerWindow) {
+        try {
+          var ps = innerFrame.contentDocument.createElement('script');
+          ps.textContent = platformScript;
+          innerFrame.contentDocument.head.appendChild(ps);
+        } catch (e) {}
+      }
+      try {
+        var fs = innerFrame.contentDocument.createElement('script');
+        fs.setAttribute('data-sunpeak-fence', '');
+        fs.textContent = PAINT_FENCE_SCRIPT;
+        innerFrame.contentDocument.head.appendChild(fs);
+      } catch (e) {}
+      if (p.theme) {
+        try {
+          innerFrame.contentDocument.documentElement.style.colorScheme = p.theme;
+          var bg = innerFrame.contentDocument.createElement('style');
+          bg.setAttribute('data-sunpeak-bg', '');
+          bg.textContent = 'html { background-color: var(--color-background-primary, Canvas); }';
+          innerFrame.contentDocument.head.appendChild(bg);
+        } catch (e) {}
+      }
+      if (p.styleVars) {
+        try {
+          var root = innerFrame.contentDocument.documentElement;
+          for (var k in p.styleVars) {
+            if (p.styleVars[k]) root.style.setProperty(k, p.styleVars[k]);
+          }
+        } catch (e) {}
+      }
+      innerFrame.style.opacity = '1';
+      innerFrame.style.transition = 'opacity 100ms';
+    });
+
+    innerFrame.style.opacity = '0';
+    document.body.appendChild(innerFrame);
+    innerWindow = innerFrame.contentWindow;
+  }
+
+  var PAINT_FENCE_SCRIPT = 'window.addEventListener("message",function(e){' +
+    'if(e.data&&e.data.method==="sunpeak/fence"){' +
+    'var fid=e.data.params&&e.data.params.fenceId;' +
+    'requestAnimationFrame(function(){' +
+    'e.source.postMessage({jsonrpc:"2.0",method:"sunpeak/fence-ack",params:{fenceId:fid}},"*");' +
+    '});}});';
+
+  var readyInterval = setInterval(function() {
+    window.parent.postMessage({
+      jsonrpc: '2.0',
+      method: 'ui/notifications/sandbox-proxy-ready',
+      params: {}
+    }, '*');
+  }, 200);
+  setTimeout(function() {
+    window.parent.postMessage({
+      jsonrpc: '2.0',
+      method: 'ui/notifications/sandbox-proxy-ready',
+      params: {}
+    }, '*');
+  }, 0);
+  setTimeout(function() { clearInterval(readyInterval); }, 10000);
+})();
+</script>
+</body>
+</html>`;
+
+await mkdir(dirname(OUT_PATH), { recursive: true });
+await writeFile(OUT_PATH, HTML, 'utf8');
+console.log(`Wrote ${OUT_PATH} (${HTML.length} bytes)`);

--- a/packages/sunpeak/scripts/scope-embed-theme.mjs
+++ b/packages/sunpeak/scripts/scope-embed-theme.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Post-process `dist/embed.css` so Tailwind's theme tokens are scoped to the
+ * Inspector subtree instead of leaking onto the host page's `:root`.
+ *
+ * Why: Tailwind v4 emits theme tokens (`--font-sans`, `--color-*`, etc.) into
+ * a single `:root, :host` selector by design. When an embedder imports
+ * `sunpeak/embed.css`, those declarations land on their host page's `:root`
+ * and shadow whatever the embedder defined for the same variable names.
+ *
+ * Why this is safe: Tailwind utilities like `font-sans` produce
+ * `font-family: var(--font-sans)` — they read the variable from the CSS
+ * cascade. Every inspector element has `.sunpeak-inspector-root` as an
+ * ancestor, so the scoped tokens resolve identically. Outside the inspector,
+ * the tokens are undefined → the host's own variables stay intact.
+ *
+ * What we do NOT rewrite:
+ *  - `*, :before, :after, ::backdrop` in `@layer properties` — these declare
+ *    Tailwind's `--tw-*` utility internals (used by transform, ring, etc.).
+ *    They're name-prefixed and don't collide with anything an embedder would
+ *    define. Leaving them global avoids breaking inspector-internal utilities.
+ *
+ * The drift guard in `src/inspector/embed-css-output.test.ts` verifies the
+ * resulting CSS has no remaining `:root, :host` declarations.
+ */
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CSS_PATH = resolve(__dirname, '..', 'dist', 'embed.css');
+
+if (!existsSync(CSS_PATH)) {
+  console.error(`[scope-embed-theme] ${CSS_PATH} not found — run vite build first.`);
+  process.exit(1);
+}
+
+const input = readFileSync(CSS_PATH, 'utf8');
+
+// Match `:root, :host` (and the unspaced minified `:root,:host`) only when
+// followed by `{` — the start of a declaration block. Don't match instances
+// inside selector lists or comments.
+const ROOT_HOST_RE = /:root\s*,\s*:host\s*\{/g;
+const matches = input.match(ROOT_HOST_RE);
+
+if (!matches || matches.length === 0) {
+  console.warn(
+    '[scope-embed-theme] No `:root, :host` declarations found — Tailwind output may have changed. Skipping rewrite.'
+  );
+  process.exit(0);
+}
+
+const output = input.replace(ROOT_HOST_RE, '.sunpeak-inspector-root{');
+
+writeFileSync(CSS_PATH, output, 'utf8');
+console.log(
+  `[scope-embed-theme] Rewrote ${matches.length} \`:root, :host\` declaration(s) to \`.sunpeak-inspector-root\` in ${CSS_PATH}`
+);

--- a/packages/sunpeak/src/embed.css
+++ b/packages/sunpeak/src/embed.css
@@ -1,0 +1,156 @@
+/*
+ * Embed-safe CSS for hosting the Inspector inside another React app.
+ *
+ * Same Tailwind utilities and theme variables as `sunpeak/style.css`, but
+ * with preflight scoped under `.sunpeak-inspector-root` so it doesn't
+ * collide with the host page's own button/input/h1/list/etc. styles.
+ *
+ * Use this file when you import `<Inspector app={…} />` into your own
+ * React app. For Inspector usage inside the sunpeak CLI / template (where
+ * resources need full Tailwind preflight applied to their iframe document),
+ * use `sunpeak/style.css` instead.
+ */
+@layer theme, base, components, utilities;
+@import "tailwindcss/theme.css" layer(theme);
+@import "tailwindcss/utilities.css" layer(utilities);
+
+/* Scan simulator source files for Tailwind classes */
+@source "./inspector/**/*.{ts,tsx}";
+@source "./chatgpt/**/*.{ts,tsx}";
+@source "./claude/**/*.{ts,tsx}";
+
+/*
+ * Dark-mode variant — same selector as `style.css` so utility classes like
+ * `dark:bg-…` resolve identically.
+ */
+@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
+
+/*
+ * Scoped preflight — applies only inside `.sunpeak-inspector-root`. Trimmed
+ * equivalent of Tailwind's preflight that resets box-sizing, default
+ * margins, list bullets, and form-element typography so utility classes
+ * compose predictably without bleeding into the host page.
+ */
+@layer base {
+  .sunpeak-inspector-root,
+  .sunpeak-inspector-root *,
+  .sunpeak-inspector-root *::before,
+  .sunpeak-inspector-root *::after {
+    box-sizing: border-box;
+    border: 0 solid;
+  }
+
+  .sunpeak-inspector-root {
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+      Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  }
+
+  .sunpeak-inspector-root h1,
+  .sunpeak-inspector-root h2,
+  .sunpeak-inspector-root h3,
+  .sunpeak-inspector-root h4,
+  .sunpeak-inspector-root h5,
+  .sunpeak-inspector-root h6 {
+    font-size: inherit;
+    font-weight: inherit;
+    margin: 0;
+  }
+
+  .sunpeak-inspector-root p,
+  .sunpeak-inspector-root pre,
+  .sunpeak-inspector-root blockquote,
+  .sunpeak-inspector-root figure,
+  .sunpeak-inspector-root hr {
+    margin: 0;
+  }
+
+  .sunpeak-inspector-root ul,
+  .sunpeak-inspector-root ol,
+  .sunpeak-inspector-root menu {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .sunpeak-inspector-root a {
+    color: inherit;
+    text-decoration: inherit;
+  }
+
+  .sunpeak-inspector-root button,
+  .sunpeak-inspector-root input,
+  .sunpeak-inspector-root select,
+  .sunpeak-inspector-root optgroup,
+  .sunpeak-inspector-root textarea {
+    font: inherit;
+    color: inherit;
+    margin: 0;
+    padding: 0;
+    background-color: transparent;
+  }
+
+  .sunpeak-inspector-root button,
+  .sunpeak-inspector-root [type="button"],
+  .sunpeak-inspector-root [type="reset"],
+  .sunpeak-inspector-root [type="submit"] {
+    -webkit-appearance: button;
+    background-image: none;
+  }
+
+  .sunpeak-inspector-root img,
+  .sunpeak-inspector-root svg,
+  .sunpeak-inspector-root video,
+  .sunpeak-inspector-root canvas,
+  .sunpeak-inspector-root audio,
+  .sunpeak-inspector-root iframe,
+  .sunpeak-inspector-root embed,
+  .sunpeak-inspector-root object {
+    display: block;
+    vertical-align: middle;
+  }
+
+  .sunpeak-inspector-root img,
+  .sunpeak-inspector-root video {
+    max-width: 100%;
+    height: auto;
+  }
+
+  /* Monospace family for code-like elements, matching Tailwind preflight. */
+  .sunpeak-inspector-root code,
+  .sunpeak-inspector-root kbd,
+  .sunpeak-inspector-root samp,
+  .sunpeak-inspector-root pre {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      "Liberation Mono", "Courier New", monospace;
+    font-size: 1em;
+  }
+
+  /* Disabled controls and interactive defaults. */
+  .sunpeak-inspector-root [disabled] {
+    cursor: default;
+  }
+  .sunpeak-inspector-root summary {
+    cursor: pointer;
+  }
+
+  /* Native dialog inherits arbitrary user agent margin/padding/borders. */
+  .sunpeak-inspector-root dialog {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background-color: inherit;
+    color: inherit;
+  }
+
+  /* Browser default focus rings are unscoped; let Tailwind/our explicit
+     focus styles drive interactive feedback inside the inspector. */
+  .sunpeak-inspector-root :focus-visible {
+    outline-color: currentColor;
+  }
+}
+
+/* Sidebar form + checkbox rules, shared with `globals.css` via this partial. */
+@import "./inspector/sidebar-chrome.css";

--- a/packages/sunpeak/src/inspector/app-flatten.test.ts
+++ b/packages/sunpeak/src/inspector/app-flatten.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from 'vitest';
+import { flattenAppToSimulations } from './app-flatten';
+import type { InspectorApp } from './app-types';
+
+function makeTool(name: string, outputTemplate?: string) {
+  return {
+    name,
+    inputSchema: { type: 'object' as const, properties: {}, required: [] },
+    ...(outputTemplate
+      ? { _meta: { openai: { outputTemplate } } }
+      : {}),
+  };
+}
+
+describe('flattenAppToSimulations', () => {
+  it('returns an empty map when no app is provided', () => {
+    expect(flattenAppToSimulations(undefined)).toEqual({});
+  });
+
+  it('emits one Simulation per (tool, simulation) pair, scoped by tool name', () => {
+    const app: InspectorApp = {
+      resources: [{ uri: 'ui://albums', html: '<html>albums</html>' }],
+      tools: [
+        {
+          tool: makeTool('show_albums', 'ui://albums'),
+          simulations: [
+            { name: 'two-albums', toolInput: { count: 2 } },
+            { name: 'no-albums', toolInput: { count: 0 } },
+          ],
+        },
+      ],
+    };
+    const flat = flattenAppToSimulations(app);
+    expect(Object.keys(flat).sort()).toEqual([
+      'show_albums__no-albums',
+      'show_albums__two-albums',
+    ]);
+    expect(flat['show_albums__two-albums'].resourceHtml).toBe('<html>albums</html>');
+    expect(flat['show_albums__two-albums'].tool.name).toBe('show_albums');
+    expect(flat['show_albums__two-albums'].toolInput).toEqual({ count: 2 });
+  });
+
+  it('emits one fixture-less Simulation when a tool has no simulations', () => {
+    const app: InspectorApp = {
+      resources: [{ uri: 'ui://albums', html: '<h1>x</h1>' }],
+      tools: [{ tool: makeTool('show_albums', 'ui://albums') }],
+    };
+    const flat = flattenAppToSimulations(app);
+    expect(Object.keys(flat)).toEqual(['show_albums__show_albums']);
+    expect(flat['show_albums__show_albums'].toolInput).toBeUndefined();
+    expect(flat['show_albums__show_albums'].toolResult).toBeUndefined();
+  });
+
+  it('shares a resource across multiple tools via outputTemplate URI', () => {
+    const app: InspectorApp = {
+      resources: [{ uri: 'ui://albums', html: '<h1>shared</h1>' }],
+      tools: [
+        { tool: makeTool('show_albums', 'ui://albums') },
+        { tool: makeTool('search_albums', 'ui://albums') },
+      ],
+    };
+    const flat = flattenAppToSimulations(app);
+    expect(Object.keys(flat).sort()).toEqual([
+      'search_albums__search_albums',
+      'show_albums__show_albums',
+    ]);
+    expect(flat['search_albums__search_albums'].resourceHtml).toBe('<h1>shared</h1>');
+    expect(flat['show_albums__show_albums'].resourceHtml).toBe('<h1>shared</h1>');
+  });
+
+  it('skips tools whose outputTemplate references an unknown resource', () => {
+    const app: InspectorApp = {
+      resources: [{ uri: 'ui://albums', html: '<h1>x</h1>' }],
+      tools: [
+        { tool: makeTool('show_albums', 'ui://albums') },
+        { tool: makeTool('orphan', 'ui://missing') },
+      ],
+    };
+    const flat = flattenAppToSimulations(app);
+    expect(Object.keys(flat)).toEqual(['show_albums__show_albums']);
+  });
+
+  it('skips tools with no outputTemplate', () => {
+    const app: InspectorApp = {
+      resources: [{ uri: 'ui://albums', html: '<h1>x</h1>' }],
+      tools: [{ tool: makeTool('headless_tool') }],
+    };
+    const flat = flattenAppToSimulations(app);
+    expect(flat).toEqual({});
+  });
+
+  it('warns when a tool has duplicate simulation names', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      flattenAppToSimulations({
+        resources: [{ uri: 'ui://x', html: '<p>x</p>' }],
+        tools: [
+          {
+            tool: makeTool('t', 'ui://x'),
+            simulations: [
+              { name: 'dup', toolInput: { a: 1 } },
+              { name: 'dup', toolInput: { a: 2 } },
+            ],
+          },
+        ],
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Duplicate simulation name 'dup' under tool 't'")
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('warns when app.resources has duplicate URIs', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      flattenAppToSimulations({
+        resources: [
+          { uri: 'ui://albums', html: '<h1>first</h1>' },
+          { uri: 'ui://albums', html: '<h1>second</h1>' },
+        ],
+        tools: [],
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Duplicate resource URI 'ui://albums'")
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('carries simulation userMessage and serverTools through to the flat entry', () => {
+    const app: InspectorApp = {
+      resources: [{ uri: 'ui://albums', html: '<h1>x</h1>' }],
+      tools: [
+        {
+          tool: makeTool('show_albums', 'ui://albums'),
+          simulations: [
+            {
+              name: 'sample',
+              userMessage: 'show me albums',
+              serverTools: { search: { content: [{ type: 'text', text: 'ok' }] } },
+            },
+          ],
+        },
+      ],
+    };
+    const flat = flattenAppToSimulations(app);
+    const sim = flat['show_albums__sample'];
+    expect(sim.userMessage).toBe('show me albums');
+    expect(sim.serverTools).toBeDefined();
+  });
+});

--- a/packages/sunpeak/src/inspector/app-flatten.test.ts
+++ b/packages/sunpeak/src/inspector/app-flatten.test.ts
@@ -6,9 +6,7 @@ function makeTool(name: string, outputTemplate?: string) {
   return {
     name,
     inputSchema: { type: 'object' as const, properties: {}, required: [] },
-    ...(outputTemplate
-      ? { _meta: { openai: { outputTemplate } } }
-      : {}),
+    ...(outputTemplate ? { _meta: { openai: { outputTemplate } } } : {}),
   };
 }
 
@@ -31,10 +29,7 @@ describe('flattenAppToSimulations', () => {
       ],
     };
     const flat = flattenAppToSimulations(app);
-    expect(Object.keys(flat).sort()).toEqual([
-      'show_albums__no-albums',
-      'show_albums__two-albums',
-    ]);
+    expect(Object.keys(flat).sort()).toEqual(['show_albums__no-albums', 'show_albums__two-albums']);
     expect(flat['show_albums__two-albums'].resourceHtml).toBe('<html>albums</html>');
     expect(flat['show_albums__two-albums'].tool.name).toBe('show_albums');
     expect(flat['show_albums__two-albums'].toolInput).toEqual({ count: 2 });

--- a/packages/sunpeak/src/inspector/app-flatten.ts
+++ b/packages/sunpeak/src/inspector/app-flatten.ts
@@ -1,0 +1,118 @@
+/**
+ * Convert the public `InspectorApp` shape into the internal flat `Simulation`
+ * map the Inspector's existing code already operates on. The hierarchical
+ * shape (App → resources + tools → simulations) is just a more ergonomic
+ * surface; flattening here means the rest of the component is unchanged.
+ *
+ * Linkage: each tool's `_meta.openai.outputTemplate` URI selects the matching
+ * resource. Tools whose template doesn't resolve to a known resource are
+ * skipped — they have no UI to render and would only confuse the sidebar.
+ *
+ * A tool with no `simulations` still produces one entry so the sidebar has
+ * something to select. That entry carries no fixture data, so the Inspector
+ * shows the "Press Run" empty state and `onCallTool` decides what happens.
+ *
+ * Naming split — `Simulation.name` vs `Simulation.displayName`:
+ *
+ * - `name` is the unique internal key used everywhere the Inspector indexes
+ *   simulations (state, dropdown `value`, the simulations map keys). For the
+ *   flattened embed path it's `<toolName>__<userSimName>` so two tools can
+ *   share a simulation name without colliding.
+ * - `displayName` is the user-facing label shown in the sidebar's Simulation
+ *   dropdown. Set to the embedder's raw `sim.name` so users see what they
+ *   wrote, not the internal composite. Sidebar code falls back to `name`
+ *   when `displayName` is omitted (the legacy CLI path).
+ *
+ * Don't collapse these — the URL-param deep-link path (`?simulation=X`) and
+ * the rest of the Inspector code rely on `name` being a stable unique key.
+ */
+import type { Resource } from '@modelcontextprotocol/sdk/types.js';
+import type { Simulation } from '../types/simulation';
+import type { InspectorApp, InspectorAppResource } from './app-types';
+
+/** Pull the output-template URI off a tool's _meta, if present. */
+function getOutputTemplate(toolMeta: unknown): string | undefined {
+  if (!toolMeta || typeof toolMeta !== 'object') return undefined;
+  const openai = (toolMeta as Record<string, unknown>).openai;
+  if (!openai || typeof openai !== 'object') return undefined;
+  const template = (openai as Record<string, unknown>).outputTemplate;
+  return typeof template === 'string' ? template : undefined;
+}
+
+/** Build an MCP-shaped `Resource` from the embedder's input. Used purely for
+ * sidebar metadata (CSP, permissions, prefersBorder); the actual HTML render
+ * goes through `resourceHtml` on the resulting Simulation. */
+function toMcpResource(r: InspectorAppResource): Resource {
+  return {
+    uri: r.uri,
+    mimeType: r.mimeType ?? 'text/html',
+    name: r.uri,
+    ...(r._meta ? { _meta: r._meta } : {}),
+  } as Resource;
+}
+
+/**
+ * Flatten an `InspectorApp` to the `Record<string, Simulation>` shape the
+ * Inspector consumes internally. Returns an empty map if `app` is missing.
+ */
+export function flattenAppToSimulations(
+  app: InspectorApp | undefined
+): Record<string, Simulation> {
+  if (!app) return {};
+  const result: Record<string, Simulation> = {};
+
+  // Index resources by URI so each tool can resolve its output template.
+  // Duplicate URIs are almost always typos — warn so the embedder notices
+  // (the silent last-write semantics would hide the bug otherwise).
+  const resourcesByUri = new Map<string, InspectorAppResource>();
+  for (const r of app.resources) {
+    if (resourcesByUri.has(r.uri)) {
+      console.warn(
+        `[Inspector] Duplicate resource URI '${r.uri}' in app.resources — the second entry replaces the first.`
+      );
+    }
+    resourcesByUri.set(r.uri, r);
+  }
+
+  for (const appTool of app.tools) {
+    const uri = getOutputTemplate(appTool.tool._meta);
+    if (!uri) continue;
+    const resource = resourcesByUri.get(uri);
+    if (!resource) continue;
+
+    const mcpResource = toMcpResource(resource);
+    const sims =
+      appTool.simulations && appTool.simulations.length > 0
+        ? appTool.simulations
+        : [{ name: appTool.tool.name }];
+
+    for (const sim of sims) {
+      // Compose a key unique across the whole app. Multiple tools may share
+      // a resource and multiple sims may share a name across tools; prefix
+      // with the tool name to keep keys stable.
+      const key = `${appTool.tool.name}__${sim.name}`;
+      // Same name twice under one tool is almost always a typo — second
+      // would silently replace the first. Warn so the embedder catches it.
+      if (key in result) {
+        console.warn(
+          `[Inspector] Duplicate simulation name '${sim.name}' under tool '${appTool.tool.name}' — the second entry replaces the first.`
+        );
+      }
+      result[key] = {
+        name: key,
+        // Pretty label for the sidebar. The internal `name` is the unique
+        // composite key; the embedder's chosen simulation name surfaces here.
+        displayName: sim.name,
+        resourceHtml: resource.html,
+        userMessage: sim.userMessage,
+        tool: appTool.tool,
+        resource: mcpResource,
+        toolInput: sim.toolInput,
+        toolResult: sim.toolResult,
+        serverTools: sim.serverTools,
+      };
+    }
+  }
+
+  return result;
+}

--- a/packages/sunpeak/src/inspector/app-flatten.ts
+++ b/packages/sunpeak/src/inspector/app-flatten.ts
@@ -55,9 +55,7 @@ function toMcpResource(r: InspectorAppResource): Resource {
  * Flatten an `InspectorApp` to the `Record<string, Simulation>` shape the
  * Inspector consumes internally. Returns an empty map if `app` is missing.
  */
-export function flattenAppToSimulations(
-  app: InspectorApp | undefined
-): Record<string, Simulation> {
+export function flattenAppToSimulations(app: InspectorApp | undefined): Record<string, Simulation> {
   if (!app) return {};
   const result: Record<string, Simulation> = {};
 

--- a/packages/sunpeak/src/inspector/app-types.ts
+++ b/packages/sunpeak/src/inspector/app-types.ts
@@ -1,0 +1,99 @@
+/**
+ * Public input shape for embedding the Inspector inside another React app.
+ *
+ * Mirrors the MCP App data model: one App contains one or more Resources,
+ * each Resource is rendered by one or more Tools (linked via the tool's
+ * `_meta.openai.outputTemplate` URI), and each Tool can have zero or more
+ * saved Simulations for testing UI states.
+ *
+ * The Inspector flattens this hierarchy into its internal `Simulation` map
+ * at runtime, so callers can construct the structure they already have from
+ * MCP `listTools` + `listResources` without translating between formats.
+ */
+import type { Tool, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { ServerToolMock } from '../types/simulation';
+
+/** A resource owned by the App. The URI links it to one or more Tools. */
+export interface InspectorAppResource {
+  /**
+   * URI that uniquely identifies this resource within the App. Tools refer
+   * to it via `tool._meta.openai.outputTemplate`. Typically `ui://...`.
+   */
+  uri: string;
+  /**
+   * The HTML document for this resource. Pass the string returned by
+   * `mcpClient.readResource({ uri })`; the Inspector hands it to the
+   * sandbox iframe via PostMessage and never hosts it at a URL.
+   */
+  html: string;
+  /**
+   * Optional MIME type. Defaults to `text/html`. The current Inspector only
+   * renders HTML — other types are reserved for future use.
+   */
+  mimeType?: string;
+  /**
+   * Optional MCP `_meta` payload carried through to the iframe. Used by the
+   * MCP Apps SDK for resource-declared sandbox permissions, CSP, etc.
+   *
+   * Type is intentionally loose (`Record<string, unknown>`) — the Inspector
+   * doesn't validate the shape, it only reads specific subkeys defensively
+   * (`_meta.ui.permissions`, `_meta.ui.prefersBorder`, `_meta.ui.csp`). The
+   * embedder is responsible for shape correctness if they want those
+   * features. Other fields are ignored.
+   */
+  _meta?: Record<string, unknown>;
+}
+
+/** A simulation: one saved test state for a tool. */
+export interface InspectorAppSimulation {
+  /**
+   * Unique simulation name within the tool — surfaced in the sidebar's
+   * Simulation picker.
+   */
+  name: string;
+  /**
+   * Optional user prompt to display in the conversation chrome. When omitted,
+   * the Inspector shows a generic "Call my <tool> tool" message.
+   */
+  userMessage?: string;
+  /** Tool arguments — sent to the resource via the MCP Apps protocol. */
+  toolInput?: Record<string, unknown>;
+  /** Pre-canned tool result — what the model would receive. */
+  toolResult?: CallToolResult;
+  /**
+   * Mock responses for `callServerTool` calls the resource makes back to the
+   * server. Same shape as the existing `ServerToolMock` API.
+   */
+  serverTools?: Record<string, ServerToolMock>;
+}
+
+/** A tool defined by the App, plus any simulations testing its UI states. */
+export interface InspectorAppTool {
+  /**
+   * MCP `Tool` definition. The tool's `_meta.openai.outputTemplate` selects
+   * which resource the Inspector renders when this tool runs.
+   */
+  tool: Tool;
+  /** Optional saved test states for this tool. */
+  simulations?: InspectorAppSimulation[];
+}
+
+/**
+ * One MCP App's data, in the shape the Inspector renders. Pass via the
+ * `app` prop on `<Inspector />` when embedding inside another React app.
+ */
+export interface InspectorApp {
+  /** Optional display name shown in the conversation chrome header. */
+  name?: string;
+  /**
+   * Optional icon shown next to the name. Accepts either short text (e.g.
+   * an emoji like `🎵`) or an `https://` URL — the host shells render the
+   * URL as an `<img>` when it validates as an allowed origin, otherwise
+   * fall back to rendering the value as text.
+   */
+  icon?: string;
+  /** Resources this App exposes — typically one entry per UI surface. */
+  resources: InspectorAppResource[];
+  /** Tools this App exposes — at least one per resource the user can reach. */
+  tools: InspectorAppTool[];
+}

--- a/packages/sunpeak/src/inspector/embed-css-output.test.ts
+++ b/packages/sunpeak/src/inspector/embed-css-output.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Drift guard for the built `dist/embed.css`.
+ *
+ * `sunpeak/embed.css` is the stylesheet embedders import into their own
+ * React app. The whole point is that nothing in it should leak onto the
+ * host page's global cascade — every declaration that affects elements
+ * must be scoped under `.sunpeak-inspector-root`.
+ *
+ * This test reads the built file and asserts:
+ *   1. No remaining `:root, :host` selectors (Tailwind theme tokens — these
+ *      are rewritten by `scripts/scope-embed-theme.mjs` after Tailwind emits).
+ *   2. No global element selectors at top level (html, body, button, h1-h6,
+ *      ol, ul, a, table, etc.) — those would mean preflight bleeds.
+ *   3. Every preflight rule is scoped under `.sunpeak-inspector-root`.
+ *
+ * The test skips when `dist/embed.css` doesn't exist (developer hasn't run
+ * `pnpm build` yet). CI always builds before testing.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const EMBED_CSS = resolve(__dirname, '..', '..', 'dist', 'embed.css');
+
+describe('embed.css drift guard', () => {
+  it.skipIf(!existsSync(EMBED_CSS))(
+    'has zero `:root` or `:host` substrings — theme tokens must be scoped',
+    () => {
+      const css = readFileSync(EMBED_CSS, 'utf8');
+      // Paranoid check: assert NO `:root` or `:host` appears anywhere. The
+      // rewriter in `scripts/scope-embed-theme.mjs` uses a specific pattern
+      // to rewrite Tailwind's `:root, :host` block; if Tailwind ever changes
+      // its output shape (e.g. `:where(:root, :host)`, `:host, :root` reversed,
+      // or splits into separate blocks), the rewriter could silently miss it.
+      // This stronger check fails loudly so we notice immediately.
+      //
+      // Tailwind v4's `@layer properties` uses `*, :before, :after, ::backdrop`
+      // — no `:root` or `:host` mentions there — so 0 is the legitimate target.
+      const rootMatches = css.match(/:root/g) ?? [];
+      const hostMatches = css.match(/:host/g) ?? [];
+      expect(
+        rootMatches,
+        `Unexpected \`:root\` selectors in embed.css (${rootMatches.length}). The rewriter in scripts/scope-embed-theme.mjs may need updating — Tailwind's theme output format may have changed.`
+      ).toEqual([]);
+      expect(
+        hostMatches,
+        `Unexpected \`:host\` selectors in embed.css (${hostMatches.length}).`
+      ).toEqual([]);
+    }
+  );
+
+  it.skipIf(!existsSync(EMBED_CSS))(
+    'has no top-level element selectors — preflight must be scoped',
+    () => {
+      const css = readFileSync(EMBED_CSS, 'utf8');
+      // Top-level selectors in minified CSS sit right after a `}` (or at
+      // file start). Match common preflight elements followed by ANY selector
+      // continuation: `,` `{` `:` (pseudo-class) `[` (attribute selector) or
+      // whitespace. Catches `}button,`, `}button{`, `}button:hover{`,
+      // `}input[type="…"]`, etc. — any of which would indicate a global
+      // preflight leak.
+      const TOP_LEVEL_ELEMENT_RE =
+        /(\}|^)(html|body|button|input|select|textarea|h[1-6]|p|a|ul|ol|li|table|hr|fieldset|blockquote|dialog|summary|code|pre|kbd|samp|abbr|sub|sup|small|strong|figure|menu|details|legend)[\s:,[{]/g;
+      const matches = css.match(TOP_LEVEL_ELEMENT_RE);
+      expect(
+        matches ?? [],
+        `Unexpected global element selectors in embed.css: ${(matches ?? []).join(', ')}`
+      ).toEqual([]);
+    }
+  );
+
+  it.skipIf(!existsSync(EMBED_CSS))(
+    'contains the inspector scope class for preflight rules',
+    () => {
+      const css = readFileSync(EMBED_CSS, 'utf8');
+      // The scoped preflight should produce at least a dozen `.sunpeak-inspector-root`
+      // occurrences — if this number plummets, something is wrong with the build.
+      const occurrences = (css.match(/\.sunpeak-inspector-root/g) ?? []).length;
+      expect(occurrences).toBeGreaterThan(20);
+    }
+  );
+});

--- a/packages/sunpeak/src/inspector/globals.css
+++ b/packages/sunpeak/src/inspector/globals.css
@@ -1,3 +1,13 @@
+/*
+ * Full Tailwind preflight + utilities. This is the CSS resources load into
+ * their iframe documents — they need preflight applied at `html`/`body`
+ * level to reset browser defaults (sans-serif body, list bullets, default
+ * border widths, transparent button backgrounds).
+ *
+ * Embedders who host the Inspector inside their own React app should
+ * import `sunpeak/embed.css` instead, which contains preflight scoped under
+ * `.sunpeak-inspector-root` so it doesn't bleed into host page styles.
+ */
 @import "tailwindcss";
 
 /* Scan simulator source files for Tailwind classes */
@@ -7,77 +17,13 @@
 @source "../chatgpt/**/*.{ts,tsx}";
 @source "../claude/**/*.{ts,tsx}";
 
-/* Configure dark mode to use data-theme attribute */
+/*
+ * Configure dark mode to use data-theme attribute. The selector matches when
+ * data-theme="dark" is on the element itself OR any ancestor — this lets the
+ * Inspector set the attribute on its own root (the embed-friendly model) while
+ * still working in older code paths where it's set on a parent.
+ */
 @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 
-/* Sidebar utility — host-overridable via --sim-bg-sidebar */
-@utility bg-sidebar {
-  background-color: var(--sim-bg-sidebar, var(--color-background-secondary));
-}
-
-/* Sidebar form elements — match SDK look */
-.sunpeak-inspector-root select,
-.sunpeak-inspector-root input:not([type="checkbox"]),
-.sunpeak-inspector-root textarea {
-  border: 0;
-  box-shadow: inset 0 0 0 1px var(--color-border-primary);
-  transition: box-shadow 150ms ease, color 150ms ease, background-color 150ms ease;
-}
-.sunpeak-inspector-root select:hover,
-.sunpeak-inspector-root input:not([type="checkbox"]):hover,
-.sunpeak-inspector-root textarea:hover {
-  box-shadow: inset 0 0 0 1px var(--color-border-secondary);
-}
-.sunpeak-inspector-root select:focus-visible,
-.sunpeak-inspector-root input:not([type="checkbox"]):focus-visible,
-.sunpeak-inspector-root textarea:focus-visible {
-  box-shadow: inset 0 0 0 1px var(--color-border-secondary);
-  outline: 2px solid var(--color-ring-primary);
-  outline-offset: -1px;
-}
-.sunpeak-inspector-root button:focus-visible {
-  outline: 2px solid var(--color-ring-primary);
-  outline-offset: -1px;
-}
-
-/* Custom checkbox */
-.sunpeak-inspector-root input[type="checkbox"] {
-  appearance: none;
-  -webkit-appearance: none;
-  width: 16px;
-  height: 16px;
-  border-radius: 4px;
-  border: 1px solid var(--color-border-secondary);
-  background-color: transparent;
-  background-size: 10px;
-  background-position: center;
-  background-repeat: no-repeat;
-  cursor: pointer;
-  flex-shrink: 0;
-  transition: border-color 150ms ease, background-color 150ms ease;
-}
-.sunpeak-inspector-root input[type="checkbox"]:hover {
-  border-color: var(--color-text-tertiary);
-}
-.sunpeak-inspector-root input[type="checkbox"]:checked {
-  border-color: var(--color-background-inverse);
-  background-color: var(--color-background-inverse);
-  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 10 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M2 5L4.25 7L8 3' stroke='white' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3e%3c/svg%3e");
-}
-[data-theme="dark"] .sunpeak-inspector-root input[type="checkbox"]:checked {
-  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 10 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M2 5L4.25 7L8 3' stroke='%23111' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3e%3c/svg%3e");
-}
-.sunpeak-inspector-root input[type="checkbox"]:focus-visible {
-  outline: 2px solid var(--color-ring-primary);
-  outline-offset: 2px;
-}
-
-/* Hide native number input spinners */
-.sunpeak-inspector-root input[type="number"]::-webkit-inner-spin-button,
-.sunpeak-inspector-root input[type="number"]::-webkit-outer-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-.sunpeak-inspector-root input[type="number"] {
-  -moz-appearance: textfield;
-}
+/* Sidebar form + checkbox rules, shared with `embed.css` via this partial. */
+@import "./sidebar-chrome.css";

--- a/packages/sunpeak/src/inspector/iframe-resource.tsx
+++ b/packages/sunpeak/src/inspector/iframe-resource.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useMemo, useCallback } from 'react';
 import { McpAppHost, type McpAppHostOptions } from './mcp-app-host';
 import { MOCK_OPENAI_RUNTIME_SCRIPT } from './mock-openai-runtime';
 import { generateSandboxProxyHtml } from './sandbox-proxy';
+import { SUNPEAK_INLINE_HELPER_SCRIPT } from './inline-helper-script';
 import type { McpUiHostContext, McpUiResourcePermissions } from '@modelcontextprotocol/ext-apps';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
@@ -224,6 +225,37 @@ e.source.postMessage({jsonrpc:"2.0",method:"sunpeak/fence-ack",params:{fenceId:f
 });}});`;
 
 /**
+ * Inject the paint-fence responder and (optionally) a platform runtime script
+ * into a user-provided HTML document. Used for the `html` prop mode where the
+ * embedder hands us a complete document from `mcpClient.readResource(...)` and
+ * we need to splice in the same infrastructure that the `scriptSrc` wrapper
+ * provides. The injection is placed before `</head>` when present, falling
+ * back to the start of `<body>` or the document start.
+ */
+export function injectInfraScripts(html: string, platformScript?: string): string {
+  const fenceTag = `<script data-sunpeak-fence>${PAINT_FENCE_SCRIPT}</script>`;
+  const platformTag = platformScript ? `<script>${platformScript}</script>` : '';
+  // Inline MCP Apps SDK shim — completes the initialize handshake on behalf
+  // of plain-HTML resources and exposes window.sunpeak.{onToolInput,
+  // onToolResult, onHostContextChange}. The helper bails out if the real
+  // SDK is already loaded.
+  const helperTag = `<script data-sunpeak-helper>${SUNPEAK_INLINE_HELPER_SCRIPT}</script>`;
+  const injection = `${platformTag}${fenceTag}${helperTag}`;
+  // Tag matching is case-insensitive per the HTML spec. Most apps use the
+  // lowercase form, but be tolerant of `</HEAD>` / `<BODY>` so an upstream
+  // generator quirk doesn't silently skip the injection.
+  const headMatch = html.match(/<\/head\s*>/i);
+  if (headMatch) {
+    return html.replace(headMatch[0], `${injection}${headMatch[0]}`);
+  }
+  const bodyMatch = html.match(/<body([^>]*)>/i);
+  if (bodyMatch) {
+    return html.replace(bodyMatch[0], `${bodyMatch[0]}${injection}`);
+  }
+  return injection + html;
+}
+
+/**
  * Generates HTML wrapper for a script URL.
  * The MCP Apps SDK in the loaded script handles communication via PostMessageTransport.
  */
@@ -309,6 +341,15 @@ interface IframeResourceProps {
    * Mutually exclusive with src.
    */
   scriptSrc?: string;
+  /**
+   * Resource HTML to render directly — typically the string returned by
+   * `mcpClient.readResource(...)`. The Inspector hands the HTML to the
+   * sandbox proxy via PostMessage; the host page never hosts it at a URL.
+   * The Inspector injects its paint-fence responder and (when enabled) the
+   * platform runtime script before delivery.
+   * Mutually exclusive with src and scriptSrc.
+   */
+  html?: string;
   /** Initial host context for the MCP Apps bridge */
   hostContext?: McpUiHostContext;
   /** Tool input arguments to send after connection */
@@ -371,6 +412,7 @@ interface IframeResourceProps {
 export function IframeResource({
   src,
   scriptSrc,
+  html,
   hostContext,
   toolInput,
   toolInputPartial,
@@ -389,7 +431,8 @@ export function IframeResource({
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const hostRef = useRef<McpAppHost | null>(null);
 
-  // Determine which URL to validate
+  // Determine which URL to validate (html mode has no URL — embedder supplies
+  // the document body directly).
   const resourceUrl = src ?? scriptSrc;
 
   // Refs for resource data so the stable onSandboxReady callback can access current values
@@ -399,6 +442,8 @@ export function IframeResource({
   srcRef.current = src;
   const scriptSrcRef = useRef(scriptSrc);
   scriptSrcRef.current = scriptSrc;
+  const htmlRef = useRef(html);
+  htmlRef.current = html;
   const cspRef = useRef(csp);
   cspRef.current = csp;
   const hostContextRef = useRef(hostContext);
@@ -479,10 +524,30 @@ export function IframeResource({
           // The sandbox proxy is ready. Deliver the app content.
           const currentSrc = srcRef.current;
           const currentScriptSrc = scriptSrcRef.current;
+          const currentHtml = htmlRef.current;
           const currentHost = hostRef.current;
           if (!currentHost) return;
 
-          if (currentScriptSrc) {
+          if (currentHtml) {
+            // html mode: the embedder handed us a complete HTML document
+            // (typically from mcpClient.readResource). Inject the paint-fence
+            // responder and (when enabled) the mock platform runtime, then
+            // hand the document to the proxy via the existing
+            // sandbox-resource-ready protocol.
+            const platformScriptStr = injectOpenAIRuntimeRef.current
+              ? MOCK_OPENAI_RUNTIME_SCRIPT
+              : undefined;
+            const finalHtml = injectInfraScripts(currentHtml, platformScriptStr);
+            currentHost.sendSandboxResourceReady({
+              html: finalHtml,
+              sandbox:
+                'allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox',
+            });
+            if (iframeRef.current) {
+              iframeRef.current.style.opacity = '1';
+              iframeRef.current.style.transition = 'opacity 100ms';
+            }
+          } else if (currentScriptSrc) {
             // scriptSrc mode (prod): use the official sandbox-resource-ready protocol.
             // Generate the full app HTML and send it to the proxy.
             const absoluteScriptSrc = currentScriptSrc.startsWith('/')
@@ -648,7 +713,30 @@ export function IframeResource({
   // through PostMessage, not via iframe src/srcdoc.
   const sandboxSrc = useMemo(() => {
     if (!sandboxUrl) return undefined;
-    const url = new URL('/proxy', sandboxUrl);
+    // Two supported shapes for sandboxUrl:
+    //   1. Host root, e.g. "http://localhost:24680" — append "/proxy" (the
+    //      CLI dev server convention from `startSandboxServer`).
+    //   2. Full URL, e.g. "https://sandbox.example.com/sandbox-proxy.html"
+    //      — use as-is. Embedders hosting the static `dist/sandbox-proxy.html`
+    //      pass the file's full URL.
+    // We treat anything with a path beyond "/" as a full URL.
+    let url: URL;
+    try {
+      const parsed = new URL(sandboxUrl);
+      const hasPath = parsed.pathname && parsed.pathname !== '/';
+      url = hasPath ? parsed : new URL('/proxy', sandboxUrl);
+    } catch {
+      return undefined;
+    }
+    // Reject anything that isn't http(s). The URL constructor accepts
+    // `javascript:` and `data:` schemes; while modern browsers block
+    // `javascript:` in cross-origin iframe src, treating non-http(s) values
+    // here as invalid matches the precedent set by the OAuth flow and the
+    // mock `openExternal` runtime, and removes a class of footguns.
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      console.warn('[IframeResource] Ignoring non-http(s) sandboxUrl:', sandboxUrl);
+      return undefined;
+    }
     if (injectOpenAIRuntime) url.searchParams.set('platform', 'chatgpt');
     return url.toString();
   }, [sandboxUrl, injectOpenAIRuntime]);

--- a/packages/sunpeak/src/inspector/index.ts
+++ b/packages/sunpeak/src/inspector/index.ts
@@ -23,6 +23,15 @@ import '../claude/claude-host';
 export { Inspector } from './inspector';
 export type { InspectorProps } from './inspector';
 
+// Public input shape for embedding (App → resources + tools → simulations).
+export type {
+  InspectorApp,
+  InspectorAppResource,
+  InspectorAppTool,
+  InspectorAppSimulation,
+} from './app-types';
+export { flattenAppToSimulations } from './app-flatten';
+
 // State hook (for custom inspector builds)
 export { useInspectorState } from './use-inspector-state';
 export type { UseInspectorStateOptions, InspectorState } from './use-inspector-state';

--- a/packages/sunpeak/src/inspector/inject-infra-scripts.test.ts
+++ b/packages/sunpeak/src/inspector/inject-infra-scripts.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for `injectInfraScripts` — the helper that splices the
+ * paint-fence responder and the platform runtime into resource HTML before
+ * the Inspector hands it to the sandbox proxy. Exercises the three placement
+ * branches (head, body, no-tag) plus tag-case tolerance.
+ */
+import { describe, it, expect } from 'vitest';
+import { injectInfraScripts } from './iframe-resource';
+
+const FENCE_MARKER = 'data-sunpeak-fence';
+
+describe('injectInfraScripts', () => {
+  it('injects before </head> when a head closing tag is present', () => {
+    const html = '<!DOCTYPE html><html><head><title>x</title></head><body></body></html>';
+    const out = injectInfraScripts(html);
+    expect(out).toContain(FENCE_MARKER);
+    expect(out.indexOf(FENCE_MARKER)).toBeLessThan(out.indexOf('</head>'));
+  });
+
+  it('falls back to after <body> when there is no </head>', () => {
+    const html = '<!DOCTYPE html><html><body><p>hi</p></body></html>';
+    const out = injectInfraScripts(html);
+    const fenceAt = out.indexOf(FENCE_MARKER);
+    const bodyAt = out.indexOf('<body>');
+    expect(fenceAt).toBeGreaterThan(bodyAt);
+  });
+
+  it('prepends the injection when neither </head> nor <body> exists', () => {
+    const html = '<p>just a fragment</p>';
+    const out = injectInfraScripts(html);
+    expect(out.startsWith('<script')).toBe(true);
+    expect(out.endsWith('<p>just a fragment</p>')).toBe(true);
+  });
+
+  it('only adds a platform script tag when one is supplied', () => {
+    const withoutPlatform = injectInfraScripts('<html><head></head></html>');
+    expect(withoutPlatform).not.toContain('PLATFORM_MARKER');
+
+    const withPlatform = injectInfraScripts(
+      '<html><head></head></html>',
+      'window.PLATFORM_MARKER = true;'
+    );
+    expect(withPlatform).toContain('PLATFORM_MARKER');
+    // platform script must run BEFORE the fence responder so platform globals
+    // are visible to the app from first render.
+    expect(withPlatform.indexOf('PLATFORM_MARKER')).toBeLessThan(
+      withPlatform.indexOf(FENCE_MARKER)
+    );
+  });
+
+  it('matches uppercase / mixed-case </HEAD>', () => {
+    const html = '<HTML><HEAD></HEAD><BODY></BODY></HTML>';
+    const out = injectInfraScripts(html);
+    expect(out).toContain(FENCE_MARKER);
+    expect(out.indexOf(FENCE_MARKER)).toBeLessThan(out.indexOf('</HEAD>'));
+  });
+
+  it('injects the inline SDK helper alongside the paint fence', () => {
+    const out = injectInfraScripts('<html><head></head></html>');
+    expect(out).toContain('data-sunpeak-helper');
+    expect(out).toContain('window.sunpeak');
+    expect(out).toContain('ui/initialize');
+  });
+
+  it('exposes the full helper callback surface (input/partial/result/cancelled/host-context)', () => {
+    const out = injectInfraScripts('<html><head></head></html>');
+    expect(out).toContain('onToolInput');
+    expect(out).toContain('onToolInputPartial');
+    expect(out).toContain('onToolResult');
+    expect(out).toContain('onToolCancelled');
+    expect(out).toContain('onHostContextChange');
+  });
+
+  it('honors the <meta name="sunpeak-helper" content="off"> opt-out at runtime', () => {
+    // The opt-out is a runtime check inside the script body. We verify the
+    // body contains the meta-name query and an `off` comparison; the
+    // case-insensitive behavior and runtime dispatch are exercised by
+    // inline-helper-runtime.test.ts.
+    const out = injectInfraScripts('<html><head></head></html>');
+    expect(out).toMatch(/meta\[name="sunpeak-helper"\]/);
+    expect(out).toMatch(/'off'/);
+  });
+
+  it('preserves <body> attributes when injecting via the body fallback', () => {
+    const html = '<html><body class="dark" data-x="y"><p>hi</p></body></html>';
+    const out = injectInfraScripts(html);
+    expect(out).toContain('<body class="dark" data-x="y">');
+    expect(out.indexOf(FENCE_MARKER)).toBeGreaterThan(
+      out.indexOf('<body class="dark" data-x="y">')
+    );
+  });
+});

--- a/packages/sunpeak/src/inspector/inline-helper-runtime.test.ts
+++ b/packages/sunpeak/src/inspector/inline-helper-runtime.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Runtime behavior tests for the inline helper. The helper is a string of JS
+ * we inject into resource HTML, so the tests evaluate the script against a
+ * fresh happy-dom window and drive its postMessage / DOM interactions
+ * directly.
+ *
+ * Covers the round-5 fixes:
+ *   - Dispatch iterates a snapshot, so a self-unsubscribing callback doesn't
+ *     skip later callbacks.
+ *   - tool-cancelled clears cached tool-input / tool-result so late
+ *     subscribers don't get stale replays.
+ *   - <meta name="sunpeak-helper" content="off"> opt-out matches
+ *     case-insensitively.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Window } from 'happy-dom';
+import { SUNPEAK_INLINE_HELPER_SCRIPT } from './inline-helper-script';
+
+// Each test gets a fresh window with a stubbed `parent` we can flush
+// messages from. The helper's `window.parent.postMessage` becomes a
+// recorder; our test sends inbound messages by firing MessageEvent on
+// the helper's window directly with `source: realParent`.
+function makeWindow(opts: { metaContent?: string } = {}) {
+  const w = new Window().window as unknown as Window & { parent: Window };
+  // happy-dom defaults `parent === window`, which is exactly what the
+  // helper's `ev.source !== window.parent` guard needs.
+  const sent: Array<Record<string, unknown>> = [];
+  (w as unknown as { parent: unknown }).parent = w;
+  (w.parent as unknown as { postMessage: (d: unknown) => void }).postMessage = (
+    data: unknown
+  ) => {
+    sent.push(data as Record<string, unknown>);
+  };
+  // Optional meta-tag opt-out
+  if (opts.metaContent != null) {
+    const meta = w.document.createElement('meta');
+    meta.setAttribute('name', 'sunpeak-helper');
+    meta.setAttribute('content', opts.metaContent);
+    w.document.head.appendChild(meta);
+  }
+  // Evaluate the helper script in the window's global scope
+  // by using new Function with `window` injected.
+  const fn = new Function('window', 'document', SUNPEAK_INLINE_HELPER_SCRIPT);
+  fn(w as unknown, w.document as unknown);
+  return { w, sent };
+}
+
+function fireIncoming(
+  w: Window & { parent: Window },
+  data: Record<string, unknown>
+): void {
+  // The helper checks `ev.source !== window.parent`. Use the window's own
+  // MessageEvent constructor and dispatcher so happy-dom's types line up.
+  const ev = new (w as unknown as { MessageEvent: typeof MessageEvent }).MessageEvent(
+    'message',
+    { data, source: w.parent as unknown as MessageEventSource }
+  );
+  // Happy-dom's Window#dispatchEvent expects happy-dom's Event subtype, not
+  // lib.dom's. Cast through unknown to satisfy strict TS.
+  (w as unknown as { dispatchEvent: (e: unknown) => boolean }).dispatchEvent(ev);
+}
+
+describe('inline helper runtime', () => {
+  describe('basic dispatch', () => {
+    let env: ReturnType<typeof makeWindow>;
+    beforeEach(() => {
+      env = makeWindow();
+    });
+
+    it('exposes window.sunpeak with all five callback methods', () => {
+      // @ts-expect-error helper attaches to window
+      const sp = env.w.sunpeak;
+      expect(typeof sp.onToolInput).toBe('function');
+      expect(typeof sp.onToolInputPartial).toBe('function');
+      expect(typeof sp.onToolResult).toBe('function');
+      expect(typeof sp.onToolCancelled).toBe('function');
+      expect(typeof sp.onHostContextChange).toBe('function');
+    });
+
+    it('sends a ui/initialize request on install', () => {
+      const initialize = env.sent.find((m) => m.method === 'ui/initialize');
+      expect(initialize).toBeDefined();
+      expect(initialize).toMatchObject({
+        jsonrpc: '2.0',
+        method: 'ui/initialize',
+      });
+    });
+
+    it('delivers a tool-result to a registered onToolResult', () => {
+      const seen: unknown[] = [];
+      // @ts-expect-error helper attaches to window
+      env.w.sunpeak.onToolResult((r: unknown) => seen.push(r));
+      fireIncoming(env.w, {
+        jsonrpc: '2.0',
+        method: 'ui/notifications/tool-result',
+        params: { content: [{ type: 'text', text: 'hi' }], structuredContent: { x: 1 } },
+      });
+      expect(seen).toHaveLength(1);
+      expect(seen[0]).toMatchObject({ structuredContent: { x: 1 } });
+    });
+
+    it('replays the last delivered value to late subscribers', () => {
+      fireIncoming(env.w, {
+        jsonrpc: '2.0',
+        method: 'ui/notifications/tool-input',
+        params: { arguments: { a: 1 } },
+      });
+      const seen: unknown[] = [];
+      // @ts-expect-error helper attaches to window
+      env.w.sunpeak.onToolInput((args: unknown) => seen.push(args));
+      expect(seen).toEqual([{ a: 1 }]);
+    });
+
+    it('throws TypeError naming the actual method when given a non-function', () => {
+      // @ts-expect-error helper attaches to window
+      const sp = env.w.sunpeak;
+      expect(() => sp.onToolResult('not a fn')).toThrow(/onToolResult/);
+    });
+  });
+
+  describe('self-unsubscribe during dispatch', () => {
+    it('does not skip subsequent callbacks when one unsubscribes itself', () => {
+      const env = makeWindow();
+      const seen: string[] = [];
+      // @ts-expect-error helper attaches to window
+      const sp = env.w.sunpeak;
+      // A registers a callback that unsubscribes itself when called
+      const unsubA = sp.onToolResult(() => {
+        seen.push('A');
+        unsubA();
+      });
+      sp.onToolResult(() => seen.push('B'));
+      sp.onToolResult(() => seen.push('C'));
+      fireIncoming(env.w, {
+        jsonrpc: '2.0',
+        method: 'ui/notifications/tool-result',
+        params: {},
+      });
+      // All three should fire on the first delivery. Without the snapshot
+      // fix, B would be skipped (A's splice shifts B into A's index, the
+      // for-loop increments past it).
+      expect(seen).toEqual(['A', 'B', 'C']);
+      // On a second delivery only B and C should fire (A unsubscribed)
+      seen.length = 0;
+      fireIncoming(env.w, {
+        jsonrpc: '2.0',
+        method: 'ui/notifications/tool-result',
+        params: {},
+      });
+      expect(seen).toEqual(['B', 'C']);
+    });
+  });
+
+  describe('cancellation clears cached input/result', () => {
+    it('does not replay tool-input/result to subscribers registered after cancellation', () => {
+      const env = makeWindow();
+      // Deliver an input and result first
+      fireIncoming(env.w, {
+        jsonrpc: '2.0',
+        method: 'ui/notifications/tool-input',
+        params: { arguments: { x: 1 } },
+      });
+      fireIncoming(env.w, {
+        jsonrpc: '2.0',
+        method: 'ui/notifications/tool-result',
+        params: { structuredContent: { y: 2 } },
+      });
+      // Then a cancellation
+      fireIncoming(env.w, {
+        jsonrpc: '2.0',
+        method: 'ui/notifications/tool-cancelled',
+        params: {},
+      });
+      // Late subscribers should NOT see the stale values
+      const seenInputs: unknown[] = [];
+      const seenResults: unknown[] = [];
+      // @ts-expect-error helper attaches to window
+      env.w.sunpeak.onToolInput((v: unknown) => seenInputs.push(v));
+      // @ts-expect-error helper attaches to window
+      env.w.sunpeak.onToolResult((v: unknown) => seenResults.push(v));
+      expect(seenInputs).toEqual([]);
+      expect(seenResults).toEqual([]);
+    });
+
+    it('still replays host-context (which is unaffected by tool cancellation)', () => {
+      const env = makeWindow();
+      fireIncoming(env.w, {
+        jsonrpc: '2.0',
+        method: 'ui/notifications/host-context-changed',
+        params: { theme: 'dark' },
+      });
+      fireIncoming(env.w, {
+        jsonrpc: '2.0',
+        method: 'ui/notifications/tool-cancelled',
+        params: {},
+      });
+      const seen: unknown[] = [];
+      // @ts-expect-error helper attaches to window
+      env.w.sunpeak.onHostContextChange((v: unknown) => seen.push(v));
+      expect(seen).toEqual([{ theme: 'dark' }]);
+    });
+  });
+
+  describe('meta-tag opt-out', () => {
+    it('does NOT install window.sunpeak when <meta content="off"> is present', () => {
+      const env = makeWindow({ metaContent: 'off' });
+      // @ts-expect-error helper attaches to window
+      expect(env.w.sunpeak).toBeUndefined();
+    });
+
+    it('matches the meta value case-insensitively', () => {
+      for (const v of ['OFF', 'Off', 'oFf']) {
+        const env = makeWindow({ metaContent: v });
+        // @ts-expect-error helper attaches to window
+        expect(env.w.sunpeak, `expected sunpeak undefined for content="${v}"`).toBeUndefined();
+      }
+    });
+
+    it('does NOT opt out for other content values', () => {
+      const env = makeWindow({ metaContent: 'on' });
+      // @ts-expect-error helper attaches to window
+      expect(env.w.sunpeak).toBeDefined();
+    });
+  });
+
+  describe('security: ignores messages from non-parent sources', () => {
+    it('drops a message whose source is not window.parent', () => {
+      const env = makeWindow();
+      const seen: unknown[] = [];
+      // @ts-expect-error helper attaches to window
+      env.w.sunpeak.onToolResult((v: unknown) => seen.push(v));
+      // Fire an event with source set to something OTHER than window.parent.
+      const ev = new (env.w as unknown as { MessageEvent: typeof MessageEvent }).MessageEvent(
+        'message',
+        {
+          data: {
+            jsonrpc: '2.0',
+            method: 'ui/notifications/tool-result',
+            params: { structuredContent: { forged: true } },
+          },
+          source: {} as MessageEventSource,
+        }
+      );
+      (env.w as unknown as { dispatchEvent: (e: unknown) => boolean }).dispatchEvent(ev);
+      expect(seen).toEqual([]);
+    });
+  });
+});

--- a/packages/sunpeak/src/inspector/inline-helper-runtime.test.ts
+++ b/packages/sunpeak/src/inspector/inline-helper-runtime.test.ts
@@ -26,9 +26,7 @@ function makeWindow(opts: { metaContent?: string } = {}) {
   // helper's `ev.source !== window.parent` guard needs.
   const sent: Array<Record<string, unknown>> = [];
   (w as unknown as { parent: unknown }).parent = w;
-  (w.parent as unknown as { postMessage: (d: unknown) => void }).postMessage = (
-    data: unknown
-  ) => {
+  (w.parent as unknown as { postMessage: (d: unknown) => void }).postMessage = (data: unknown) => {
     sent.push(data as Record<string, unknown>);
   };
   // Optional meta-tag opt-out
@@ -45,16 +43,13 @@ function makeWindow(opts: { metaContent?: string } = {}) {
   return { w, sent };
 }
 
-function fireIncoming(
-  w: Window & { parent: Window },
-  data: Record<string, unknown>
-): void {
+function fireIncoming(w: Window & { parent: Window }, data: Record<string, unknown>): void {
   // The helper checks `ev.source !== window.parent`. Use the window's own
   // MessageEvent constructor and dispatcher so happy-dom's types line up.
-  const ev = new (w as unknown as { MessageEvent: typeof MessageEvent }).MessageEvent(
-    'message',
-    { data, source: w.parent as unknown as MessageEventSource }
-  );
+  const ev = new (w as unknown as { MessageEvent: typeof MessageEvent }).MessageEvent('message', {
+    data,
+    source: w.parent as unknown as MessageEventSource,
+  });
   // Happy-dom's Window#dispatchEvent expects happy-dom's Event subtype, not
   // lib.dom's. Cast through unknown to satisfy strict TS.
   (w as unknown as { dispatchEvent: (e: unknown) => boolean }).dispatchEvent(ev);

--- a/packages/sunpeak/src/inspector/inline-helper-script.ts
+++ b/packages/sunpeak/src/inspector/inline-helper-script.ts
@@ -1,0 +1,166 @@
+/**
+ * Inline helper script injected into resource HTML alongside the paint-fence
+ * and platform-runtime scripts. It performs the MCP Apps `ui/initialize`
+ * handshake on behalf of the resource and exposes a friendly callback API
+ * via `window.sunpeak.{onToolInput, onToolInputPartial, onToolResult,
+ * onToolCancelled, onHostContextChange}`.
+ *
+ * This exists so embedders can ship plain HTML resources (e.g. a hardcoded
+ * `<html>…</html>` string they pass via `app.resources[].html`) without
+ * bundling the MCP Apps SDK. Without this helper, the host buffers tool
+ * inputs and results forever — the SDK's initialize gate would never close.
+ *
+ * Opt-out: resource HTML that already uses the MCP Apps SDK can disable the
+ * helper by including `<meta name="sunpeak-helper" content="off">` in its
+ * `<head>`. Without the opt-out, the helper and the SDK both send
+ * `ui/initialize` and the host bridge logs a (harmless) double-init warning.
+ *
+ * The helper is intentionally protocol-compatible: from the host's view it
+ * looks like a regular MCP Apps client completing the handshake. The host
+ * then unbuffers and delivers the queued notifications normally.
+ */
+
+// Kept in sync with `LATEST_PROTOCOL_VERSION` in `@modelcontextprotocol/ext-apps`.
+// The drift guard in `sandbox-static.test.ts` doesn't cover this string, so
+// when bumping the ext-apps dependency, search for this constant.
+const PROTOCOL_VERSION = '2026-01-26';
+
+export const SUNPEAK_INLINE_HELPER_SCRIPT = `
+(function() {
+  if (window.sunpeak) return; // already installed (e.g. parent hot-reload)
+  // Opt-out: resource HTML using the real MCP Apps SDK can suppress the
+  // helper to avoid sending two ui/initialize requests. Manual lowercase
+  // comparison so content="off" / "OFF" / "Off" all match (the Selectors
+  // L4 case-insensitive flag isn't supported in all test environments).
+  try {
+    var metas = document.querySelectorAll('meta[name="sunpeak-helper"]');
+    for (var mi = 0; mi < metas.length; mi++) {
+      var contentAttr = metas[mi].getAttribute('content');
+      if (contentAttr && contentAttr.toLowerCase() === 'off') return;
+    }
+  } catch (e) { /* document not ready or querySelector missing */ }
+
+  var listeners = {
+    toolInput: [],
+    toolInputPartial: [],
+    toolResult: [],
+    toolCancelled: [],
+    hostContext: []
+  };
+  var last = {
+    toolInput: undefined,
+    toolInputPartial: undefined,
+    toolResult: undefined,
+    toolCancelled: undefined,
+    hostContext: undefined
+  };
+  function dispatch(channel, value) {
+    last[channel] = value;
+    // Iterate over a SNAPSHOT — callbacks that unsubscribe themselves
+    // mutate the live list, which would skip subsequent callbacks under a
+    // for-by-index loop on the original array.
+    var list = listeners[channel].slice();
+    for (var i = 0; i < list.length; i++) {
+      try { list[i](value); } catch (e) { console.error('[sunpeak] callback error:', e); }
+    }
+  }
+  // Map channel names to the public method name for error messages.
+  var channelMethodName = {
+    toolInput: 'onToolInput',
+    toolInputPartial: 'onToolInputPartial',
+    toolResult: 'onToolResult',
+    toolCancelled: 'onToolCancelled',
+    hostContext: 'onHostContextChange'
+  };
+  function subscribe(channel) {
+    return function(cb) {
+      if (typeof cb !== 'function') {
+        throw new TypeError('window.sunpeak.' + channelMethodName[channel] + ' expects a function');
+      }
+      listeners[channel].push(cb);
+      if (last[channel] !== undefined) {
+        try { cb(last[channel]); } catch (e) { console.error('[sunpeak] callback error:', e); }
+      }
+      return function unsubscribe() {
+        var idx = listeners[channel].indexOf(cb);
+        if (idx >= 0) listeners[channel].splice(idx, 1);
+      };
+    };
+  }
+
+  window.sunpeak = {
+    onToolInput: subscribe('toolInput'),
+    onToolInputPartial: subscribe('toolInputPartial'),
+    onToolResult: subscribe('toolResult'),
+    onToolCancelled: subscribe('toolCancelled'),
+    onHostContextChange: subscribe('hostContext')
+  };
+
+  var nextId = 1;
+  var pending = {};
+
+  function sendRequest(method, params) {
+    var id = nextId++;
+    return new Promise(function(resolve, reject) {
+      pending[id] = { resolve: resolve, reject: reject };
+      try {
+        window.parent.postMessage({ jsonrpc: '2.0', id: id, method: method, params: params }, '*');
+      } catch (e) {
+        delete pending[id];
+        reject(e);
+      }
+    });
+  }
+  function sendNotification(method, params) {
+    try {
+      window.parent.postMessage({ jsonrpc: '2.0', method: method, params: params || {} }, '*');
+    } catch (e) { /* parent detached */ }
+  }
+
+  window.addEventListener('message', function(ev) {
+    // Only trust messages from the actual parent (the sandbox proxy).
+    // Without this guard, a sibling iframe in the same browsing context or
+    // a browser extension content script could forge JSON-RPC notifications
+    // and drive the embedder's onToolResult/onToolInput callbacks with
+    // attacker-controlled data.
+    if (ev.source !== window.parent) return;
+    var msg = ev.data;
+    if (!msg || typeof msg !== 'object' || msg.jsonrpc !== '2.0') return;
+    if (typeof msg.id !== 'undefined' && pending[msg.id]) {
+      var p = pending[msg.id];
+      delete pending[msg.id];
+      if (msg.error) p.reject(new Error((msg.error && msg.error.message) || 'request error'));
+      else p.resolve(msg.result);
+      return;
+    }
+    if (msg.method === 'ui/notifications/tool-input') {
+      dispatch('toolInput', (msg.params && msg.params.arguments) || {});
+    } else if (msg.method === 'ui/notifications/tool-input-partial') {
+      dispatch('toolInputPartial', (msg.params && msg.params.arguments) || {});
+    } else if (msg.method === 'ui/notifications/tool-result') {
+      // tool-result params are the CallToolResult directly per the spec.
+      dispatch('toolResult', msg.params || {});
+    } else if (msg.method === 'ui/notifications/tool-cancelled') {
+      // Clear cached input / partial / result so a late onToolResult
+      // subscriber doesn't get the cancelled-then-stale value replayed.
+      // hostContext stays — the environment hasn't changed.
+      last.toolInput = undefined;
+      last.toolInputPartial = undefined;
+      last.toolResult = undefined;
+      dispatch('toolCancelled', msg.params || {});
+    } else if (msg.method === 'ui/notifications/host-context-changed') {
+      dispatch('hostContext', msg.params || {});
+    }
+  });
+
+  sendRequest('ui/initialize', {
+    appInfo: { name: 'sunpeak-inline-helper', version: '1.0.0' },
+    appCapabilities: {},
+    protocolVersion: '${PROTOCOL_VERSION}'
+  }).then(function() {
+    sendNotification('ui/notifications/initialized');
+  }).catch(function(err) {
+    console.warn('[sunpeak] ui/initialize failed:', err && err.message);
+  });
+})();
+`.trim();

--- a/packages/sunpeak/src/inspector/inspector.test.tsx
+++ b/packages/sunpeak/src/inspector/inspector.test.tsx
@@ -1009,6 +1009,12 @@ describe('Inspector', () => {
     });
   });
 
+  // Note: integration of the `app` prop with the iframe lifecycle is covered
+  // by the flattener unit tests (`app-flatten.test.ts`) and the e2e suite,
+  // not here. jsdom's iframe semantics differ enough from real browsers that
+  // rendering a populated app through the iframe stack adds noise without
+  // catching anything the unit + e2e layers don't already cover.
+
   // ── Story 3: Programmatic testing (URL params) ──
   // URL param tests are covered by E2E tests (inspector-modes.spec.ts) which
   // navigate to real URLs. Unit-testing URL params in jsdom is unreliable because
@@ -1044,6 +1050,98 @@ describe('Inspector', () => {
       // @ts-expect-error — prodTools was removed from the type
       const url = createInspectorUrl({ simulation: 'test', prodTools: true });
       expect(url).not.toContain('prodTools');
+    });
+  });
+
+  // ── Embedded mode: the `app` prop drives a self-contained instance ──
+  // These tests use an empty-tools app so the Inspector renders the empty
+  // state (no iframe lifecycle to drive in jsdom). Sidebar gating and root
+  // sizing are observable without rendering an actual resource.
+  describe('Embedded mode (`app` prop)', () => {
+    const emptyApp = { name: 'My Embed', resources: [], tools: [] };
+
+    it('hides the MCP Server URL input', () => {
+      render(<Inspector app={emptyApp} onCallTool={vi.fn()} />);
+      expect(screen.queryByTestId('server-url')).not.toBeInTheDocument();
+    });
+
+    it('hides the Authentication section', () => {
+      render(<Inspector app={emptyApp} onCallTool={vi.fn()} />);
+      expect(screen.queryByText('Authentication')).not.toBeInTheDocument();
+    });
+
+    it('hides the Prod Resources checkbox', () => {
+      render(<Inspector app={emptyApp} onCallTool={vi.fn()} />);
+      expect(
+        screen.queryByRole('checkbox', { name: /prod resources/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not call /__sunpeak/list-tools on mount', () => {
+      render(<Inspector app={emptyApp} onCallTool={vi.fn()} />);
+      expect(fetchSpy).not.toHaveBeenCalledWith('/__sunpeak/list-tools');
+    });
+
+    it('uses h-full w-full instead of viewport sizing on the root element', () => {
+      const { container } = render(<Inspector app={emptyApp} onCallTool={vi.fn()} />);
+      const root = container.querySelector('.sunpeak-inspector-root');
+      expect(root?.className).toMatch(/\bh-full\b/);
+      expect(root?.className).not.toMatch(/\bh-screen\b/);
+    });
+
+    it('shows the embedded-mode empty-state message when no tools exist', () => {
+      render(<Inspector app={emptyApp} onCallTool={vi.fn()} />);
+      expect(screen.getByText('No tools with UI resources in this app')).toBeInTheDocument();
+    });
+
+    it('reacts to a new `app` prop — swapping in a different app updates the tool list', async () => {
+      const appA = {
+        name: 'A',
+        resources: [],
+        tools: [],
+      };
+      const appB = {
+        name: 'B',
+        resources: [{ uri: 'ui://b', html: '<html><body>B</body></html>' }],
+        tools: [
+          {
+            tool: {
+              name: 'tool_b',
+              inputSchema: { type: 'object' as const, properties: {}, required: [] },
+              _meta: { openai: { outputTemplate: 'ui://b' } },
+            },
+          },
+        ],
+      };
+      const { rerender } = render(<Inspector app={appA} onCallTool={vi.fn()} />);
+      // No tools in appA — embedded empty state.
+      expect(screen.getByText('No tools with UI resources in this app')).toBeInTheDocument();
+      // Swap to appB. The Inspector should pick up the new tool without errors.
+      rerender(<Inspector app={appB} onCallTool={vi.fn()} />);
+      await waitFor(() => {
+        const opts = screen
+          .getAllByRole('option')
+          .filter((o) => o.textContent === 'tool_b');
+        expect(opts.length).toBe(1);
+      });
+    });
+
+    it('warns when both `app` and `simulations` are supplied', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        render(
+          <Inspector
+            app={emptyApp}
+            simulations={{ stray: createSim() }}
+            onCallTool={vi.fn()}
+          />
+        );
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Both `app` and `simulations` were provided')
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
   });
 });

--- a/packages/sunpeak/src/inspector/inspector.test.tsx
+++ b/packages/sunpeak/src/inspector/inspector.test.tsx
@@ -1072,9 +1072,7 @@ describe('Inspector', () => {
 
     it('hides the Prod Resources checkbox', () => {
       render(<Inspector app={emptyApp} onCallTool={vi.fn()} />);
-      expect(
-        screen.queryByRole('checkbox', { name: /prod resources/i })
-      ).not.toBeInTheDocument();
+      expect(screen.queryByRole('checkbox', { name: /prod resources/i })).not.toBeInTheDocument();
     });
 
     it('does not call /__sunpeak/list-tools on mount', () => {
@@ -1119,9 +1117,7 @@ describe('Inspector', () => {
       // Swap to appB. The Inspector should pick up the new tool without errors.
       rerender(<Inspector app={appB} onCallTool={vi.fn()} />);
       await waitFor(() => {
-        const opts = screen
-          .getAllByRole('option')
-          .filter((o) => o.textContent === 'tool_b');
+        const opts = screen.getAllByRole('option').filter((o) => o.textContent === 'tool_b');
         expect(opts.length).toBe(1);
       });
     });
@@ -1130,11 +1126,7 @@ describe('Inspector', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       try {
         render(
-          <Inspector
-            app={emptyApp}
-            simulations={{ stray: createSim() }}
-            onCallTool={vi.fn()}
-          />
+          <Inspector app={emptyApp} simulations={{ stray: createSim() }} onCallTool={vi.fn()} />
         );
         expect(warnSpy).toHaveBeenCalledWith(
           expect.stringContaining('Both `app` and `simulations` were provided')

--- a/packages/sunpeak/src/inspector/inspector.tsx
+++ b/packages/sunpeak/src/inspector/inspector.tsx
@@ -148,11 +148,7 @@ export function Inspector({
   const conflictWarnedRef = React.useRef(false);
   React.useEffect(() => {
     if (conflictWarnedRef.current) return;
-    if (
-      app &&
-      initialSimulationsProp &&
-      Object.keys(initialSimulationsProp).length > 0
-    ) {
+    if (app && initialSimulationsProp && Object.keys(initialSimulationsProp).length > 0) {
       conflictWarnedRef.current = true;
       console.warn(
         '[Inspector] Both `app` and `simulations` were provided. `app` takes precedence; `simulations` is ignored.'
@@ -1039,10 +1035,7 @@ export function Inspector({
   if (!showSidebar) {
     return (
       <ThemeProvider theme={state.theme} applyTheme={applyTheme}>
-        <div
-          ref={rootRef}
-          className={`sunpeak-inspector-root flex ${rootSizing}`}
-        >
+        <div ref={rootRef} className={`sunpeak-inspector-root flex ${rootSizing}`}>
           {conversationContent}
         </div>
       </ThemeProvider>
@@ -1063,137 +1056,142 @@ export function Inspector({
              */}
             {!isEmbedded && (
               <>
-            <SidebarControl
-              label={
-                <span className="flex items-center gap-1.5">
-                  MCP Server
-                  {serverUrl && !demoMode && (
-                    <span
-                      className="inline-block w-2 h-2 rounded-full"
-                      data-testid="connection-status"
-                      style={{
-                        backgroundColor:
-                          connection.status === 'connected'
-                            ? '#22c55e'
-                            : connection.status === 'connecting'
-                              ? '#eab308'
-                              : connection.status === 'error'
-                                ? '#ef4444'
-                                : '#6b7280',
-                      }}
-                      title={connection.error ?? connection.status}
-                    />
-                  )}
-                </span>
-              }
-              tooltip="MCP server URL"
-              data-testid="server-url"
-            >
-              <SidebarInput
-                value={demoMode ? 'http://localhost:8000/mcp' : serverUrl}
-                onChange={demoMode ? () => {} : setServerUrl}
-                applyOnBlur
-                placeholder="http://localhost:8000/mcp"
-                disabled={demoMode}
-              />
-            </SidebarControl>
-
-            {/* ── Authentication (hidden in demo mode) ── */}
-            {!demoMode && (
-              <SidebarCollapsibleControl
-                key={`auth-${authType === 'none' ? 'none' : 'active'}`}
-                label="Authentication"
-                defaultCollapsed={authType === 'none'}
-              >
-                <div className="space-y-1">
-                  <SidebarSelect
-                    value={authType}
-                    onChange={(value) => {
-                      const newType = value as AuthType;
-                      setAuthType(newType);
-                      setOauthStatus('none');
-                      setOauthError(undefined);
-                      // Reconnect without auth when switching to "none"
-                      if (newType === 'none' && serverUrl) {
-                        connection.reconnect(serverUrl);
-                      }
-                    }}
-                    options={[
-                      { value: 'none', label: 'None' },
-                      { value: 'bearer', label: 'Bearer Token' },
-                      { value: 'oauth', label: 'OAuth' },
-                    ]}
-                  />
-
-                  {authType === 'bearer' && (
-                    <SidebarInput
-                      type="password"
-                      value={bearerToken}
-                      onChange={(value) => {
-                        setBearerToken(value);
-                        // Reconnect with the new token when applied
-                        if (serverUrl && value) {
-                          connection.reconnect(serverUrl, { type: 'bearer', bearerToken: value });
-                        }
-                      }}
-                      applyOnBlur
-                      placeholder="Paste your token"
-                    />
-                  )}
-
-                  {authType === 'oauth' && (
-                    <div className="space-y-1">
-                      <SidebarInput
-                        value={oauthClientId}
-                        onChange={setOauthClientId}
-                        applyOnBlur
-                        placeholder="Client ID (optional)"
-                      />
-                      {oauthClientId && (
-                        <SidebarInput
-                          type="password"
-                          value={oauthClientSecret}
-                          onChange={setOauthClientSecret}
-                          applyOnBlur
-                          placeholder="Client Secret (optional)"
+                <SidebarControl
+                  label={
+                    <span className="flex items-center gap-1.5">
+                      MCP Server
+                      {serverUrl && !demoMode && (
+                        <span
+                          className="inline-block w-2 h-2 rounded-full"
+                          data-testid="connection-status"
+                          style={{
+                            backgroundColor:
+                              connection.status === 'connected'
+                                ? '#22c55e'
+                                : connection.status === 'connecting'
+                                  ? '#eab308'
+                                  : connection.status === 'error'
+                                    ? '#ef4444'
+                                    : '#6b7280',
+                          }}
+                          title={connection.error ?? connection.status}
                         />
                       )}
-                      <SidebarInput
-                        value={oauthScopes}
-                        onChange={setOauthScopes}
-                        applyOnBlur
-                        placeholder="Scopes (optional)"
-                      />
-                      <button
-                        type="button"
-                        onClick={handleStartOAuth}
-                        disabled={!serverUrl || oauthStatus === 'authorizing'}
-                        className="w-full h-7 text-xs rounded-md px-2 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-                        style={{
-                          backgroundColor:
-                            oauthStatus === 'authorized' ? '#22c55e' : 'var(--color-text-primary)',
-                          color: 'var(--color-background-primary)',
+                    </span>
+                  }
+                  tooltip="MCP server URL"
+                  data-testid="server-url"
+                >
+                  <SidebarInput
+                    value={demoMode ? 'http://localhost:8000/mcp' : serverUrl}
+                    onChange={demoMode ? () => {} : setServerUrl}
+                    applyOnBlur
+                    placeholder="http://localhost:8000/mcp"
+                    disabled={demoMode}
+                  />
+                </SidebarControl>
+
+                {/* ── Authentication (hidden in demo mode) ── */}
+                {!demoMode && (
+                  <SidebarCollapsibleControl
+                    key={`auth-${authType === 'none' ? 'none' : 'active'}`}
+                    label="Authentication"
+                    defaultCollapsed={authType === 'none'}
+                  >
+                    <div className="space-y-1">
+                      <SidebarSelect
+                        value={authType}
+                        onChange={(value) => {
+                          const newType = value as AuthType;
+                          setAuthType(newType);
+                          setOauthStatus('none');
+                          setOauthError(undefined);
+                          // Reconnect without auth when switching to "none"
+                          if (newType === 'none' && serverUrl) {
+                            connection.reconnect(serverUrl);
+                          }
                         }}
-                      >
-                        {oauthStatus === 'authorizing'
-                          ? 'Authorizing\u2026'
-                          : oauthStatus === 'authorized'
-                            ? 'Authorized'
-                            : 'Authorize'}
-                      </button>
-                      {oauthError && (
-                        <div
-                          className="text-[9px]"
-                          style={{ color: 'var(--color-text-danger, #dc2626)' }}
-                        >
-                          {oauthError}
+                        options={[
+                          { value: 'none', label: 'None' },
+                          { value: 'bearer', label: 'Bearer Token' },
+                          { value: 'oauth', label: 'OAuth' },
+                        ]}
+                      />
+
+                      {authType === 'bearer' && (
+                        <SidebarInput
+                          type="password"
+                          value={bearerToken}
+                          onChange={(value) => {
+                            setBearerToken(value);
+                            // Reconnect with the new token when applied
+                            if (serverUrl && value) {
+                              connection.reconnect(serverUrl, {
+                                type: 'bearer',
+                                bearerToken: value,
+                              });
+                            }
+                          }}
+                          applyOnBlur
+                          placeholder="Paste your token"
+                        />
+                      )}
+
+                      {authType === 'oauth' && (
+                        <div className="space-y-1">
+                          <SidebarInput
+                            value={oauthClientId}
+                            onChange={setOauthClientId}
+                            applyOnBlur
+                            placeholder="Client ID (optional)"
+                          />
+                          {oauthClientId && (
+                            <SidebarInput
+                              type="password"
+                              value={oauthClientSecret}
+                              onChange={setOauthClientSecret}
+                              applyOnBlur
+                              placeholder="Client Secret (optional)"
+                            />
+                          )}
+                          <SidebarInput
+                            value={oauthScopes}
+                            onChange={setOauthScopes}
+                            applyOnBlur
+                            placeholder="Scopes (optional)"
+                          />
+                          <button
+                            type="button"
+                            onClick={handleStartOAuth}
+                            disabled={!serverUrl || oauthStatus === 'authorizing'}
+                            className="w-full h-7 text-xs rounded-md px-2 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                            style={{
+                              backgroundColor:
+                                oauthStatus === 'authorized'
+                                  ? '#22c55e'
+                                  : 'var(--color-text-primary)',
+                              color: 'var(--color-background-primary)',
+                            }}
+                          >
+                            {oauthStatus === 'authorizing'
+                              ? 'Authorizing\u2026'
+                              : oauthStatus === 'authorized'
+                                ? 'Authorized'
+                                : 'Authorize'}
+                          </button>
+                          {oauthError && (
+                            <div
+                              className="text-[9px]"
+                              style={{ color: 'var(--color-text-danger, #dc2626)' }}
+                            >
+                              {oauthError}
+                            </div>
+                          )}
                         </div>
                       )}
                     </div>
-                  )}
-                </div>
-              </SidebarCollapsibleControl>
-            )}
+                  </SidebarCollapsibleControl>
+                )}
               </>
             )}
 

--- a/packages/sunpeak/src/inspector/inspector.tsx
+++ b/packages/sunpeak/src/inspector/inspector.tsx
@@ -23,6 +23,8 @@ import { getHostShell, getRegisteredHosts, type HostId } from './hosts';
 import { resolveServerToolResult } from '../types/simulation';
 import type { Simulation } from '../types/simulation';
 import type { ScreenWidth } from './inspector-types';
+import type { InspectorApp } from './app-types';
+import { flattenAppToSimulations } from './app-flatten';
 
 // Register built-in host shells. These imports live here (in the component file)
 // rather than in the barrel index.ts because Rollup code-splitting can separate
@@ -36,6 +38,18 @@ const DOCS_BASE_URL = 'https://sunpeak.ai/docs';
 
 export interface InspectorProps {
   children?: React.ReactNode;
+  /**
+   * Hierarchical input for embedding: an MCP App with its resources, tools,
+   * and saved simulations. Mirrors the MCP App data model — resources are
+   * keyed by URI, and each tool's `_meta.openai.outputTemplate` selects the
+   * resource it renders. The Inspector flattens this internally; pass the
+   * shape you already have from `listTools` + `listResources` + your fixture
+   * store and the component renders it. See `InspectorApp`.
+   *
+   * Mutually exclusive with `simulations`. When both are provided, `app`
+   * wins — `simulations` stays for back-compat with the CLI codepath.
+   */
+  app?: InspectorApp;
   simulations?: Record<string, Simulation>;
   appName?: string;
   appIcon?: string;
@@ -94,11 +108,18 @@ function hasFixtureData(sim: Simulation): boolean {
   return sim.toolResult != null || sim.toolInput != null || sim.serverTools != null;
 }
 
+// Reference-stable empty default. A destructuring default of `= {}` creates a
+// fresh object on every render — when combined with `useMemo(..., [..., props])`
+// downstream that drives a `useEffect(setState(...), [memo])`, that produces
+// an infinite render loop. Don't reinline this.
+const EMPTY_SIMULATIONS: Readonly<Record<string, Simulation>> = Object.freeze({});
+
 export function Inspector({
   children,
-  simulations: initialSimulations = {},
-  appName = 'Sunpeak',
-  appIcon,
+  app,
+  simulations: initialSimulationsProp = EMPTY_SIMULATIONS,
+  appName: appNameProp,
+  appIcon: appIconProp,
   defaultHost = 'chatgpt',
   onCallTool,
   onCallToolDirect,
@@ -108,6 +129,43 @@ export function Inspector({
   sandboxUrl,
   mcpServerUrl,
 }: InspectorProps) {
+  // When `app` is provided it drives both the simulation map and the header
+  // name/icon. Falling back to the legacy props keeps existing callers working.
+  const initialSimulations = React.useMemo(
+    () => (app ? flattenAppToSimulations(app) : initialSimulationsProp),
+    [app, initialSimulationsProp]
+  );
+  const appName = app?.name ?? appNameProp ?? 'Sunpeak';
+  const appIcon = app?.icon ?? appIconProp;
+  // `!!app` (rather than `app !== undefined`) so a slipped-in `null` doesn't
+  // flip the inspector into embedded mode while delivering no actual app.
+  const isEmbedded = !!app;
+
+  // Warn at most once per component instance when both inputs are supplied.
+  // Without the ref guard the useEffect dep `initialSimulationsProp` changes
+  // reference each parent render (when `simulations` is passed inline), which
+  // would cause the warning to spam the console repeatedly.
+  const conflictWarnedRef = React.useRef(false);
+  React.useEffect(() => {
+    if (conflictWarnedRef.current) return;
+    if (
+      app &&
+      initialSimulationsProp &&
+      Object.keys(initialSimulationsProp).length > 0
+    ) {
+      conflictWarnedRef.current = true;
+      console.warn(
+        '[Inspector] Both `app` and `simulations` were provided. `app` takes precedence; `simulations` is ignored.'
+      );
+    }
+  }, [app, initialSimulationsProp]);
+  // Root element ref — host theming, CSS variables, and page-style overrides
+  // are applied here rather than on `document.documentElement`. This keeps the
+  // Inspector self-contained when embedded inside another React app: the host
+  // page's `<button>`/`<input>`/typography stay untouched, and the inspector's
+  // colors/fonts apply only to its own subtree.
+  const rootRef = React.useRef<HTMLDivElement | null>(null);
+
   // Simulations can be updated when the user reconnects to a different server.
   const [simulations, setSimulations] = React.useState(initialSimulations);
   // Sync with prop changes (e.g., HMR during development).
@@ -238,7 +296,9 @@ export function Inspector({
 
   // useMcpConnection does a mount-only health check for the initial URL.
   // URL changes are handled below via connection.reconnect().
-  const connection = useMcpConnection(mcpServerUrl || undefined);
+  // In embedded mode (`app` prop) the Inspector never talks to /__sunpeak/*
+  // endpoints — connection state lives in the embedding app's MCP client.
+  const connection = useMcpConnection(isEmbedded ? undefined : mcpServerUrl || undefined);
   const [prodResources, setProdResources] = React.useState(
     state.urlProdResources ?? defaultProdResources
   );
@@ -590,23 +650,48 @@ export function Inspector({
     }
   }, [activeShell, displayMode, setDisplayMode]);
 
-  // Apply host style variables to the document root.
-  // Uses useLayoutEffect so variables are set BEFORE paint, preventing a flash
-  // of stale colors when switching hosts and then toggling theme.
-  React.useLayoutEffect(() => {
-    const vars = activeShell?.styleVariables;
-    if (!vars) return;
-    const root = document.documentElement;
-    for (const [key, value] of Object.entries(vars)) {
-      if (value) root.style.setProperty(key, value);
-    }
-  }, [activeShell]);
-
-  // Apply host page styles. Cleans up old properties when switching hosts.
-  // Uses useLayoutEffect to stay in sync with style variables above.
+  // Apply host theming + CSS variables + page styles to the inspector root.
+  // Scoped to the root element (not document.documentElement) so the host page
+  // is unaffected when the Inspector is embedded inside another React app.
+  // Uses useLayoutEffect so values are set BEFORE paint, preventing a flash
+  // of stale colors when switching hosts or toggling theme.
+  //
+  // Both `styleVariables` (--color-* tokens) and `pageStyles` keys are tracked
+  // so they can be removed when switching to a host that doesn't define them.
+  // Necessary for third-party HostShells; the two built-in shells happen to
+  // define the same set of keys so this would otherwise look like it works
+  // by overwriting.
+  const prevStyleVarKeysRef = React.useRef<string[]>([]);
   const prevPageStyleKeysRef = React.useRef<string[]>([]);
   React.useLayoutEffect(() => {
-    const root = document.documentElement;
+    const root = rootRef.current;
+    if (!root) return;
+
+    // Data attributes — `data-theme` drives the Tailwind `dark` variant via
+    // the `@custom-variant` rule in globals.css. `color-scheme` is set so
+    // `light-dark()` CSS functions resolve correctly inside the subtree.
+    root.setAttribute('data-theme', state.theme);
+    root.style.colorScheme = state.theme;
+
+    // Style variables (e.g. host-specific --color-* tokens).
+    for (const key of prevStyleVarKeysRef.current) {
+      root.style.removeProperty(key);
+    }
+    const vars = activeShell?.styleVariables;
+    if (vars) {
+      const keys: string[] = [];
+      for (const [key, value] of Object.entries(vars)) {
+        if (value) {
+          root.style.setProperty(key, value);
+          keys.push(key);
+        }
+      }
+      prevStyleVarKeysRef.current = keys;
+    } else {
+      prevStyleVarKeysRef.current = [];
+    }
+
+    // Page-level style overrides.
     for (const key of prevPageStyleKeysRef.current) {
       root.style.removeProperty(key);
     }
@@ -621,10 +706,14 @@ export function Inspector({
     } else {
       prevPageStyleKeysRef.current = [];
     }
-  }, [activeShell]);
+  }, [activeShell, state.theme]);
 
-  // Inject host font CSS (@font-face rules) so the conversation chrome
-  // uses the same font as the real host (e.g., Anthropic Sans for Claude).
+  // Inject host font CSS (@font-face rules) so the conversation chrome uses
+  // the same font as the real host (e.g., Anthropic Sans for Claude).
+  // @font-face rules can't be scoped to a subtree, so this is the one
+  // document-level injection the Inspector makes. The font itself is only
+  // referenced by host shells inside the Inspector subtree, so the host page
+  // sees a defined-but-unused @font-face — harmless.
   React.useLayoutEffect(() => {
     const fontCss = activeShell?.fontCss;
     const id = 'sunpeak-host-fonts';
@@ -758,13 +847,15 @@ export function Inspector({
           className="text-sm text-center max-w-xs"
           style={{ color: 'var(--color-text-secondary)' }}
         >
-          {isError
-            ? 'Could not connect to MCP server'
-            : isConnected
-              ? 'No tools with UI resources found on this server'
-              : serverUrl
-                ? 'Connecting\u2026'
-                : 'Enter an MCP server URL to get started'}
+          {isEmbedded
+            ? 'No tools with UI resources in this app'
+            : isError
+              ? 'Could not connect to MCP server'
+              : isConnected
+                ? 'No tools with UI resources found on this server'
+                : serverUrl
+                  ? 'Connecting\u2026'
+                  : 'Enter an MCP server URL to get started'}
         </span>
       </div>
     );
@@ -788,6 +879,35 @@ export function Inspector({
         <span className="text-sm" style={{ color: 'var(--color-text-secondary)' }}>
           Building&hellip;
         </span>
+      </div>
+    );
+  } else if (state.resourceHtml) {
+    // Embedded path — caller supplied the resource HTML directly (e.g. from
+    // `mcpClient.readResource(...)`). The Inspector forwards it to the
+    // sandbox iframe via PostMessage; no URL hosting required.
+    content = (
+      <div className="h-full w-full" style={{ background: iframeBg }}>
+        <IframeResource
+          key={`${state.activeHost}-${state.selectedSimulationName}-html`}
+          html={state.resourceHtml}
+          hostContext={hostContext}
+          toolInput={state.toolInput}
+          toolResult={state.effectiveToolResult}
+          hostOptions={{
+            hostInfo: activeShell?.hostInfo,
+            hostCapabilities: activeShell?.hostCapabilities,
+            onDisplayModeChange: state.handleDisplayModeChange,
+            onUpdateModelContext: state.handleUpdateModelContext,
+            onCallTool: handleCallTool,
+          }}
+          permissions={state.permissions}
+          prefersBorder={state.prefersBorder}
+          onDisplayModeReady={state.handleDisplayModeReady}
+          debugInjectState={state.modelContext}
+          injectOpenAIRuntime={state.activeHost === 'chatgpt'}
+          sandboxUrl={sandboxUrl}
+          className="h-full w-full"
+        />
       </div>
     );
   } else if (effectiveResourceUrl) {
@@ -847,8 +967,14 @@ export function Inspector({
     content = children;
   }
 
-  // Use the active host's theme applier
-  const applyTheme = activeShell?.applyTheme;
+  // Theme is applied to rootRef directly via useLayoutEffect above. Override
+  // ThemeProvider's default (which would set data-theme on documentElement)
+  // with a no-op so the embed stays scoped to the Inspector's subtree. The
+  // ThemeProvider default behavior is preserved for callers using it outside
+  // the bundled Inspector.
+  const applyTheme = React.useCallback((_theme: 'light' | 'dark') => {
+    // intentionally empty — applied via rootRef useLayoutEffect above
+  }, []);
 
   // ── Run button (shown in conversation header when no simulation is active) ──
   // Visible when "None (call server)" is selected OR when no fixtures exist for the tool.
@@ -905,10 +1031,20 @@ export function Inspector({
     content
   );
 
+  // Embedded mode: fill the parent container instead of the viewport so the
+  // host React app can place the Inspector inside a sized region (a sidebar,
+  // a modal, a dashboard panel) without it escaping its container.
+  const rootSizing = isEmbedded ? 'h-full w-full' : 'h-screen w-screen';
+
   if (!showSidebar) {
     return (
       <ThemeProvider theme={state.theme} applyTheme={applyTheme}>
-        <div className="flex h-screen w-screen">{conversationContent}</div>
+        <div
+          ref={rootRef}
+          className={`sunpeak-inspector-root flex ${rootSizing}`}
+        >
+          {conversationContent}
+        </div>
       </ThemeProvider>
     );
   }
@@ -916,9 +1052,17 @@ export function Inspector({
   return (
     <ThemeProvider theme={state.theme} applyTheme={applyTheme}>
       <SimpleSidebar
+        rootRef={rootRef}
+        fillParent={isEmbedded}
         controls={
           <div className="space-y-1">
-            {/* ── MCP Server URL (always visible; read-only in demo mode) ── */}
+            {/*
+             * MCP Server URL + Authentication only appear in the CLI codepath.
+             * When `app` is provided (embedded mode), connection and auth are
+             * owned by the embedding application's MCP client.
+             */}
+            {!isEmbedded && (
+              <>
             <SidebarControl
               label={
                 <span className="flex items-center gap-1.5">
@@ -1050,9 +1194,11 @@ export function Inspector({
                 </div>
               </SidebarCollapsibleControl>
             )}
+              </>
+            )}
 
-            {/* ── Prod Resources (framework mode only, hidden in demo mode) ── */}
-            {!hideInspectorModes && !demoMode && (
+            {/* ── Prod Resources (framework mode only, hidden in demo + embedded modes) ── */}
+            {!hideInspectorModes && !demoMode && !isEmbedded && (
               <SidebarCheckbox
                 checked={prodResources}
                 onChange={setProdResources}
@@ -1132,7 +1278,9 @@ export function Inspector({
                           ]),
                       ...(selectedToolInfo?.fixtureSimNames ?? []).map((simName) => ({
                         value: simName,
-                        label: simName,
+                        // Prefer the user-facing displayName (set by the
+                        // `app` prop's flattener) over the internal key.
+                        label: simulations[simName]?.displayName ?? simName,
                       })),
                     ]}
                   />

--- a/packages/sunpeak/src/inspector/sandbox-static.test.ts
+++ b/packages/sunpeak/src/inspector/sandbox-static.test.ts
@@ -26,18 +26,15 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const DIST_HTML = resolve(__dirname, '..', '..', 'dist', 'sandbox-proxy.html');
 
 describe('static sandbox HTML drift guard', () => {
-  it.skipIf(!existsSync(DIST_HTML))(
-    'embeds the live MOCK_OPENAI_RUNTIME_SCRIPT verbatim',
-    () => {
-      const html = readFileSync(DIST_HTML, 'utf8');
-      // The script is emitted as a JSON-stringified JS string in the generated
-      // HTML (so it can be assigned to a JS variable safely). We check that
-      // the same literal source appears inside the file. If `MOCK_OPENAI_RUNTIME_SCRIPT`
-      // changes and the script doesn't get regenerated (or the duplicate copy
-      // inside `scripts/generate-sandbox-html.mjs` drifts), this fails.
-      expect(html).toContain(JSON.stringify(MOCK_OPENAI_RUNTIME_SCRIPT));
-    }
-  );
+  it.skipIf(!existsSync(DIST_HTML))('embeds the live MOCK_OPENAI_RUNTIME_SCRIPT verbatim', () => {
+    const html = readFileSync(DIST_HTML, 'utf8');
+    // The script is emitted as a JSON-stringified JS string in the generated
+    // HTML (so it can be assigned to a JS variable safely). We check that
+    // the same literal source appears inside the file. If `MOCK_OPENAI_RUNTIME_SCRIPT`
+    // changes and the script doesn't get regenerated (or the duplicate copy
+    // inside `scripts/generate-sandbox-html.mjs` drifts), this fails.
+    expect(html).toContain(JSON.stringify(MOCK_OPENAI_RUNTIME_SCRIPT));
+  });
 
   it.skipIf(!existsSync(DIST_HTML))(
     'declares the sandbox-proxy-ready notification (the proxy handshake)',

--- a/packages/sunpeak/src/inspector/sandbox-static.test.ts
+++ b/packages/sunpeak/src/inspector/sandbox-static.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Drift guard for the static sandbox HTML shipped at `dist/sandbox-proxy.html`.
+ *
+ * `scripts/generate-sandbox-html.mjs` duplicates two pieces of logic from this
+ * package's TypeScript sources because it runs in plain Node at build time and
+ * can't import .ts modules:
+ *
+ *   1. The proxy relay logic (from `src/inspector/sandbox-proxy.ts`)
+ *   2. The mock OpenAI runtime (from `src/inspector/mock-openai-runtime.ts`)
+ *
+ * If the source changes and the script doesn't, embedders' sandbox proxies
+ * drift away from the CLI sandbox server's behavior — subtle bugs that don't
+ * reproduce in development. This test makes drift loud.
+ *
+ * The test skips when `dist/sandbox-proxy.html` doesn't exist (developer
+ * hasn't run `pnpm build` yet). CI always builds before testing, so drift
+ * shows up there.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { MOCK_OPENAI_RUNTIME_SCRIPT } from './mock-openai-runtime';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DIST_HTML = resolve(__dirname, '..', '..', 'dist', 'sandbox-proxy.html');
+
+describe('static sandbox HTML drift guard', () => {
+  it.skipIf(!existsSync(DIST_HTML))(
+    'embeds the live MOCK_OPENAI_RUNTIME_SCRIPT verbatim',
+    () => {
+      const html = readFileSync(DIST_HTML, 'utf8');
+      // The script is emitted as a JSON-stringified JS string in the generated
+      // HTML (so it can be assigned to a JS variable safely). We check that
+      // the same literal source appears inside the file. If `MOCK_OPENAI_RUNTIME_SCRIPT`
+      // changes and the script doesn't get regenerated (or the duplicate copy
+      // inside `scripts/generate-sandbox-html.mjs` drifts), this fails.
+      expect(html).toContain(JSON.stringify(MOCK_OPENAI_RUNTIME_SCRIPT));
+    }
+  );
+
+  it.skipIf(!existsSync(DIST_HTML))(
+    'declares the sandbox-proxy-ready notification (the proxy handshake)',
+    () => {
+      const html = readFileSync(DIST_HTML, 'utf8');
+      expect(html).toContain('ui/notifications/sandbox-proxy-ready');
+      expect(html).toContain('ui/notifications/sandbox-resource-ready');
+      expect(html).toContain('sunpeak/sandbox-load-src');
+      expect(html).toContain('sunpeak/fence');
+    }
+  );
+});

--- a/packages/sunpeak/src/inspector/sidebar-chrome.css
+++ b/packages/sunpeak/src/inspector/sidebar-chrome.css
@@ -1,0 +1,81 @@
+/*
+ * Shared sidebar chrome rules — imported by both `inspector/globals.css`
+ * (the full-preflight stylesheet for resources) and `embed.css` (the
+ * scoped-preflight stylesheet for embedders). Keep all rules scoped under
+ * `.sunpeak-inspector-root` so this file is safe in both contexts.
+ *
+ * Don't duplicate these rules anywhere else — that's how they drift.
+ */
+
+/* Sidebar utility — host-overridable via --sim-bg-sidebar */
+@utility bg-sidebar {
+  background-color: var(--sim-bg-sidebar, var(--color-background-secondary));
+}
+
+/* Sidebar form elements — match SDK look */
+.sunpeak-inspector-root select,
+.sunpeak-inspector-root input:not([type="checkbox"]),
+.sunpeak-inspector-root textarea {
+  border: 0;
+  box-shadow: inset 0 0 0 1px var(--color-border-primary);
+  transition: box-shadow 150ms ease, color 150ms ease, background-color 150ms ease;
+}
+.sunpeak-inspector-root select:hover,
+.sunpeak-inspector-root input:not([type="checkbox"]):hover,
+.sunpeak-inspector-root textarea:hover {
+  box-shadow: inset 0 0 0 1px var(--color-border-secondary);
+}
+.sunpeak-inspector-root select:focus-visible,
+.sunpeak-inspector-root input:not([type="checkbox"]):focus-visible,
+.sunpeak-inspector-root textarea:focus-visible {
+  box-shadow: inset 0 0 0 1px var(--color-border-secondary);
+  outline: 2px solid var(--color-ring-primary);
+  outline-offset: -1px;
+}
+.sunpeak-inspector-root button:focus-visible {
+  outline: 2px solid var(--color-ring-primary);
+  outline-offset: -1px;
+}
+
+/* Custom checkbox */
+.sunpeak-inspector-root input[type="checkbox"] {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  border: 1px solid var(--color-border-secondary);
+  background-color: transparent;
+  background-size: 10px;
+  background-position: center;
+  background-repeat: no-repeat;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: border-color 150ms ease, background-color 150ms ease;
+}
+.sunpeak-inspector-root input[type="checkbox"]:hover {
+  border-color: var(--color-text-tertiary);
+}
+.sunpeak-inspector-root input[type="checkbox"]:checked {
+  border-color: var(--color-background-inverse);
+  background-color: var(--color-background-inverse);
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 10 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M2 5L4.25 7L8 3' stroke='white' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3e%3c/svg%3e");
+}
+.sunpeak-inspector-root[data-theme="dark"] input[type="checkbox"]:checked,
+[data-theme="dark"] .sunpeak-inspector-root input[type="checkbox"]:checked {
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 10 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M2 5L4.25 7L8 3' stroke='%23111' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3e%3c/svg%3e");
+}
+.sunpeak-inspector-root input[type="checkbox"]:focus-visible {
+  outline: 2px solid var(--color-ring-primary);
+  outline-offset: 2px;
+}
+
+/* Hide native number input spinners */
+.sunpeak-inspector-root input[type="number"]::-webkit-inner-spin-button,
+.sunpeak-inspector-root input[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.sunpeak-inspector-root input[type="number"] {
+  -moz-appearance: textfield;
+}

--- a/packages/sunpeak/src/inspector/simple-sidebar.tsx
+++ b/packages/sunpeak/src/inspector/simple-sidebar.tsx
@@ -6,6 +6,18 @@ interface SimpleSidebarProps {
   controls: React.ReactNode;
   /** Optional element rendered right-aligned in the Controls header row */
   headerRight?: React.ReactNode;
+  /**
+   * Optional ref attached to the outer `.sunpeak-inspector-root` element.
+   * The Inspector uses this to scope host theming, CSS variables, and page
+   * styles to its own subtree rather than `document.documentElement`.
+   */
+  rootRef?: React.Ref<HTMLDivElement>;
+  /**
+   * When true, the sidebar's outer root sizes to its parent (`h-full w-full`)
+   * instead of the viewport (`h-screen w-full`). Used by embedders who place
+   * the Inspector inside a sized container.
+   */
+  fillParent?: boolean;
 }
 
 const DEFAULT_SIDEBAR_WIDTH = 260; // ChatGPT sidebar: 260px (extracted 2026-03-21)
@@ -22,7 +34,13 @@ function ChevronRightIcon() {
   );
 }
 
-export function SimpleSidebar({ children, controls, headerRight }: SimpleSidebarProps) {
+export function SimpleSidebar({
+  children,
+  controls,
+  headerRight,
+  rootRef,
+  fillParent = false,
+}: SimpleSidebarProps) {
   const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
   const [sidebarWidth, setSidebarWidth] = React.useState(DEFAULT_SIDEBAR_WIDTH);
   const [isResizing, setIsResizing] = React.useState(false);
@@ -55,7 +73,12 @@ export function SimpleSidebar({ children, controls, headerRight }: SimpleSidebar
   }, [isResizing]);
 
   return (
-    <div className="sunpeak-inspector-root flex h-screen w-full overflow-hidden relative">
+    <div
+      ref={rootRef}
+      className={`sunpeak-inspector-root flex ${
+        fillParent ? 'h-full w-full' : 'h-screen w-full'
+      } overflow-hidden relative`}
+    >
       {/* Resize overlay to capture mouse events during drag */}
       {isResizing && <div className="fixed inset-0 z-50 cursor-col-resize" />}
 

--- a/packages/sunpeak/src/inspector/theme-provider.tsx
+++ b/packages/sunpeak/src/inspector/theme-provider.tsx
@@ -16,7 +16,14 @@ type ThemeProviderState = {
 
 const ThemeProviderContext = React.createContext<ThemeProviderState | undefined>(undefined);
 
-/** Default theme applier: sets data-theme attribute on document.documentElement */
+/**
+ * Default theme applier: sets `data-theme` on `document.documentElement`.
+ * Kept for callers using `ThemeProvider` outside the bundled `<Inspector />`
+ * (e.g. custom-inspector builds composed from this package's primitives).
+ * The bundled Inspector overrides this with a no-op applier and applies
+ * theme to its own root element, so embedding it inside a host React app
+ * leaves the host's document attributes untouched.
+ */
 function defaultApplyTheme(theme: Theme): void {
   if (typeof document !== 'undefined') {
     document.documentElement.setAttribute('data-theme', theme);

--- a/packages/sunpeak/src/inspector/use-inspector-state.ts
+++ b/packages/sunpeak/src/inspector/use-inspector-state.ts
@@ -121,6 +121,7 @@ export interface InspectorState {
   // ── Content props (for IframeResource) ──
   resourceUrl: string | undefined;
   resourceScript: string | undefined;
+  resourceHtml: string | undefined;
   csp: ResourceCSP | undefined;
   permissions: McpUiResourcePermissions | undefined;
   prefersBorder: boolean;
@@ -712,6 +713,7 @@ export function useInspectorState({
 
   const resourceUrl = selectedSim?.resourceUrl;
   const resourceScript = selectedSim?.resourceScript;
+  const resourceHtml = selectedSim?.resourceHtml;
   const csp = selectedSim?.resource ? extractResourceCSP(selectedSim.resource) : undefined;
   const resourceMeta = (selectedSim?.resource?._meta as Record<string, unknown> | undefined)?.ui as
     | { permissions?: McpUiResourcePermissions; prefersBorder?: boolean; domain?: string }
@@ -795,6 +797,7 @@ export function useInspectorState({
 
     resourceUrl,
     resourceScript,
+    resourceHtml,
     csp,
     permissions,
     prefersBorder,

--- a/packages/sunpeak/src/types/simulation.ts
+++ b/packages/sunpeak/src/types/simulation.ts
@@ -28,7 +28,15 @@ export type ServerToolMock =
  */
 export interface Simulation {
   // Unique identifier derived from the simulation filename (e.g., 'show-albums')
+  // or a flattener-composed key (`<tool>__<sim>`) in the embedded App path.
+  // Must be unique across the whole inspector instance.
   name: string;
+
+  // Optional pretty label shown in the sidebar's Simulation dropdown. When
+  // omitted, the Inspector falls back to `name`. Used by the embedded App
+  // path to show the user's chosen simulation name (e.g. `two-albums`) in
+  // place of the internal flattened key (`show_albums__two-albums`).
+  displayName?: string;
 
   // URL to an HTML page to load in an iframe (dev mode).
   // The page mounts the resource component and uses SDK's useApp().
@@ -36,6 +44,12 @@ export interface Simulation {
 
   // URL to a built resource for iframe rendering (production builds).
   resourceScript?: string;
+
+  // Resource HTML as a string — used by the embedding path where the caller
+  // hands the Inspector a complete document (typically from
+  // `mcpClient.readResource(...)`) and the Inspector forwards it to the
+  // sandbox iframe via PostMessage. Mutually exclusive with the URL fields.
+  resourceHtml?: string;
 
   userMessage?: string; // Decoration for the inspector, no functional purpose.
 
@@ -49,12 +63,10 @@ export interface Simulation {
   // Tool input arguments (the arguments object sent to CallTool).
   toolInput?: Record<string, unknown>;
 
-  // Tool result data (the response from CallTool).
-  toolResult?: {
-    content?: Array<{ type: string; text: string }>;
-    structuredContent?: unknown;
-    isError?: boolean;
-  };
+  // Tool result data (the response from CallTool). Matches the full MCP
+  // `CallToolResult` shape so structured content, image parts, isError, and
+  // _meta all flow through unchanged.
+  toolResult?: CallToolResult;
 
   // Initial host context overrides for the simulation.
   hostContext?: Partial<McpUiHostContext>;

--- a/packages/sunpeak/tests/e2e/inspector-modes.spec.ts
+++ b/packages/sunpeak/tests/e2e/inspector-modes.spec.ts
@@ -164,14 +164,19 @@ for (const host of hosts) {
   });
 
   test.describe(`Theme Switching [${host}]`, () => {
-    test('switching theme to light updates the document', async ({ page }) => {
+    test('switching theme to light updates the inspector root', async ({ page }) => {
       await page.goto(createInspectorUrl({ simulation: 'show-albums', theme: 'dark', host }));
 
       // Click "Light" button in Theme toggle
       await page.locator('button[aria-pressed]:has-text("Light")').click();
 
-      // The color-scheme should change to light
-      const colorScheme = await page.evaluate(() => document.documentElement.style.colorScheme);
+      // Theme (data-theme + color-scheme) is applied to the inspector root
+      // ref rather than `document.documentElement` — keeps the Inspector
+      // self-contained when embedded inside another React app.
+      const colorScheme = await page
+        .locator('.sunpeak-inspector-root')
+        .first()
+        .evaluate((el) => (el as HTMLElement).style.colorScheme);
       expect(colorScheme).toContain('light');
     });
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
+      '@tailwindcss/cli':
+        specifier: ^4.3.0
+        version: 4.3.0
       '@tailwindcss/vite':
         specifier: ^4.3.0
         version: 4.3.0(vite@8.0.12(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.0))
@@ -706,6 +709,94 @@ packages:
   '@oxc-project/types@0.130.0':
     resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
 
+  '@parcel/watcher-android-arm64@2.5.6':
+    resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    resolution: {integrity: sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    resolution: {integrity: sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    resolution: {integrity: sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    resolution: {integrity: sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    resolution: {integrity: sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    resolution: {integrity: sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@parcel/watcher@2.5.6':
+    resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
+    engines: {node: '>= 10.0.0'}
+
   '@playwright/test@1.60.0':
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
@@ -1083,6 +1174,10 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tailwindcss/cli@4.3.0':
+    resolution: {integrity: sha512-X9kdlqyMopO9fewbgHsEeuy31YzMHbdZ9VsKt004tB+mxSg1CNbyhZYCzvhciN0AM4R4b5lvIprPjtNq7iQxpQ==}
+    hasBin: true
 
   '@tailwindcss/node@4.3.0':
     resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
@@ -2481,6 +2576,10 @@ packages:
   mlly@1.8.1:
     resolution: {integrity: sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==}
 
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2498,6 +2597,9 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
@@ -3830,6 +3932,66 @@ snapshots:
   '@oxc-project/types@0.130.0':
     optional: true
 
+  '@parcel/watcher-android-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher@2.5.6':
+    dependencies:
+      detect-libc: 2.1.2
+      is-glob: 4.0.3
+      node-addon-api: 7.1.1
+      picomatch: 4.0.4
+    optionalDependencies:
+      '@parcel/watcher-android-arm64': 2.5.6
+      '@parcel/watcher-darwin-arm64': 2.5.6
+      '@parcel/watcher-darwin-x64': 2.5.6
+      '@parcel/watcher-freebsd-x64': 2.5.6
+      '@parcel/watcher-linux-arm-glibc': 2.5.6
+      '@parcel/watcher-linux-arm-musl': 2.5.6
+      '@parcel/watcher-linux-arm64-glibc': 2.5.6
+      '@parcel/watcher-linux-arm64-musl': 2.5.6
+      '@parcel/watcher-linux-x64-glibc': 2.5.6
+      '@parcel/watcher-linux-x64-musl': 2.5.6
+      '@parcel/watcher-win32-arm64': 2.5.6
+      '@parcel/watcher-win32-ia32': 2.5.6
+      '@parcel/watcher-win32-x64': 2.5.6
+
   '@playwright/test@1.60.0':
     dependencies:
       playwright: 1.60.0
@@ -4062,6 +4224,16 @@ snapshots:
     optional: true
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@tailwindcss/cli@4.3.0':
+    dependencies:
+      '@parcel/watcher': 2.5.6
+      '@tailwindcss/node': 4.3.0
+      '@tailwindcss/oxide': 4.3.0
+      enhanced-resolve: 5.21.3
+      mri: 1.2.0
+      picocolors: 1.1.1
+      tailwindcss: 4.3.0
 
   '@tailwindcss/node@4.3.0':
     dependencies:
@@ -5642,6 +5814,8 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
+  mri@1.2.0: {}
+
   ms@2.1.3: {}
 
   murmurhash-js@1.0.0: {}
@@ -5651,6 +5825,8 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
+
+  node-addon-api@7.1.1: {}
 
   node-exports-info@1.6.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds a hierarchical `app` prop on `<Inspector />` (App → resources + tools → simulations) so third-party React apps can drop in the Inspector with HTML strings instead of standing up a sunpeak dev server. Auto-injects a `window.sunpeak` helper (`onToolInput` / `onToolInputPartial` / `onToolResult` / `onToolCancelled` / `onHostContextChange`) that performs the MCP Apps initialize handshake on behalf of plain-HTML resources, with `<meta name="sunpeak-helper" content="off">` opt-out for resources bundling the SDK directly.
- Ships two CSS entries: `sunpeak/style.css` keeps full Tailwind preflight for resource iframe documents (CLI/template path); new `sunpeak/embed.css` provides the same utilities with preflight and Tailwind theme tokens rewritten to `.sunpeak-inspector-root` (via a post-build script), so embedders' host pages keep their own `<button>`/`<input>`/lists/`:root` variables intact. Static sandbox proxy at `dist/sandbox-proxy.html` lets embedders host the cross-origin sandbox iframe without a Node process.
- Embedded mode hides CLI-only sidebar UI, skips the `/__sunpeak/list-tools` health check, sizes to parent (`h-full w-full`), applies host theming/variables to the inspector root ref (not `document.documentElement`), and locks down security with an `ev.source` guard on the helper's message listener, http(s)-only `sandboxUrl` validation, and tool-result JSON escaping.

## Test plan

- [x] `pnpm --filter sunpeak validate` (414 unit tests across 20 files, lint, typecheck, build pipeline all clean)
- [x] Template e2e: 123 pass (4 pre-existing `dev-overlay.spec.ts:67` failures verified against baseline, unrelated to this change)
- [x] End-to-end Playwright spike: fresh Vite + React + Tailwind app, installed sunpeak from packed tarball, verified Inspector mounts, CSS isolation holds (host pink button + bulleted lists intact), `window.sunpeak` delivers tool inputs/results into the inner iframe, tool/simulation switching works, hide/show lifecycle cleans up, zero console errors
- [x] `pnpm --filter sunpeak dev` resource rendering matches Claude/ChatGPT behavior (sans-serif body, no list bullets, transparent button backgrounds)