### PR TITLE
Replicate MCP app model context in inspector

### DIFF
--- a/examples/albums-example/package.json
+++ b/examples/albums-example/package.json
@@ -18,7 +18,7 @@
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",
     "embla-carousel-wheel-gestures": "^8.1.0",
-    "sunpeak": "^0.20.32",
+    "sunpeak": "^0.20.34",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },

--- a/examples/carousel-example/package.json
+++ b/examples/carousel-example/package.json
@@ -18,7 +18,7 @@
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",
     "embla-carousel-wheel-gestures": "^8.1.0",
-    "sunpeak": "^0.20.32",
+    "sunpeak": "^0.20.34",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },

--- a/examples/map-example/package.json
+++ b/examples/map-example/package.json
@@ -18,7 +18,7 @@
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",
     "mapbox-gl": "^3.24.0",
-    "sunpeak": "^0.20.32",
+    "sunpeak": "^0.20.34",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },

--- a/examples/review-example/package.json
+++ b/examples/review-example/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
-    "sunpeak": "^0.20.32",
+    "sunpeak": "^0.20.34",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },

--- a/packages/sunpeak/bin/commands/inspect.mjs
+++ b/packages/sunpeak/bin/commands/inspect.mjs
@@ -1402,6 +1402,32 @@ async function createModelInstance(provider, modelId, apiKey) {
   return createAnthropic({ apiKey })(normalizedModelId);
 }
 
