### PR TITLE
Fix inspector embed MCP reconnects

### DIFF
--- a/docs/testing/inspector-embedding.mdx
+++ b/docs/testing/inspector-embedding.mdx
@@ -271,6 +271,27 @@ auth, routing, and rate-limiting your product needs. This isn't a sunpeak
 constraint — any browser-side MCP client hits the same wall. The Inspector
 itself doesn't care; it only sees whatever the MCP client returns.
 
+### Letting the Inspector connect to MCP URLs
+
+You can also let the Inspector own the live MCP connection. Omit the `app`
+prop, pass an optional `mcpServerUrl`, and run or proxy the sunpeak inspector
+backend routes (`/__sunpeak/*`) from your own backend:
+
+```tsx
+<Inspector
+  mcpServerUrl="https://mcp.example.com/mcp"
+  inspectorApiBaseUrl="/api/sunpeak"
+  sandboxUrl="https://sandbox.example.com/sandbox-proxy.html"
+/>
+```
+
+The Inspector uses those backend routes for MCP discovery, tool calls, OAuth,
+and dynamic client registration when the upstream server supports it. By
+default it calls same-origin `/__sunpeak` routes; set `inspectorApiBaseUrl`
+when your embedded React app needs to talk to a different origin or a proxy
+path. Users can edit the MCP Server URL in the sidebar, and the preview
+reconnects to the new server without rerunning the original command.
+
 ## Building `app` from MCP calls
 
 If your app already has an MCP SDK `Client`, build the `app` object from
@@ -471,6 +492,18 @@ is needed.
   When provided, the Inspector switches to embedded mode: the MCP Server URL
   input, Authentication section, and Prod Resources checkbox are hidden, and
   no `/__sunpeak/*` requests are made.
+</ResponseField>
+
+<ResponseField name="mcpServerUrl" type="string">
+  Initial MCP server URL for the Inspector's built-in live connection flow.
+  Omit `app` when using this mode. Users can edit the URL in the sidebar; the
+  Inspector reconnects and refreshes the preview.
+</ResponseField>
+
+<ResponseField name="inspectorApiBaseUrl" type="string">
+  Base URL for the sunpeak inspector backend endpoints (`/__sunpeak/*`).
+  Defaults to same-origin. Set this when your embedded Inspector is served
+  from a different app or needs to call a proxy path such as `/api/sunpeak`.
 </ResponseField>
 
 <ResponseField name="onCallTool" type="(params: { name: string; arguments?: Record<string, unknown> }) => Promise<CallToolResult> | CallToolResult">

--- a/packages/sunpeak/src/inspector/inspector-api.ts
+++ b/packages/sunpeak/src/inspector/inspector-api.ts
@@ -1,0 +1,45 @@
+export function inspectorApiEndpoint(path: string, apiBaseUrl?: string): string {
+  if (!apiBaseUrl) return path;
+  const base = apiBaseUrl.replace(/\/+$/, '');
+  const suffix = path.startsWith('/') ? path : `/${path}`;
+  return `${base}${suffix}`;
+}
+
+export async function readInspectorJson<T>(res: Response, endpoint: string): Promise<T> {
+  const text = await res.text();
+  if (!text) return {} as T;
+
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    const contentType = res.headers.get('content-type');
+    const preview = text.trim().replace(/\s+/g, ' ').slice(0, 120);
+    const typeHint = contentType ? ` (${contentType})` : '';
+    throw new Error(
+      `Expected JSON from ${endpoint} but received a non-JSON response${typeHint}: ${preview}`
+    );
+  }
+}
+
+export function resolveInspectorResourceUrls<T>(simulations: T, apiBaseUrl?: string): T {
+  if (!apiBaseUrl || !simulations || typeof simulations !== 'object') return simulations;
+
+  const resolved: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(simulations as Record<string, unknown>)) {
+    if (!value || typeof value !== 'object') {
+      resolved[key] = value;
+      continue;
+    }
+
+    const sim = value as Record<string, unknown>;
+    resolved[key] = {
+      ...sim,
+      resourceUrl:
+        typeof sim.resourceUrl === 'string' && sim.resourceUrl.startsWith('/')
+          ? inspectorApiEndpoint(sim.resourceUrl, apiBaseUrl)
+          : sim.resourceUrl,
+    };
+  }
+
+  return resolved as T;
+}

