### PR TITLE
Add reset control for model chat

### DIFF
--- a/docs/testing/inspector-embedding.mdx
+++ b/docs/testing/inspector-embedding.mdx
@@ -355,6 +355,11 @@ Embedded model chat is opt-in. Passing `modelChat` by itself does not enable
 the chat UI; set `modelChat.enabled: true` and provide `modelChat.onChat` so
 your app owns the actual model call.
 
+Each `modelChat.onChat` request includes `conversationId`. If your backend
+keeps provider-side conversation state, store it under that id. When a user
+clicks the reset button in the Model Chat controls, the Inspector clears the
+visible transcript and sends the next turn with a new id.
+
 ## The sandbox proxy
 
 The Inspector renders apps inside a **double-iframe**: an outer sandbox proxy

--- a/packages/sunpeak/bin/commands/inspect.mjs
+++ b/packages/sunpeak/bin/commands/inspect.mjs
@@ -1405,6 +1405,16 @@ function normalizeModelProviderModelId(provider, modelId) {
   return normalizedModelId;
 }
 
+function normalizeModelConversationId(conversationId) {
+  if (typeof conversationId !== 'string') return undefined;
+  const trimmed = conversationId.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.length > 200 || /[\u0000-\u001f\u007f]/.test(trimmed)) {
+    throw new Error('Invalid model conversation ID.');
+  }
+  return trimmed;
+}
+
 async function createModelInstance(provider, modelId, apiKey) {
   assertModelProvider(provider);
   const normalizedModelId = normalizeModelProviderModelId(provider, modelId);
@@ -1490,7 +1500,15 @@ async function executeModelChatToolCall({ client, name, arguments: args }) {
   };
 }
 