+const MODEL_VISIBLE_JSON_LIMIT_BYTES = 20000;
+
+function formatJsonForModel(value) {
+  const json = JSON.stringify(value);
+  if (json.length <= MODEL_VISIBLE_JSON_LIMIT_BYTES) return json;
+  return `${json.slice(0, MODEL_VISIBLE_JSON_LIMIT_BYTES)}...`;
+}
+
+function normalizeModelAppContext(appContext) {
+  if (!appContext || typeof appContext !== 'object') return undefined;
+  const normalized = {};
+  if (Array.isArray(appContext.content) && appContext.content.length > 0) {
+    normalized.content = appContext.content;
+  }
+  if (appContext.structuredContent !== undefined) {
+    normalized.structuredContent = appContext.structuredContent;
+  }
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function formatSharedAppContextForModel(appContext) {
+  const normalized = normalizeModelAppContext(appContext);
+  if (!normalized) return '';
+  return formatJsonForModel(normalized);
+}
+
 function formatModelVisibleToolResult(tool, result) {
   const toolName = tool?.name || 'MCP tool';
   if (result?.isError) {
@@ -1412,7 +1438,21 @@ function formatModelVisibleToolResult(tool, result) {
       .trim();
     return text || `${toolName} returned an error.`;
   }
-  return `${toolName} completed. The MCP App is ready to render.`;
+
+  const visibleResult = {};
+  if (Array.isArray(result?.content)) {
+    visibleResult.content = result.content;
+  }
+  if (result && 'structuredContent' in result) {
+    visibleResult.structuredContent = result.structuredContent;
+  }
+  if (result?.isError != null) {
+    visibleResult.isError = result.isError;
+  }
+
+  return Object.keys(visibleResult).length > 0
+    ? formatJsonForModel(visibleResult)
+    : `${toolName} completed. The MCP App is ready to render.`;
 }
 
 async function executeModelChatToolCall({ client, name, arguments: args }) {
@@ -1424,7 +1464,7 @@ async function executeModelChatToolCall({ client, name, arguments: args }) {
   };
 }
 
-async function runModelChat({ client, provider, modelId, messages, apiKey }) {
+async function runModelChat({ client, provider, modelId, messages, apiKey, appContext }) {
   assertModelProvider(provider);
   const { generateText, tool: aiTool, jsonSchema } = await import('ai');
   const model = await createModelInstance(provider, modelId, apiKey);
@@ -1451,11 +1491,19 @@ async function runModelChat({ client, provider, modelId, messages, apiKey }) {
     });
   }
 
+  const sharedAppContext = formatSharedAppContextForModel(appContext);
+
   const result = await generateText({
     model,
     tools,
-    system:
+    system: [
       'You are chatting inside the Sunpeak Inspector. When you call an MCP tool that renders an app, the host will render the app below your message. Do not repeat raw tool output, JSON, image URLs, markdown image lists, or full item inventories. Keep any narration brief and let the app carry the visual result.',
+      sharedAppContext
+        ? `Shared MCP App context from the currently rendered app, available for this turn:\n${sharedAppContext}`
+        : '',
+    ]
+      .filter(Boolean)
+      .join('\n\n'),
     messages: messages.map((message) => ({
       role: message.role,
       content: String(message.content ?? ''),
@@ -2485,6 +2533,7 @@ function sunpeakInspectEndpointsPlugin(getClient, setClient, pluginOpts = {}) {
               modelId: parsed.modelId,
               messages: safeMessages,
               apiKey,
+              appContext: normalizeModelAppContext(parsed.appContext),
             })
           );
           res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -2625,7 +2674,9 @@ export const _securityTestExports = {
   isToolVisibleToModel,
   executeModelChatToolCall,
   formatModelVisibleToolResult,
+  formatSharedAppContextForModel,
   normalizeApiKey,
+  normalizeModelAppContext,
   normalizeModelId,
   quoteSecurityInteractiveArg,
   readRequestBody,

--- a/packages/sunpeak/scripts/validate.mjs
+++ b/packages/sunpeak/scripts/validate.mjs
@@ -603,6 +603,7 @@ async function runScaffoldSmokeTest() {
     // This is the first command users run after `sunpeak new`. Verify the dev
     // server starts, discovers tools, and serves resource HTML.
     const devPort = await getPort(19100);
+    const devMcpPort = await getPort(19110);
     const devSandboxPort = await getPort(24700);
     const devHmrPort = await getPort(24701);
     {
@@ -611,7 +612,12 @@ async function runScaffoldSmokeTest() {
         devServer = await startServerProcess(
           'node', [SUNPEAK_BIN, 'dev', '--port', String(devPort), '--no-begging'],
           projectDir,
-          { CI: '1', SUNPEAK_SANDBOX_PORT: String(devSandboxPort), SUNPEAK_HMR_PORT: String(devHmrPort) },
+          {
+            CI: '1',
+            SUNPEAK_MCP_PORT: String(devMcpPort),
+            SUNPEAK_SANDBOX_PORT: String(devSandboxPort),
+            SUNPEAK_HMR_PORT: String(devHmrPort),
+          },
           'scaffold dev', 30000
         );
 
@@ -632,12 +638,14 @@ async function runScaffoldSmokeTest() {
     // Vite dep cache, so this catches flaky first-run issues (port mismatches,
     // slow Vite optimization, etc.). We explicitly delete the cache before running.
     const testPort = await getPort(19200);
+    const testMcpPort = await getPort(19210);
     const testHmrPort = await getPort(24712);
     const testSandboxPort = await getPort(24710);
     const viteCacheDir = join(projectDir, 'node_modules', '.vite-mcp');
     if (existsSync(viteCacheDir)) rmSync(viteCacheDir, { recursive: true });
     const testResult = runCommandCapture('pnpm test', projectDir, {
       SUNPEAK_TEST_PORT: String(testPort),
+      SUNPEAK_MCP_PORT: String(testMcpPort),
       SUNPEAK_HMR_PORT: String(testHmrPort),
       SUNPEAK_SANDBOX_PORT: String(testSandboxPort),
     });
@@ -830,10 +838,12 @@ async function testExample(resource, index) {
   // Find available ports for parallel execution.
   // Each parallel example gets its own preferred port range to minimize contention.
   const testPort = await getPort(6776 + index);
+  const mcpPort = await getPort(18700 + index);
   const hmrPort = await getPort(24679 + index * 2);
   const sandboxPort = await getPort(24680 + index * 2);
   const env = {
     SUNPEAK_TEST_PORT: String(testPort),
+    SUNPEAK_MCP_PORT: String(mcpPort),
     SUNPEAK_HMR_PORT: String(hmrPort),
     SUNPEAK_SANDBOX_PORT: String(sandboxPort),
   };

--- a/packages/sunpeak/src/cli/inspect.test.ts
+++ b/packages/sunpeak/src/cli/inspect.test.ts
@@ -533,7 +533,7 @@ describe('inspect endpoint security helpers', () => {
     ).toBe(false);
   });
 
-  it('keeps app-rendering tool payloads out of model-visible tool results', async () => {
+  it('exposes model-visible MCP tool result fields without component-only _meta', async () => {
     const { _securityTestExports } = await importInspectCommand();
 
     const result = _securityTestExports.formatModelVisibleToolResult(
@@ -546,15 +546,51 @@ describe('inspect endpoint security helpers', () => {
               photos: [{ url: 'https://cdn.sunpeak.ai/demo/pizza1.jpeg' }],
             },
           ],
+          _meta: { modelVisible: true },
         },
         content: [{ type: 'text', text: 'Pizza Tour raw text' }],
+        _meta: { token: 'hidden' },
       }
     );
 
-    expect(result).toContain('show-albums completed');
-    expect(result).not.toContain('Pizza Tour');
-    expect(result).not.toContain('cdn.sunpeak.ai');
-    expect(result).not.toContain('structuredContent');
+    expect(result).toContain('Pizza Tour');
+    expect(result).toContain('Pizza Tour raw text');
+    expect(result).toContain('structuredContent');
+    expect(result).toContain('modelVisible');
+    expect(result).not.toContain('hidden');
+  });
+
+  it('formats shared MCP App context for model chat', async () => {
+    const { _securityTestExports } = await importInspectCommand();
+
+    const result = _securityTestExports.formatSharedAppContextForModel({
+      content: [{ type: 'text', text: 'Selected album changed' }],
+      structuredContent: { selectedAlbum: 'Pizza Tour', _meta: { modelVisible: true } },
+    });
+
+    expect(result).toContain('Selected album changed');
+    expect(result).toContain('Pizza Tour');
+    expect(result).toContain('modelVisible');
+  });
+
+  it('formats text-only shared MCP App context for model chat', async () => {
+    const { _securityTestExports } = await importInspectCommand();
+
+    const result = _securityTestExports.formatSharedAppContextForModel({
+      content: [{ type: 'text', text: 'Viewing page 2 of 4' }],
+    });
+
+    expect(result).toContain('Viewing page 2 of 4');
+  });
+
+  it('treats empty content-only MCP App context as cleared', async () => {
+    const { _securityTestExports } = await importInspectCommand();
+
+    expect(_securityTestExports.normalizeModelAppContext({ content: [] })).toBeUndefined();
+    expect(
+      _securityTestExports.normalizeModelAppContext({ structuredContent: undefined })
+    ).toBeUndefined();
+    expect(_securityTestExports.formatSharedAppContextForModel({ content: [] })).toBe('');
   });
 
   it('uses MCP tool calls for model chat', async () => {

--- a/packages/sunpeak/src/inspector/index.ts
+++ b/packages/sunpeak/src/inspector/index.ts
@@ -23,6 +23,7 @@ import '../claude/claude-host';
 export { Inspector } from './inspector';
 export type {
   InspectorModelApiKeyController,
+  InspectorModelAppContext,
   InspectorModelChatMessage,
   InspectorModelChatOptions,
   InspectorModelChatRequest,

--- a/packages/sunpeak/src/inspector/inspector.test.tsx
+++ b/packages/sunpeak/src/inspector/inspector.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { Inspector } from './inspector';
@@ -1384,6 +1384,39 @@ describe('Inspector', () => {
       await userEvent.click(screen.getByRole('button', { name: /Model Chat/ }));
       expect(screen.getByDisplayValue('fractal-careful')).toBeInTheDocument();
       expect(screen.queryByDisplayValue('fractal-deprecated')).not.toBeInTheDocument();
+    });
+
+    it('passes app context to model chat handlers', async () => {
+      const onChat = vi.fn(async () => ({ text: 'ok' }));
+      render(
+        <Inspector
+          simulations={{ test: createSim() }}
+          onCallTool={vi.fn()}
+          modelChat={{
+            providers: [{ id: 'fractal', label: 'Fractal', defaultModel: 'fractal-careful' }],
+            onChat,
+          }}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: /App Context/ }));
+      const appContext = screen.getByDisplayValue('null');
+      fireEvent.change(appContext, { target: { value: '{"selectedAlbum":"Pizza Tour"}' } });
+      fireEvent.blur(appContext);
+
+      await userEvent.click(screen.getByRole('button', { name: /Model Chat/ }));
+      const composer = document.querySelector<HTMLInputElement>('input[name="userInput"]')!;
+      await userEvent.type(composer, 'What is selected?{enter}');
+
+      await waitFor(() => expect(onChat).toHaveBeenCalledTimes(1));
+      expect(onChat).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appContext: {
+            content: [],
+            structuredContent: { selectedAlbum: 'Pizza Tour' },
+          },
+        })
+      );
     });
 
     it('prefers provider-specific default models over the global model default', async () => {

--- a/packages/sunpeak/src/inspector/inspector.tsx
+++ b/packages/sunpeak/src/inspector/inspector.tsx
@@ -57,6 +57,11 @@ export interface InspectorModelChatToolCall {
   isError?: boolean;
 }
 
+export interface InspectorModelAppContext {
+  content?: unknown[];
+  structuredContent?: unknown;
+}
+
 export interface InspectorModelChatResponse {
   text?: string;
   toolCalls?: InspectorModelChatToolCall[];
@@ -74,6 +79,7 @@ export interface InspectorModelChatRequest {
   modelId: string;
   messages: InspectorModelChatMessage[];
   tools: Simulation['tool'][];
+  appContext?: InspectorModelAppContext;
 }
 
 export interface InspectorModelApiKeyController {
@@ -988,6 +994,7 @@ export function Inspector({
           modelId,
           messages,
           tools: modelCallableTools,
+          appContext: state.modelAppContext ?? undefined,
         });
       } else {
         const endpoint = inspectorApiEndpoint('/__sunpeak/model-chat', inspectorApiBaseUrl);
@@ -998,6 +1005,7 @@ export function Inspector({
             provider: modelProvider,
             modelId,
             messages,
+            appContext: state.modelAppContext ?? undefined,
           }),
         });
         data = await readInspectorJson<InspectorModelChatResponse>(res, endpoint);
@@ -2267,7 +2275,14 @@ export function Inspector({
                 onFocus={() => state.setEditingField('modelContext')}
                 onBlur={() =>
                   state.commitJSON(state.modelContextJson, state.setModelContextError, (parsed) => {
-                    state.setModelContext(parsed as Record<string, unknown> | null);
+                    state.setModelContext(
+                      parsed != null && typeof parsed === 'object' && !Array.isArray(parsed)
+                        ? (parsed as Record<string, unknown>)
+                        : null
+                    );
+                    state.setModelAppContext(
+                      parsed == null ? null : { content: [], structuredContent: parsed }
+                    );
                   })
                 }
                 error={state.modelContextError}

--- a/packages/sunpeak/src/inspector/use-inspector-state.test.ts
+++ b/packages/sunpeak/src/inspector/use-inspector-state.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { deriveContainerDimensions, useInspectorState } from './use-inspector-state';
 import type { Simulation } from '../types/simulation';
@@ -53,6 +53,71 @@ describe('useInspectorState', () => {
         viewportWidth: 1440,
       })
     ).toEqual({ height: 848, width: 1440 });
+  });
+
+  it('stores structured model context for future model turns without changing resource state', () => {
+    const simulations = { 'ui-tool': createSim('ui-tool', true) };
+    const { result } = renderHook(() => useInspectorState({ simulations }));
+
+    act(() => {
+      result.current.handleUpdateModelContext([], { selectedAlbum: 'Pizza Tour' });
+    });
+
+    expect(result.current.modelContext).toBeNull();
+    expect(result.current.modelAppContext).toEqual({
+      content: [],
+      structuredContent: { selectedAlbum: 'Pizza Tour' },
+    });
+  });
+
+  it('stores text-only model context without injecting it as resource state', () => {
+    const simulations = { 'ui-tool': createSim('ui-tool', true) };
+    const { result } = renderHook(() => useInspectorState({ simulations }));
+
+    act(() => {
+      result.current.handleUpdateModelContext([{ type: 'text', text: 'Viewing page 2 of 4' }]);
+    });
+
+    expect(result.current.modelContext).toBeNull();
+    expect(result.current.modelAppContext).toEqual({
+      content: [{ type: 'text', text: 'Viewing page 2 of 4' }],
+    });
+  });
+
+  it('clears model context when the app writes empty content', () => {
+    const simulations = { 'ui-tool': createSim('ui-tool', true) };
+    const { result } = renderHook(() => useInspectorState({ simulations }));
+
+    act(() => {
+      result.current.handleUpdateModelContext([], { selectedAlbum: 'Pizza Tour' });
+    });
+    act(() => {
+      result.current.handleUpdateModelContext([]);
+    });
+
+    expect(result.current.modelContext).toBeNull();
+    expect(result.current.modelAppContext).toBeNull();
+  });
+
+  it('keeps app-written model context across simulation changes', () => {
+    const simulations = {
+      first: createSim('first', true),
+      second: createSim('second', true),
+    };
+    const { result } = renderHook(() => useInspectorState({ simulations }));
+
+    act(() => {
+      result.current.handleUpdateModelContext([], { selectedAlbum: 'Pizza Tour' });
+    });
+    act(() => {
+      result.current.setSelectedSimulationName('second');
+    });
+
+    expect(result.current.modelAppContext).toEqual({
+      content: [],
+      structuredContent: { selectedAlbum: 'Pizza Tour' },
+    });
+    expect(result.current.modelContextJson).toBe('{\n  "selectedAlbum": "Pizza Tour"\n}');
   });
 
   describe('preference persistence', () => {

--- a/packages/sunpeak/src/inspector/use-inspector-state.ts
+++ b/packages/sunpeak/src/inspector/use-inspector-state.ts
@@ -14,6 +14,11 @@ import { extractResourceCSP, type ResourceCSP } from './iframe-resource';
 
 type Platform = NonNullable<McpUiHostContext['platform']>;
 
+interface ModelAppContext {
+  content?: unknown[];
+  structuredContent?: unknown;
+}
+
 const DEFAULT_THEME: McpUiTheme = 'dark';
 const DEFAULT_DISPLAY_MODE: McpUiDisplayMode = 'inline';
 const DEFAULT_PLATFORM: Platform = 'desktop';
@@ -82,6 +87,8 @@ export interface InspectorState {
   // ── Model context ──
   modelContext: Record<string, unknown> | null;
   setModelContext: (ctx: Record<string, unknown> | null) => void;
+  modelAppContext: ModelAppContext | null;
+  setModelAppContext: (ctx: ModelAppContext | null) => void;
 
   // ── JSON editing state (for sidebar) ──
   toolInputJson: string;
@@ -624,6 +631,7 @@ export function useInspectorState({
   // Model context
   const [modelContextJson, setModelContextJson] = useState<string>('null');
   const [modelContext, setModelContext] = useState<Record<string, unknown> | null>(null);
+  const [modelAppContext, setModelAppContext] = useState<ModelAppContext | null>(null);
 
   // Track which field is being edited
   const [editingField, setEditingField] = useState<string | null>(null);
@@ -651,7 +659,6 @@ export function useInspectorState({
       setToolResultError('');
     }
     if (editingField !== 'modelContext') {
-      setModelContextJson('null');
       setModelContext(null);
       setModelContextError('');
     }
@@ -687,6 +694,14 @@ export function useInspectorState({
 
   const handleUpdateModelContext = (content: unknown[], structuredContent?: unknown) => {
     setModelContextJson(JSON.stringify(structuredContent ?? content, null, 2));
+    setModelAppContext(
+      structuredContent === undefined && content.length === 0
+        ? null
+        : {
+            content,
+            ...(structuredContent !== undefined ? { structuredContent } : {}),
+          }
+    );
   };
 
   // ── JSON helpers ──
@@ -794,6 +809,8 @@ export function useInspectorState({
 
     modelContext,
     setModelContext,
+    modelAppContext,
+    setModelAppContext,
 
     toolInputJson,
     setToolInputJson,


### PR DESCRIPTION
Replicates MCP App shared context in real model chat by forwarding app context, preserving app-written context across turns, and keeping debug resource state separate from model-visible state. Exposes model-visible tool result fields without leaking top-level component metadata, with tests for manual and app-written context paths. Fixes validate parallelism by assigning explicit MCP ports to scaffold and example runs, and refreshes generated examples to the current sunpeak package version. Validation: pnpm validate.