--- a/packages/sunpeak/src/inspector/inspector.test.tsx
+++ b/packages/sunpeak/src/inspector/inspector.test.tsx
@@ -416,6 +416,82 @@ describe('Inspector', () => {
       expect(screen.getByPlaceholderText('Scopes (optional)')).toBeInTheDocument();
     });
 
+    it('surfaces a clear error when OAuth start returns non-JSON', async () => {
+      const user = userEvent.setup();
+      const popup = { close: vi.fn(), closed: false, location: { href: '' } };
+      const openSpy = vi.spyOn(window, 'open').mockReturnValue(popup as unknown as Window);
+
+      fetchSpy
+        .mockResolvedValueOnce(new Response('{"tools":[]}', { status: 200 }))
+        .mockResolvedValueOnce(
+          new Response('Fractal ChatGPT App MCP Server. Connect to /mcp', {
+            status: 200,
+            headers: { 'Content-Type': 'text/plain' },
+          })
+        );
+
+      render(
+        <Inspector
+          simulations={{ test: createSim() }}
+          mcpServerUrl="http://localhost:8000/mcp"
+          onCallTool={vi.fn()}
+        />
+      );
+
+      await user.click(screen.getByText('Authentication'));
+
+      const authSection = screen.getByText('Authentication').closest('[class*="space-y"]')!;
+      const authSelect = authSection.querySelector('select')!;
+      await user.selectOptions(authSelect, 'oauth');
+      await user.click(screen.getByRole('button', { name: 'Authorize' }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Expected JSON from \/__sunpeak\/oauth\/start/)
+        ).toBeInTheDocument();
+      });
+      expect(popup.close).toHaveBeenCalled();
+
+      openSpy.mockRestore();
+    });
+
+    it('uses inspectorApiBaseUrl for OAuth start requests', async () => {
+      const user = userEvent.setup();
+      const popup = { close: vi.fn(), closed: false, location: { href: '' } };
+      const openSpy = vi.spyOn(window, 'open').mockReturnValue(popup as unknown as Window);
+
+      fetchSpy
+        .mockResolvedValueOnce(new Response('{"tools":[]}', { status: 200 }))
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ error: 'No auth configured' }), { status: 400 })
+        );
+
+      render(
+        <Inspector
+          simulations={{ test: createSim() }}
+          mcpServerUrl="http://localhost:8000/mcp"
+          inspectorApiBaseUrl="https://preview.example/api"
+          onCallTool={vi.fn()}
+        />
+      );
+
+      await user.click(screen.getByText('Authentication'));
+
+      const authSection = screen.getByText('Authentication').closest('[class*="space-y"]')!;
+      const authSelect = authSection.querySelector('select')!;
+      await user.selectOptions(authSelect, 'oauth');
+      await user.click(screen.getByRole('button', { name: 'Authorize' }));
+
+      await waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledWith(
+          'https://preview.example/api/__sunpeak/oauth/start',
+          expect.objectContaining({ method: 'POST' })
+        );
+      });
+
+      openSpy.mockRestore();
+    });
+
     it('reconnects with bearer token when token is entered', async () => {
       const user = userEvent.setup();
 

--- a/packages/sunpeak/src/inspector/inspector.tsx
+++ b/packages/sunpeak/src/inspector/inspector.tsx
@@ -25,6 +25,7 @@ import type { Simulation } from '../types/simulation';
 import type { ScreenWidth } from './inspector-types';
 import type { InspectorApp } from './app-types';
 import { flattenAppToSimulations } from './app-flatten';
+import { inspectorApiEndpoint, readInspectorJson } from './inspector-api';
 
 // Register built-in host shells. These imports live here (in the component file)
 // rather than in the barrel index.ts because Rollup code-splitting can separate
@@ -89,6 +90,13 @@ export interface InspectorProps {
    * to a different server.
    */
   mcpServerUrl?: string;
+  /**
+   * Base URL for the sunpeak inspector backend endpoints (`/__sunpeak/*`).
+   * Defaults to same-origin. Embedders that serve the React Inspector from
+   * their own app can point this at a same-origin proxy or hosted inspector
+   * backend, for example `/api/sunpeak`.
+   */
+  inspectorApiBaseUrl?: string;
 }
 
 type Platform = 'mobile' | 'desktop' | 'web';
@@ -128,6 +136,7 @@ export function Inspector({
   demoMode = false,
   sandboxUrl,
   mcpServerUrl,
+  inspectorApiBaseUrl,
 }: InspectorProps) {
   // When `app` is provided it drives both the simulation map and the header
   // name/icon. Falling back to the legacy props keeps existing callers working.
@@ -294,7 +303,10 @@ export function Inspector({
   // URL changes are handled below via connection.reconnect().
   // In embedded mode (`app` prop) the Inspector never talks to /__sunpeak/*
   // endpoints — connection state lives in the embedding app's MCP client.
-  const connection = useMcpConnection(isEmbedded ? undefined : mcpServerUrl || undefined);
+  const connection = useMcpConnection(
+    isEmbedded ? undefined : mcpServerUrl || undefined,
+    inspectorApiBaseUrl
+  );
   const [prodResources, setProdResources] = React.useState(
     state.urlProdResources ?? defaultProdResources
   );
@@ -303,6 +315,7 @@ export function Inspector({
   const [isRunning, setIsRunning] = React.useState(false);
   const [hasRun, setHasRun] = React.useState(false);
   const [showCheck, setShowCheck] = React.useState(false);
+  const [serverPreviewGeneration, setServerPreviewGeneration] = React.useState(0);
   const checkTimerRef = React.useRef<ReturnType<typeof setTimeout>>(undefined);
   const oauthCleanupRef = React.useRef<(() => void) | undefined>(undefined);
 
@@ -357,7 +370,8 @@ export function Inspector({
     );
 
     try {
-      const res = await fetch('/__sunpeak/oauth/start', {
+      const endpoint = inspectorApiEndpoint('/__sunpeak/oauth/start', inspectorApiBaseUrl);
+      const res = await fetch(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -367,17 +381,17 @@ export function Inspector({
           clientSecret: oauthClientSecret || undefined,
         }),
       });
+      const data = await readInspectorJson<{
+        error?: string;
+        status?: string;
+        authUrl?: string;
+        simulations?: Record<string, unknown>;
+      }>(res, endpoint);
       if (!res.ok) {
         let message = `OAuth start failed (${res.status})`;
-        try {
-          const json = await res.json();
-          if (json.error) message = json.error;
-        } catch {
-          // Response wasn't JSON
-        }
+        if (data.error) message = data.error;
         throw new Error(message);
       }
-      const data = await res.json();
 
       if (data.error) {
         popup?.close();
@@ -478,7 +492,15 @@ export function Inspector({
       setOauthError(err instanceof Error ? err.message : String(err));
       setOauthStatus('error');
     }
-  }, [serverUrl, oauthScopes, oauthClientId, oauthClientSecret, demoMode, connection]);
+  }, [
+    serverUrl,
+    oauthScopes,
+    oauthClientId,
+    oauthClientSecret,
+    demoMode,
+    connection,
+    inspectorApiBaseUrl,
+  ]);
 
   // When reconnecting to a new server succeeds, update simulations.
   // Only clear on error after a user-initiated reconnect (URL change), not on the
@@ -487,6 +509,7 @@ export function Inspector({
   React.useEffect(() => {
     if (connection.simulations) {
       setSimulations(connection.simulations as Record<string, Simulation>);
+      setServerPreviewGeneration((generation) => generation + 1);
     } else if (connection.status === 'error' && connection.hasReconnected) {
       setSimulations({});
     }
@@ -910,7 +933,7 @@ export function Inspector({
     content = (
       <div className="h-full w-full" style={{ background: iframeBg }}>
         <IframeResource
-          key={`${state.activeHost}-${state.selectedSimulationName}-${effectiveResourceUrl}-${prodResources}-${prodResourcesGeneration}`}
+          key={`${state.activeHost}-${state.selectedSimulationName}-${effectiveResourceUrl}-${prodResources}-${prodResourcesGeneration}-${serverPreviewGeneration}`}
           src={effectiveResourceUrl}
           hostContext={hostContext}
           toolInput={state.toolInput}

--- a/packages/sunpeak/src/inspector/use-mcp-connection.test.ts
+++ b/packages/sunpeak/src/inspector/use-mcp-connection.test.ts
@@ -79,6 +79,48 @@ describe('useMcpConnection', () => {
     );
   });
 
+  it('uses the configured inspector API base URL and resolves resource URLs', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response('{"tools":[]}', { status: 200 }));
+
+    const { result } = renderHook(() =>
+      useMcpConnection('http://localhost:8000/mcp', 'https://preview.example/api')
+    );
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('connected');
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith('https://preview.example/api/__sunpeak/list-tools');
+
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          status: 'ok',
+          simulations: {
+            tool: {
+              name: 'tool',
+              resourceUrl: '/__sunpeak/read-resource?uri=ui%3A%2F%2Ftool',
+            },
+          },
+        }),
+        { status: 200 }
+      )
+    );
+
+    await act(() => result.current.reconnect('http://localhost:9000/mcp'));
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://preview.example/api/__sunpeak/connect',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ url: 'http://localhost:9000/mcp' }),
+      })
+    );
+    expect(result.current.simulations?.tool).toMatchObject({
+      resourceUrl: 'https://preview.example/api/__sunpeak/read-resource?uri=ui%3A%2F%2Ftool',
+    });
+  });
+
   it('reconnect sends auth config in the request body', async () => {
     // Initial health check succeeds
     fetchSpy.mockResolvedValueOnce(new Response('{"tools":[]}', { status: 200 }));
@@ -144,6 +186,23 @@ describe('useMcpConnection', () => {
     expect(result.current.simulations).toBe(sims);
     expect(result.current.hasReconnected).toBe(true);
     expect(result.current.error).toBeUndefined();
+  });
+
+  it('setConnected resolves resource URLs with the configured inspector API base URL', () => {
+    const { result } = renderHook(() => useMcpConnection(undefined, 'https://preview.example/api'));
+
+    act(() =>
+      result.current.setConnected({
+        tool: {
+          name: 'tool',
+          resourceUrl: '/__sunpeak/read-resource?uri=ui%3A%2F%2Ftool',
+        },
+      })
+    );
+
+    expect(result.current.simulations?.tool).toMatchObject({
+      resourceUrl: 'https://preview.example/api/__sunpeak/read-resource?uri=ui%3A%2F%2Ftool',
+    });
   });
 
   it('reconnect transitions to error on failure', async () => {

--- a/packages/sunpeak/src/inspector/use-mcp-connection.ts
+++ b/packages/sunpeak/src/inspector/use-mcp-connection.ts
@@ -1,4 +1,9 @@
 import { useState, useEffect, useCallback } from 'react';
+import {
+  inspectorApiEndpoint,
+  readInspectorJson,
+  resolveInspectorResourceUrls,
+} from './inspector-api';
 
 export type AuthType = 'none' | 'bearer' | 'oauth';
 
@@ -34,7 +39,10 @@ export interface McpConnectionState {
  * once (or safely twice with cancellation), while explicit `reconnect()` calls
  * are triggered by the Inspector's URL-change effect.
  */
-export function useMcpConnection(initialServerUrl: string | undefined): McpConnectionState {
+export function useMcpConnection(
+  initialServerUrl: string | undefined,
+  inspectorApiBaseUrl?: string
+): McpConnectionState {
   const [status, setStatus] = useState<McpConnectionState['status']>(
     initialServerUrl ? 'connecting' : 'disconnected'
   );
@@ -42,61 +50,71 @@ export function useMcpConnection(initialServerUrl: string | undefined): McpConne
   const [simulations, setSimulations] = useState<Record<string, unknown> | undefined>();
   const [hasReconnected, setHasReconnected] = useState(false);
 
-  const reconnect = useCallback(async (url: string, auth?: AuthConfig) => {
-    setHasReconnected(true);
-    setStatus('connecting');
-    setError(undefined);
-    try {
-      const body: Record<string, unknown> = { url };
-      if (auth && auth.type !== 'none') {
-        body.auth = auth;
-      }
-      const res = await fetch('/__sunpeak/connect', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      });
-      if (!res.ok) {
-        let message: string | undefined;
-        try {
-          const json = await res.json();
-          if (json.error) message = json.error;
-        } catch {
-          // Response wasn't JSON — fall through to status-based message
+  const reconnect = useCallback(
+    async (url: string, auth?: AuthConfig) => {
+      setHasReconnected(true);
+      setStatus('connecting');
+      setError(undefined);
+      try {
+        const body: Record<string, unknown> = { url };
+        if (auth && auth.type !== 'none') {
+          body.auth = auth;
         }
-        if (!message) {
-          if (res.status === 404) {
-            message =
-              'Server not found at this URL. Check the URL and make sure the server is running.';
-          } else if (res.status >= 500) {
-            message = `Server error (${res.status}). Check the MCP server logs for details.`;
-          } else {
-            message = `Connection failed (${res.status})`;
+        const endpoint = inspectorApiEndpoint('/__sunpeak/connect', inspectorApiBaseUrl);
+        const res = await fetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+          let message: string | undefined;
+          try {
+            const json = await readInspectorJson<{ error?: string }>(res, endpoint);
+            if (json.error) message = json.error;
+          } catch {
+            // Response wasn't JSON — fall through to status-based message
           }
+          if (!message) {
+            if (res.status === 404) {
+              message =
+                'Server not found at this URL. Check the URL and make sure the server is running.';
+            } else if (res.status >= 500) {
+              message = `Server error (${res.status}). Check the MCP server logs for details.`;
+            } else {
+              message = `Connection failed (${res.status})`;
+            }
+          }
+          throw new Error(message);
         }
-        throw new Error(message);
+        const data = await readInspectorJson<{ simulations?: Record<string, unknown> }>(
+          res,
+          endpoint
+        );
+        setStatus('connected');
+        setSimulations(resolveInspectorResourceUrls(data.simulations, inspectorApiBaseUrl));
+      } catch (err) {
+        let message = err instanceof Error ? err.message : String(err);
+        // fetch throws TypeError on network failure (server not running, DNS, etc.)
+        if (err instanceof TypeError && message === 'Failed to fetch') {
+          message = 'Cannot reach MCP server. Is it running?';
+        }
+        setError(message);
+        setStatus('error');
+        setSimulations(undefined);
       }
-      const data = await res.json();
-      setStatus('connected');
-      setSimulations(data.simulations ?? undefined);
-    } catch (err) {
-      let message = err instanceof Error ? err.message : String(err);
-      // fetch throws TypeError on network failure (server not running, DNS, etc.)
-      if (err instanceof TypeError && message === 'Failed to fetch') {
-        message = 'Cannot reach MCP server. Is it running?';
-      }
-      setError(message);
-      setStatus('error');
-      setSimulations(undefined);
-    }
-  }, []);
+    },
+    [inspectorApiBaseUrl]
+  );
 
-  const setConnected = useCallback((sims?: Record<string, unknown>) => {
-    setHasReconnected(true);
-    setStatus('connected');
-    setError(undefined);
-    setSimulations(sims);
-  }, []);
+  const setConnected = useCallback(
+    (sims?: Record<string, unknown>) => {
+      setHasReconnected(true);
+      setStatus('connected');
+      setError(undefined);
+      setSimulations(resolveInspectorResourceUrls(sims, inspectorApiBaseUrl));
+    },
+    [inspectorApiBaseUrl]
+  );
 
   // Initial health check (mount-only). Verifies the connection is alive
   // when the component mounts with a pre-configured server URL.
@@ -107,7 +125,8 @@ export function useMcpConnection(initialServerUrl: string | undefined): McpConne
     setStatus('connecting');
     (async () => {
       try {
-        const res = await fetch('/__sunpeak/list-tools');
+        const endpoint = inspectorApiEndpoint('/__sunpeak/list-tools', inspectorApiBaseUrl);
+        const res = await fetch(endpoint);
         if (cancelled) return;
         if (!res.ok) {
           const msg =


### PR DESCRIPTION
## Summary
- Add a configurable inspector API base URL so embedded inspectors can proxy `/__sunpeak/*` endpoints.
- Improve OAuth/start JSON handling and resolve discovered resource URLs through the configured inspector backend.
- Force the resource preview to reload after a successful MCP URL change and cover the flow with tests.
- Document the live embedded Inspector backend mode and the `inspectorApiBaseUrl` prop.

## Validation
- `pnpm --filter sunpeak validate`