-async function runModelChat({ client, provider, modelId, messages, apiKey, appContext }) {
+async function runModelChat({
+  client,
+  provider,
+  modelId,
+  messages,
+  apiKey,
+  appContext,
+  conversationId,
+}) {
   assertModelProvider(provider);
   const { generateText, tool: aiTool, jsonSchema } = await import('ai');
   const model = await createModelInstance(provider, modelId, apiKey);
@@ -1537,6 +1555,7 @@ async function runModelChat({ client, provider, modelId, messages, apiKey, appCo
   });
 
   return {
+    ...(conversationId ? { conversationId } : {}),
     text: result.text || '',
     toolCalls: capturedToolCalls,
     finishReason: result.finishReason,
@@ -2543,6 +2562,7 @@ function sunpeakInspectEndpointsPlugin(getClient, setClient, pluginOpts = {}) {
             res.end(JSON.stringify({ error: 'Missing chat messages.' }));
             return;
           }
+          const conversationId = normalizeModelConversationId(parsed.conversationId);
 
           const result = await withModelChatClient((client) =>
             runModelChat({
@@ -2552,6 +2572,7 @@ function sunpeakInspectEndpointsPlugin(getClient, setClient, pluginOpts = {}) {
               messages: safeMessages,
               apiKey,
               appContext: normalizeModelAppContext(parsed.appContext),
+              conversationId,
             })
           );
           res.writeHead(200, { 'Content-Type': 'application/json' });

--- a/packages/sunpeak/src/inspector/inspector.test.tsx
+++ b/packages/sunpeak/src/inspector/inspector.test.tsx
@@ -1,7 +1,7 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import { Inspector } from './inspector';
+import { Inspector, type InspectorModelChatRequest } from './inspector';
 import type { Simulation } from '../types/simulation';
 
 // Mock fetch for useMcpConnection
@@ -886,9 +886,7 @@ describe('Inspector', () => {
 
       render(<Inspector simulations={multiToolSims} onCallTool={vi.fn()} />);
 
-      const appContextTextarea = screen.getByTestId(
-        'app-context-textarea'
-      ) as HTMLTextAreaElement;
+      const appContextTextarea = screen.getByTestId('app-context-textarea') as HTMLTextAreaElement;
       fireEvent.change(appContextTextarea, {
         target: { value: '{"selectedAlbum":"Pizza Tour"}' },
       });
@@ -908,9 +906,7 @@ describe('Inspector', () => {
 
       render(<Inspector simulations={multiToolSims} onCallTool={vi.fn()} />);
 
-      const appContextTextarea = screen.getByTestId(
-        'app-context-textarea'
-      ) as HTMLTextAreaElement;
+      const appContextTextarea = screen.getByTestId('app-context-textarea') as HTMLTextAreaElement;
       fireEvent.change(appContextTextarea, {
         target: { value: '{"selectedAlbum":"Pizza Tour"}' },
       });
@@ -991,9 +987,7 @@ describe('Inspector', () => {
 
       render(<Inspector simulations={multiToolSims} onCallTool={vi.fn()} />);
 
-      const appContextTextarea = screen.getByTestId(
-        'app-context-textarea'
-      ) as HTMLTextAreaElement;
+      const appContextTextarea = screen.getByTestId('app-context-textarea') as HTMLTextAreaElement;
       fireEvent.change(appContextTextarea, {
         target: { value: '{"selectedAlbum":"Pizza Tour"}' },
       });
@@ -1482,6 +1476,95 @@ describe('Inspector', () => {
       expect(chatRequest.tools.map((tool) => tool.name)).not.toContain('app-only-action');
       expect(screen.getByText('Custom model response from embedder.')).toBeInTheDocument();
       expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('resets model chat with a new backend conversation id', async () => {
+      const onChat = vi.fn(async (_request: InspectorModelChatRequest) => ({
+        text: 'Model reply.',
+        toolCalls: [],
+      }));
+      render(
+        <Inspector
+          app={modelApp}
+          onCallTool={vi.fn()}
+          modelChat={{
+            enabled: true,
+            providers: [{ id: 'fractal', label: 'Fractal', defaultModel: 'fractal-careful' }],
+            onChat,
+          }}
+        />
+      );
+
+      const resetButton = screen.getByRole('button', { name: 'Reset model conversation' });
+      expect(resetButton).toBeDisabled();
+
+      const composer = document.querySelector<HTMLInputElement>('input[name="userInput"]')!;
+      await userEvent.type(composer, 'First prompt{enter}');
+      await waitFor(() => expect(onChat).toHaveBeenCalledTimes(1));
+      expect(screen.getByText('First prompt')).toBeInTheDocument();
+      expect(resetButton).toBeEnabled();
+
+      await userEvent.click(resetButton);
+      expect(screen.queryByText('First prompt')).not.toBeInTheDocument();
+      expect(screen.queryByText('Model reply.')).not.toBeInTheDocument();
+      expect(resetButton).toBeDisabled();
+
+      await userEvent.type(composer, 'Second prompt{enter}');
+      await waitFor(() => expect(onChat).toHaveBeenCalledTimes(2));
+
+      const requests = onChat.mock.calls.map(([request]) => request);
+      expect(requests[0].conversationId).toMatch(/^model-chat-/);
+      expect(requests[1].conversationId).toMatch(/^model-chat-/);
+      expect(requests[1].conversationId).not.toBe(requests[0].conversationId);
+      expect(requests[1].messages).toEqual([{ role: 'user', content: 'Second prompt' }]);
+    });
+
+    it('ignores an in-flight model response after resetting model chat', async () => {
+      let resolveFirst: (value: { text: string; toolCalls: [] }) => void = () => {};
+      const firstResponse = new Promise<{ text: string; toolCalls: [] }>((resolve) => {
+        resolveFirst = resolve;
+      });
+      let requestCount = 0;
+      const onChat = vi.fn(async (_request: InspectorModelChatRequest) => {
+        requestCount += 1;
+        if (requestCount === 1) return await firstResponse;
+        return { text: 'Second reply.', toolCalls: [] };
+      });
+
+      render(
+        <Inspector
+          app={modelApp}
+          onCallTool={vi.fn()}
+          modelChat={{
+            enabled: true,
+            providers: [{ id: 'fractal', label: 'Fractal', defaultModel: 'fractal-careful' }],
+            onChat,
+          }}
+        />
+      );
+
+      const resetButton = screen.getByRole('button', { name: 'Reset model conversation' });
+      const composer = document.querySelector<HTMLInputElement>('input[name="userInput"]')!;
+      await userEvent.type(composer, 'Slow prompt{enter}');
+      await waitFor(() => expect(onChat).toHaveBeenCalledTimes(1));
+      expect(screen.getByText('Slow prompt')).toBeInTheDocument();
+
+      await userEvent.click(resetButton);
+      expect(screen.queryByText('Slow prompt')).not.toBeInTheDocument();
+
+      await act(async () => {
+        resolveFirst({ text: 'Stale reply.', toolCalls: [] });
+        await firstResponse;
+      });
+      expect(screen.queryByText('Stale reply.')).not.toBeInTheDocument();
+
+      await userEvent.type(composer, 'Fresh prompt{enter}');
+      await waitFor(() => expect(onChat).toHaveBeenCalledTimes(2));
+      expect(screen.getByText('Second reply.')).toBeInTheDocument();
+
+      const requests = onChat.mock.calls.map(([request]) => request);
+      expect(requests[1].conversationId).not.toBe(requests[0].conversationId);
+      expect(requests[1].messages).toEqual([{ role: 'user', content: 'Fresh prompt' }]);
     });
 
     it('does not claim a backend-only model tool call rendered an app', async () => {

--- a/packages/sunpeak/src/inspector/inspector.tsx
+++ b/packages/sunpeak/src/inspector/inspector.tsx
@@ -74,6 +74,12 @@ export interface InspectorModelKeyStatus {
 }
 
 export interface InspectorModelChatRequest {
+  /**
+   * Stable identifier for the current visible model-chat transcript. It rotates
+   * when the user resets model chat so backend-backed handlers can start a
+   * fresh provider conversation.
+   */
+  conversationId?: string;
   provider: string;
   modelId: string;
   messages: InspectorModelChatMessage[];
@@ -204,6 +210,14 @@ const DEFAULT_MODEL_PROVIDERS: InspectorModelProvider[] = [
     defaultModel: 'claude-sonnet-4-20250514',
   },
 ];
+
+function createModelConversationId() {
+  const random =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : Math.random().toString(36).slice(2);
+  return `model-chat-${Date.now()}-${random}`;
+}
 
 function splitCssArgs(value: string): string[] {
   const args: string[] = [];
@@ -518,6 +532,7 @@ export function Inspector({
   const [chatInput, setChatInput] = React.useState('');
   const [isChatting, setIsChatting] = React.useState(false);
   const [chatStatus, setChatStatus] = React.useState('');
+  const modelConversationIdRef = React.useRef(createModelConversationId());
   const currentModelProvider = React.useMemo(
     () => modelProviderOptions.find((provider) => provider.id === modelProvider),
     [modelProvider, modelProviderOptions]
@@ -660,6 +675,15 @@ export function Inspector({
     usesApiKeyUi,
     usesLocalModelEndpoints,
   ]);
+
+  const handleResetModelConversation = React.useCallback(() => {
+    const nextConversationId = createModelConversationId();
+    modelConversationIdRef.current = nextConversationId;
+    setChatMessages([]);
+    setChatInput('');
+    setChatStatus('');
+    setIsChatting(false);
+  }, []);
 
   // Keep useInspectorState's selection in sync with our tool/simulation selection.
   React.useEffect(() => {
@@ -997,6 +1021,7 @@ export function Inspector({
     state.setToolResultJson('');
     state.setToolResultError('');
     setHasRun(false);
+    const requestConversationId = modelConversationIdRef.current;
 
     try {
       const messages = nextMessages
@@ -1008,6 +1033,7 @@ export function Inspector({
       let data: InspectorModelChatResponse;
       if (modelChatHandler) {
         data = await modelChatHandler({
+          conversationId: requestConversationId,
           provider: modelProvider,
           modelId,
           messages,
@@ -1020,6 +1046,7 @@ export function Inspector({
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
+            conversationId: requestConversationId,
             provider: modelProvider,
             modelId,
             messages,
@@ -1034,6 +1061,7 @@ export function Inspector({
       if (data.error) {
         throw new Error(data.error);
       }
+      if (requestConversationId !== modelConversationIdRef.current) return;
 
       let rendersApp = false;
       const toolCalls = data.toolCalls ?? [];
@@ -1082,6 +1110,7 @@ export function Inspector({
       });
       setChatStatus('');
     } catch (err) {
+      if (requestConversationId !== modelConversationIdRef.current) return;
       const message = err instanceof Error ? err.message : String(err);
       setChatMessages((messages) => [
         ...messages,
@@ -1093,7 +1122,9 @@ export function Inspector({
       ]);
       setChatStatus(message);
     } finally {
-      setIsChatting(false);
+      if (requestConversationId === modelConversationIdRef.current) {
+        setIsChatting(false);
+      }
     }
   }, [
     canUseModelChat,
@@ -1946,7 +1977,7 @@ export function Inspector({
                 docsPath="testing/evals"
               >
                 <div className="space-y-1">
-                  <div className="grid grid-cols-2 gap-2">
+                  <div className="grid grid-cols-[0.7fr_minmax(0,1fr)_1.75rem] items-end gap-2">
                     <SidebarControl label="Provider">
                       <SidebarSelect
                         value={modelProvider}
@@ -1976,6 +2007,41 @@ export function Inspector({
                         />
                       )}
                     </SidebarControl>
+                    <div className="space-y-1">
+                      <span
+                        className="block text-[10px] font-medium leading-tight opacity-0"
+                        aria-hidden="true"
+                      >
+                        Reset
+                      </span>
+                      <button
+                        type="button"
+                        onClick={handleResetModelConversation}
+                        disabled={chatMessages.length === 0 && !isChatting && !chatStatus}
+                        aria-label="Reset model conversation"
+                        title="Reset model conversation"
+                        className="flex h-7 w-7 items-center justify-center rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+                        style={{
+                          backgroundColor: 'var(--color-background-primary)',
+                          color: 'var(--color-text-primary)',
+                        }}
+                      >
+                        <svg
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          aria-hidden="true"
+                        >
+                          <path d="M21 12a9 9 0 1 1-2.64-6.36" />
+                          <path d="M21 3v7h-7" />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                   {usesApiKeyUi && (
                     <SidebarControl label="API Key">

--- a/packages/sunpeak/tests/e2e/inspector-modes.spec.ts
+++ b/packages/sunpeak/tests/e2e/inspector-modes.spec.ts
@@ -493,6 +493,61 @@ for (const host of hosts) {
       await expect(iframe.getByRole('heading', { name: 'Lady Bird Lake' })).not.toBeVisible();
     });
 
+    test('resetting model chat clears the transcript and starts a new backend conversation', async ({
+      page,
+    }) => {
+      const requestBodies: Array<Record<string, unknown>> = [];
+
+      await routeSavedModelKey(page);
+
+      await page.route('**/__sunpeak/model-chat', async (route) => {
+        const body = JSON.parse(route.request().postData() ?? '{}');
+        requestBodies.push(body);
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            text: `Reply ${requestBodies.length}`,
+            toolCalls: [],
+          }),
+        });
+      });
+
+      await page.goto(createInspectorUrl({ tool: 'show-albums', theme: 'dark', host }));
+
+      const resetButton = page.getByRole('button', { name: 'Reset model conversation' });
+      await expect(resetButton).toBeDisabled();
+
+      await submitModelMessage(page, 'First model prompt');
+      await expect(
+        page.locator('[data-turn="user"]').filter({ hasText: 'First model prompt' })
+      ).toBeVisible();
+      await expect(
+        page.locator('[data-turn="assistant"]').filter({ hasText: 'Reply 1' })
+      ).toBeVisible();
+      await expect(resetButton).toBeEnabled();
+
+      await resetButton.click();
+      await expect(
+        page.locator('[data-turn="user"]').filter({ hasText: 'First model prompt' })
+      ).toHaveCount(0);
+      await expect(
+        page.locator('[data-turn="assistant"]').filter({ hasText: 'Reply 1' })
+      ).toHaveCount(0);
+      await expect(resetButton).toBeDisabled();
+
+      await submitModelMessage(page, 'Second model prompt');
+      await expect(
+        page.locator('[data-turn="assistant"]').filter({ hasText: 'Reply 2' })
+      ).toBeVisible();
+
+      expect(requestBodies).toHaveLength(2);
+      expect(requestBodies[0].conversationId).toEqual(expect.stringMatching(/^model-chat-/));
+      expect(requestBodies[1].conversationId).toEqual(expect.stringMatching(/^model-chat-/));
+      expect(requestBodies[1].conversationId).not.toBe(requestBodies[0].conversationId);
+      expect(requestBodies[1].messages).toEqual([{ role: 'user', content: 'Second model prompt' }]);
+    });
+
     test('preserves model tool data when switching from the default tool to carousel', async ({
       page,
     }) => {


### PR DESCRIPTION
Adds a reset button next to the Model dropdown that clears the visible model chat transcript and rotates the backend conversation ID. The Inspector now sends `conversationId` through embedded and built-in model chat paths, with validation in the inspect endpoint so backends can start fresh context after reset. Adds unit and e2e coverage for reset behavior, stale in-flight responses, and cleared history, and documents the embedded `conversationId` contract. Validated with typecheck, lint, focused unit/e2e tests, build, and diff checks; full validate only failed in the final visual baseline creation step where `Summer Slice` was not found.