### PR TITLE
Fix inspector OAuth metadata fallback

### DIFF
--- a/packages/sunpeak/bin/commands/inspect.mjs
+++ b/packages/sunpeak/bin/commands/inspect.mjs
@@ -19,6 +19,8 @@ const { existsSync, readdirSync, readFileSync } = fs;
 const { join, resolve, dirname, sep } = path;
 import { fileURLToPath, pathToFileURL } from 'url';
 import { createServer as createHttpServer } from 'http';
+import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js';
+import { OAuthProtectedResourceMetadataSchema } from '@modelcontextprotocol/sdk/shared/auth.js';
 import { getPort } from '../lib/get-port.mjs';
 import { startSandboxServer } from '../lib/sandbox-server.mjs';
 import { getDevOverlayScript } from '../lib/dev-overlay.mjs';
@@ -177,6 +179,82 @@ function createInMemoryOAuthProvider(redirectUrl, opts = {}) {
 }
 
 /**
+ * @param {URL} serverUrl
+ * @returns {{ pathMetadataUrl: URL, rootMetadataUrl: URL } | undefined}
+ */
+function getMcpResourceMetadataUrls(serverUrl) {
+  if (serverUrl.protocol !== 'http:' && serverUrl.protocol !== 'https:') return undefined;
+  if (serverUrl.pathname === '/' || serverUrl.pathname === '') return undefined;
+
+  const pathname = serverUrl.pathname.endsWith('/')
+    ? serverUrl.pathname.slice(0, -1)
+    : serverUrl.pathname;
+
+  const pathMetadataUrl = new URL(`/.well-known/oauth-protected-resource${pathname}`, serverUrl);
+  pathMetadataUrl.search = serverUrl.search;
+
+  const rootMetadataUrl = new URL('/.well-known/oauth-protected-resource', serverUrl.origin);
+  return { pathMetadataUrl, rootMetadataUrl };
+}
+
+/**
+ * MCP auth discovery supports both endpoint-path and root protected-resource
+ * metadata. When no WWW-Authenticate resource_metadata URL is available, the
+ * current MCP authorization draft says clients must try the endpoint path
+ * first, then the root well-known URI.
+ *
+ * The SDK already falls back from endpoint-path to root on 4xx responses. This
+ * helper detects the remaining common invalid-endpoint case before OAuth starts:
+ * the endpoint-path URL returns 200 but serves a text/html or text/plain landing
+ * page instead of protected-resource metadata JSON. In that case, start OAuth
+ * directly with the root metadata URL so no partial provider state is carried
+ * across a failed SDK auth attempt.
+ *
+ * @param {string | URL} serverUrl
+ * @param {typeof fetch} [fetchFn]
+ * @returns {Promise<string | undefined>}
+ */
+export async function resolveMcpResourceMetadataUrl(serverUrl, fetchFn = fetch) {
+  let parsed;
+  try {
+    parsed = serverUrl instanceof URL ? serverUrl : new URL(serverUrl);
+  } catch {
+    return undefined;
+  }
+
+  const urls = getMcpResourceMetadataUrls(parsed);
+  if (!urls) return undefined;
+
+  let response;
+  try {
+    response = await fetchFn(urls.pathMetadataUrl, {
+      headers: { 'MCP-Protocol-Version': LATEST_PROTOCOL_VERSION },
+    });
+  } catch {
+    return undefined;
+  }
+
+  if (!response.ok) {
+    await response.body?.cancel();
+    return undefined;
+  }
+
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!contentType.toLowerCase().includes('application/json')) {
+    await response.body?.cancel();
+    return urls.rootMetadataUrl.toString();
+  }
+
+  try {
+    OAuthProtectedResourceMetadataSchema.parse(await response.json());
+  } catch {
+    return urls.rootMetadataUrl.toString();
+  }
+
+  return undefined;
+}
+
+/**
  * Negotiate OAuth with an MCP server and return an authenticated provider.
  *
  * Handles two cases:
@@ -197,10 +275,14 @@ async function negotiateOAuth(serverUrl) {
 
   const oauthState = createInMemoryOAuthProvider(callbackUrl);
   const { provider } = oauthState;
+  const resourceMetadataUrl = await resolveMcpResourceMetadataUrl(serverUrl);
 
   // First call to auth() — discovers metadata, registers client, and either
   // returns AUTHORIZED (client_credentials) or REDIRECT (authorization_code).
-  const result = await auth(provider, { serverUrl: new URL(serverUrl) });
+  const result = await auth(provider, {
+    serverUrl: new URL(serverUrl),
+    ...(resourceMetadataUrl ? { resourceMetadataUrl: new URL(resourceMetadataUrl) } : {}),
+  });
 
   if (result === 'AUTHORIZED') {
     return provider;
@@ -1054,6 +1136,7 @@ function sunpeakInspectEndpointsPlugin(getClient, setClient, pluginOpts = {}) {
           // Always create a fresh provider for an explicit Authorize click.
           // This ensures the user's current credentials (or lack thereof) are
           // used, not stale ones from a previous attempt.
+          const resourceMetadataUrl = await resolveMcpResourceMetadataUrl(serverUrl);
           const oauthState = createInMemoryOAuthProvider(callbackUrl, { clientId, clientSecret });
           oauthProviders.set(serverUrl, oauthState);
 
@@ -1062,6 +1145,7 @@ function sunpeakInspectEndpointsPlugin(getClient, setClient, pluginOpts = {}) {
           const result = await auth(oauthState.provider, {
             serverUrl,
             scope,
+            ...(resourceMetadataUrl ? { resourceMetadataUrl: new URL(resourceMetadataUrl) } : {}),
           });
 
           if (result === 'REDIRECT') {

--- a/packages/sunpeak/src/cli/inspect.test.ts
+++ b/packages/sunpeak/src/cli/inspect.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck - CLI command modules are .mjs files without TypeScript declarations
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -284,6 +284,94 @@ describe('isAuthError', () => {
   it('does not false-positive on URLs containing 401', () => {
     const err = new Error('Failed to fetch http://example.com/path/4014');
     expect(isAuthError(err)).toBe(false);
+  });
+});
+
+describe('resolveMcpResourceMetadataUrl', () => {
+  const importInspectCommand = () => import('../../bin/commands/inspect.mjs');
+
+  it('uses root protected-resource metadata when endpoint-path metadata returns text', async () => {
+    const { resolveMcpResourceMetadataUrl } = await importInspectCommand();
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchFn = async (url: URL, init?: RequestInit) => {
+      calls.push({ url: url.toString(), init });
+      return new Response('Fractal ChatGPT App MCP Server. Connect to /mcp', {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+      });
+    };
+
+    await expect(
+      resolveMcpResourceMetadataUrl('https://example.com/mcp', fetchFn)
+    ).resolves.toBe('https://example.com/.well-known/oauth-protected-resource');
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('https://example.com/.well-known/oauth-protected-resource/mcp');
+    expect(calls[0].init?.headers).toHaveProperty('MCP-Protocol-Version');
+  });
+
+  it('does not override when endpoint-path metadata is valid JSON', async () => {
+    const { resolveMcpResourceMetadataUrl } = await importInspectCommand();
+    const calls: string[] = [];
+    const fetchFn = async (url: URL) => {
+      calls.push(url.toString());
+      return new Response(
+        JSON.stringify({
+          resource: 'https://example.com/mcp',
+          authorization_servers: ['https://auth.example.com'],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
+    };
+
+    await expect(
+      resolveMcpResourceMetadataUrl('https://example.com/mcp', fetchFn)
+    ).resolves.toBeUndefined();
+    expect(calls).toEqual(['https://example.com/.well-known/oauth-protected-resource/mcp']);
+  });
+
+  it('leaves 4xx endpoint-path responses to the SDK fallback', async () => {
+    const { resolveMcpResourceMetadataUrl } = await importInspectCommand();
+    const fetchFn = async () => new Response('Not found', { status: 404 });
+
+    await expect(
+      resolveMcpResourceMetadataUrl('https://example.com/mcp', fetchFn)
+    ).resolves.toBeUndefined();
+  });
+
+  it('does not preflight root MCP server URLs', async () => {
+    const { resolveMcpResourceMetadataUrl } = await importInspectCommand();
+    const fetchFn = vi.fn();
+
+    await expect(resolveMcpResourceMetadataUrl('https://example.com', fetchFn)).resolves.toBe(
+      undefined
+    );
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('uses root protected-resource metadata when endpoint-path JSON is malformed', async () => {
+    const { resolveMcpResourceMetadataUrl } = await importInspectCommand();
+    const fetchFn = async () =>
+      new Response('{not json', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+    await expect(
+      resolveMcpResourceMetadataUrl('https://example.com/mcp', fetchFn)
+    ).resolves.toBe('https://example.com/.well-known/oauth-protected-resource');
+  });
+
+  it('uses root protected-resource metadata when endpoint-path JSON is not metadata', async () => {
+    const { resolveMcpResourceMetadataUrl } = await importInspectCommand();
+    const fetchFn = async () =>
+      new Response(JSON.stringify({ message: 'Connect to /mcp' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+    await expect(
+      resolveMcpResourceMetadataUrl('https://example.com/mcp', fetchFn)
+    ).resolves.toBe('https://example.com/.well-known/oauth-protected-resource');
   });
 });
 


### PR DESCRIPTION
Updates the inspector OAuth flow to preflight MCP endpoint-path protected-resource metadata and use the root metadata URL only when the endpoint response is an invalid 200 response. This matches MCP auth discovery behavior without retrying OAuth with partial provider state. Adds focused tests for valid endpoint metadata, text or malformed endpoint responses, SDK-handled 4xx fallback, and root URLs.\n\nValidation: pnpm --filter sunpeak test -- --run src/cli/inspect.test.ts; pnpm --filter sunpeak build; pnpm --filter sunpeak typecheck; pnpm --filter sunpeak lint.