### PR TITLE
Fix inspector model chat request handling

### DIFF
--- a/packages/sunpeak/bin/commands/inspect.mjs
+++ b/packages/sunpeak/bin/commands/inspect.mjs
@@ -1392,9 +1392,22 @@ function normalizeModelId(modelId) {
   return trimmed;
 }
 
+function normalizeModelProviderModelId(provider, modelId) {
+  const normalizedModelId = normalizeModelId(modelId);
+  if (
+    provider === 'anthropic' &&
+    /^claude-\d+(?:-\d+)+-(opus|sonnet|haiku)$/i.test(normalizedModelId)
+  ) {
+    throw new Error(
+      `Unsupported Anthropic model ID "${normalizedModelId}". Use an Anthropic API model ID such as "claude-sonnet-4-20250514".`
+    );
+  }
+  return normalizedModelId;
+}
+
 async function createModelInstance(provider, modelId, apiKey) {
   assertModelProvider(provider);
-  const normalizedModelId = normalizeModelId(modelId);
+  const normalizedModelId = normalizeModelProviderModelId(provider, modelId);
   if (provider === 'openai') {
     const { createOpenAI } = await import('@ai-sdk/openai');
     const openai = createOpenAI({ apiKey });
@@ -1430,6 +1443,17 @@ function formatSharedAppContextForModel(appContext) {
   const normalized = normalizeModelAppContext(appContext);
   if (!normalized) return '';
   return formatJsonForModel(normalized);
+}
+
+function normalizeModelChatMessages(messages) {
+  if (!Array.isArray(messages)) return [];
+  return messages
+    .filter((message) => message?.role === 'user' || message?.role === 'assistant')
+    .map((message) => ({
+      role: message.role,
+      content: String(message.content ?? '').slice(0, 20000).trim(),
+    }))
+    .filter((message) => message.content.length > 0);
 }
 
 function formatModelVisibleToolResult(tool, result) {
@@ -1504,11 +1528,11 @@ async function runModelChat({ client, provider, modelId, messages, apiKey, appCo
     ]
       .filter(Boolean)
       .join('\n\n'),
-    messages: messages.map((message) => ({
-      role: message.role,
-      content: String(message.content ?? ''),
-    })),
-    maxSteps: 5,
+    messages: normalizeModelChatMessages(messages),
+    // AI SDK v4 can send an empty assistant text block to Anthropic when a
+    // tool-only response is followed by another model step. We only need the
+    // tool result for inspector rendering, so skip that follow-up call.
+    maxSteps: provider === 'anthropic' ? 1 : 5,
     maxRetries: 0,
   });
 
@@ -2513,13 +2537,7 @@ function sunpeakInspectEndpointsPlugin(getClient, setClient, pluginOpts = {}) {
             res.end(JSON.stringify({ error: `No ${provider} API key saved.` }));
             return;
           }
-          const messages = Array.isArray(parsed.messages) ? parsed.messages : [];
-          const safeMessages = messages
-            .filter((message) => message?.role === 'user' || message?.role === 'assistant')
-            .map((message) => ({
-              role: message.role,
-              content: String(message.content ?? '').slice(0, 20000),
-            }));
+          const safeMessages = normalizeModelChatMessages(parsed.messages);
           if (safeMessages.length === 0) {
             res.writeHead(400, { 'Content-Type': 'application/json' });
             res.end(JSON.stringify({ error: 'Missing chat messages.' }));
@@ -2678,8 +2696,10 @@ export const _securityTestExports = {
   formatModelVisibleToolResult,
   formatSharedAppContextForModel,
   normalizeApiKey,
+  normalizeModelChatMessages,
   normalizeModelAppContext,
   normalizeModelId,
+  normalizeModelProviderModelId,
   quoteSecurityInteractiveArg,
   readRequestBody,
   resolveHttpRedirectsForMcp,

--- a/packages/sunpeak/src/cli/inspect.test.ts
+++ b/packages/sunpeak/src/cli/inspect.test.ts
@@ -494,6 +494,31 @@ describe('inspect endpoint security helpers', () => {
     );
   });
 
+  it('rejects common reversed Anthropic model ID shapes with a useful hint', async () => {
+    const { _securityTestExports } = await importInspectCommand();
+
+    expect(() =>
+      _securityTestExports.normalizeModelProviderModelId('anthropic', 'claude-5-6-sonnet')
+    ).toThrow('Use an Anthropic API model ID such as "claude-sonnet-4-20250514"');
+    expect(
+      _securityTestExports.normalizeModelProviderModelId('anthropic', ' claude-sonnet-4-20250514 ')
+    ).toBe('claude-sonnet-4-20250514');
+    expect(_securityTestExports.normalizeModelProviderModelId('openai', ' gpt-4o ')).toBe('gpt-4o');
+  });
+
+  it('drops empty model chat messages before provider calls', async () => {
+    const { _securityTestExports } = await importInspectCommand();
+
+    expect(
+      _securityTestExports.normalizeModelChatMessages([
+        { role: 'assistant', content: '   ' },
+        { role: 'user', content: ' Find me flights ' },
+        { role: 'system', content: 'ignored' },
+        { role: 'assistant', content: null },
+      ])
+    ).toEqual([{ role: 'user', content: 'Find me flights' }]);
+  });
+
   it('rejects API keys with control characters before credential storage', async () => {
     const { _securityTestExports } = await importInspectCommand();
 

--- a/packages/sunpeak/src/inspector/inspector.tsx
+++ b/packages/sunpeak/src/inspector/inspector.tsx
@@ -198,7 +198,11 @@ interface ToolInfo {
 
 const DEFAULT_MODEL_PROVIDERS: InspectorModelProvider[] = [
   { id: 'openai', label: 'OpenAI', defaultModel: 'gpt-4o' },
-  { id: 'anthropic', label: 'Anthropic', defaultModel: 'claude-3-5-sonnet-20241022' },
+  {
+    id: 'anthropic',
+    label: 'Anthropic',
+    defaultModel: 'claude-sonnet-4-20250514',
+  },
 ];
 
 function splitCssArgs(value: string): string[] {
@@ -995,10 +999,12 @@ export function Inspector({
     setHasRun(false);
 
     try {
-      const messages = nextMessages.map((message) => ({
-        role: message.role,
-        content: message.content,
-      }));
+      const messages = nextMessages
+        .map((message) => ({
+          role: message.role,
+          content: message.content.trim(),
+        }))
+        .filter((message) => message.content.length > 0);
       let data: InspectorModelChatResponse;
       if (modelChatHandler) {
         data = await modelChatHandler({

--- a/packages/sunpeak/tests/e2e/inspector-modes.spec.ts
+++ b/packages/sunpeak/tests/e2e/inspector-modes.spec.ts
@@ -574,7 +574,8 @@ for (const host of hosts) {
         .locator('select')
         .filter({ has: page.locator('option[value="anthropic"]') })
         .selectOption('anthropic');
-      const modelInput = page.locator('input[placeholder="claude-3-5-sonnet-20241022"]');
+      const modelInput = page.locator('input[placeholder="claude-sonnet-4-20250514"]');
+      await expect(modelInput).toHaveValue('claude-sonnet-4-20250514');
       await modelInput.fill('claude-test-model');
       await modelInput.press('Enter');
 


### PR DESCRIPTION
Sanitizes model chat messages before provider calls, updates the default Anthropic model ID, and rejects common reversed Anthropic ID shapes with a clear hint. It also avoids an Anthropic follow-up step that can produce empty text blocks after tool-only responses. Added unit coverage for normalization and e2e coverage for the updated provider selector. Validation: SUNPEAK_TEST_PORT=6785 SUNPEAK_SANDBOX_PORT=24695 pnpm --filter sunpeak validate.