### PR TITLE
Persist inspector model chat preferences

### DIFF
--- a/docs/mcp-apps-inspector.mdx
+++ b/docs/mcp-apps-inspector.mdx
@@ -74,7 +74,7 @@ The inspector sidebars let you configure:
 
 Selecting a backend-only tool shows `Tool does not render a UI` in the preview, but the tool can still be called from the sidebar and its result is still shown.
 
-Most runtime settings are reflected in the URL, making them shareable and usable in automated tests via [`createInspectorUrl`](/testing/inspector#createinspectorurl). Sidebar width adjustments are saved locally so they persist across refreshes.
+Most runtime settings are reflected in the URL, making them shareable and usable in automated tests via [`createInspectorUrl`](/testing/inspector#createinspectorurl). Sidebar preferences like host context, width adjustments, Prod Resources, and Model Chat provider/model are saved locally so they persist across refreshes.
 
 ## Using the Inspector in Tests
 

--- a/packages/sunpeak/src/inspector/inspector.test.tsx
+++ b/packages/sunpeak/src/inspector/inspector.test.tsx
@@ -6,8 +6,10 @@ import type { Simulation } from '../types/simulation';
 
 // Mock fetch for useMcpConnection
 let fetchSpy: ReturnType<typeof vi.spyOn>;
+const PREFS_KEY = 'sunpeak-inspector-prefs';
 
 beforeEach(() => {
+  localStorage.clear();
   fetchSpy = vi.spyOn(globalThis, 'fetch');
   // Default: health check succeeds
   fetchSpy.mockResolvedValue(new Response('{"tools":[]}', { status: 200 }));
@@ -1676,6 +1678,90 @@ describe('Inspector', () => {
       expect(screen.getByDisplayValue('fractal-small')).toBeInTheDocument();
       await userEvent.selectOptions(screen.getByDisplayValue('Fractal Fast'), 'fractal-careful');
       expect(screen.getByDisplayValue('fractal-large')).toBeInTheDocument();
+    });
+
+    it('defaults OpenAI model chat to the current ChatGPT default model id', () => {
+      render(<Inspector simulations={{ test: createSim() }} onCallTool={vi.fn()} />);
+
+      expect(screen.getByDisplayValue('gpt-5.5')).toBeInTheDocument();
+    });
+
+    it('restores persisted Model Chat and Prod Resources values', () => {
+      localStorage.setItem(
+        PREFS_KEY,
+        JSON.stringify({
+          modelProvider: 'fractal',
+          modelId: 'fractal-careful',
+          prodResources: true,
+        })
+      );
+
+      render(
+        <Inspector
+          simulations={{ test: createSim() }}
+          onCallTool={vi.fn()}
+          modelChat={{
+            providers: [
+              {
+                id: 'fractal',
+                label: 'Fractal Models',
+                models: ['fractal-fast', 'fractal-careful'],
+              },
+            ],
+            onChat: vi.fn(async () => ({ text: 'ok' })),
+          }}
+        />
+      );
+
+      expect(screen.getByDisplayValue('Fractal Models')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('fractal-careful')).toBeInTheDocument();
+      expect(screen.getByLabelText('Prod Resources')).toBeChecked();
+    });
+
+    it('lets persisted Prod Resources override the default prop', () => {
+      localStorage.setItem(PREFS_KEY, JSON.stringify({ prodResources: false }));
+
+      render(
+        <Inspector simulations={{ test: createSim() }} onCallTool={vi.fn()} defaultProdResources />
+      );
+
+      expect(screen.getByLabelText('Prod Resources')).not.toBeChecked();
+    });
+
+    it('persists Model Chat and Prod Resources changes without dropping host prefs', async () => {
+      localStorage.setItem(PREFS_KEY, JSON.stringify({ theme: 'light', activeHost: 'claude' }));
+
+      render(
+        <Inspector
+          simulations={{ test: createSim() }}
+          onCallTool={vi.fn()}
+          modelChat={{
+            providers: [
+              {
+                id: 'fractal',
+                label: 'Fractal Models',
+                models: ['fractal-fast', 'fractal-careful'],
+              },
+            ],
+            onChat: vi.fn(async () => ({ text: 'ok' })),
+          }}
+        />
+      );
+
+      await userEvent.selectOptions(screen.getByDisplayValue('fractal-fast'), 'fractal-careful');
+      await userEvent.click(screen.getByLabelText('Prod Resources'));
+
+      await waitFor(() => {
+        const prefs = JSON.parse(localStorage.getItem(PREFS_KEY) ?? '{}') as Record<
+          string,
+          unknown
+        >;
+        expect(prefs.modelProvider).toBe('fractal');
+        expect(prefs.modelId).toBe('fractal-careful');
+        expect(prefs.prodResources).toBe(true);
+        expect(prefs.theme).toBe('light');
+        expect(prefs.activeHost).toBe('claude');
+      });
     });
 
     it('lets host pages own API key status and save behavior for model chat outside embedded mode', async () => {

--- a/packages/sunpeak/src/inspector/inspector.tsx
+++ b/packages/sunpeak/src/inspector/inspector.tsx
@@ -5,7 +5,7 @@ import type {
   McpUiHostContext,
 } from '@modelcontextprotocol/ext-apps';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { useInspectorState } from './use-inspector-state';
+import { readStoredPrefs, useInspectorState, writeStoredPrefs } from './use-inspector-state';
 import { useMcpConnection, type AuthType, type AuthConfig } from './use-mcp-connection';
 import { IframeResource } from './iframe-resource';
 import { ThemeProvider } from './theme-provider';
@@ -204,7 +204,7 @@ interface ToolInfo {
 }
 
 const DEFAULT_MODEL_PROVIDERS: InspectorModelProvider[] = [
-  { id: 'openai', label: 'OpenAI', defaultModel: 'gpt-4o' },
+  { id: 'openai', label: 'OpenAI', defaultModel: 'gpt-5.5' },
   {
     id: 'anthropic',
     label: 'Anthropic',
@@ -382,6 +382,10 @@ export function Inspector({
       autoRun: params.get('autoRun') === 'true',
     };
   }, []);
+  const storedPrefs = React.useMemo(
+    () => (initUrlParams.autoRun ? {} : readStoredPrefs()),
+    [initUrlParams.autoRun]
+  );
 
   // ── Tool selection ──
   // ?tool=X explicitly selects a tool. ?simulation=X infers the tool from the simulation.
@@ -473,7 +477,7 @@ export function Inspector({
     inspectorApiBaseUrl
   );
   const [prodResources, setProdResources] = React.useState(
-    state.urlProdResources ?? defaultProdResources
+    state.urlProdResources ?? storedPrefs.prodResources ?? defaultProdResources
   );
   const showSidebar = state.urlSidebar !== false;
   const showDevOverlay = state.urlDevOverlay !== false;
@@ -505,6 +509,13 @@ export function Inspector({
     }
     return modelProviderOptions[0]?.id ?? 'openai';
   }, [modelChat?.defaultProvider, modelProviderOptions]);
+  const initialModelProvider = React.useMemo(() => {
+    const stored = storedPrefs.modelProvider;
+    if (stored && modelProviderOptions.some((provider) => provider.id === stored)) {
+      return stored;
+    }
+    return defaultModelProvider;
+  }, [defaultModelProvider, modelProviderOptions, storedPrefs.modelProvider]);
   const getDefaultModelId = React.useCallback(
     (provider: string) => {
       const option = modelProviderOptions.find((item) => item.id === provider);
@@ -523,8 +534,23 @@ export function Inspector({
     },
     [modelChat?.defaultModel, modelProviderOptions]
   );
-  const [modelProvider, setModelProvider] = React.useState(defaultModelProvider);
-  const [modelId, setModelId] = React.useState(() => getDefaultModelId(defaultModelProvider));
+  const getInitialModelId = React.useCallback(
+    (provider: string) => {
+      const stored = storedPrefs.modelId;
+      if (storedPrefs.modelProvider && storedPrefs.modelProvider !== provider) {
+        return getDefaultModelId(provider);
+      }
+      const option = modelProviderOptions.find((item) => item.id === provider);
+      const providerModels = option?.models ?? [];
+      if (stored && (providerModels.length === 0 || providerModels.includes(stored))) {
+        return stored;
+      }
+      return getDefaultModelId(provider);
+    },
+    [getDefaultModelId, modelProviderOptions, storedPrefs.modelId, storedPrefs.modelProvider]
+  );
+  const [modelProvider, setModelProvider] = React.useState(initialModelProvider);
+  const [modelId, setModelId] = React.useState(() => getInitialModelId(initialModelProvider));
   const [apiKeyDraft, setApiKeyDraft] = React.useState('');
   const [keyStatus, setKeyStatus] = React.useState<InspectorModelKeyStatus>({ hasKey: false });
   const [isKeyStatusLoading, setIsKeyStatusLoading] = React.useState(usesApiKeyUi);
@@ -550,6 +576,21 @@ export function Inspector({
     }
     return Array.from(map.values());
   }, [simulations]);
+
+  const isFirstInspectorPrefsRender = React.useRef(true);
+  React.useEffect(() => {
+    if (isFirstInspectorPrefsRender.current) {
+      isFirstInspectorPrefsRender.current = false;
+      return;
+    }
+    if (initUrlParams.autoRun) return;
+    writeStoredPrefs({
+      ...readStoredPrefs(),
+      prodResources,
+      modelProvider,
+      modelId,
+    });
+  }, [initUrlParams.autoRun, modelId, modelProvider, prodResources]);
 
   React.useEffect(() => {
     const nextServerUrl = mcpServerUrl ?? '';

--- a/packages/sunpeak/src/inspector/use-inspector-state.test.ts
+++ b/packages/sunpeak/src/inspector/use-inspector-state.test.ts
@@ -138,11 +138,14 @@ describe('useInspectorState', () => {
           theme: 'light',
           locale: 'ja-JP',
           activeHost: 'claude',
+          containerHeight: 480,
+          containerWidth: 720,
           containerMaxHeight: 600,
           containerMaxWidth: 800,
           screenWidth: 'tablet',
           sidebarWidth: 340,
           rightSidebarWidth: 420,
+          timeZone: 'Asia/Tokyo',
         })
       );
 
@@ -151,11 +154,14 @@ describe('useInspectorState', () => {
       expect(result.current.theme).toBe('light');
       expect(result.current.locale).toBe('ja-JP');
       expect(result.current.activeHost).toBe('claude');
+      expect(result.current.containerHeight).toBe(480);
+      expect(result.current.containerWidth).toBe(720);
       expect(result.current.containerMaxHeight).toBe(600);
       expect(result.current.containerMaxWidth).toBe(800);
       expect(result.current.screenWidth).toBe('tablet');
       expect(result.current.sidebarWidth).toBe(340);
       expect(result.current.rightSidebarWidth).toBe(420);
+      expect(result.current.timeZone).toBe('Asia/Tokyo');
     });
 
     it('ignores invalid values in stored preferences', () => {
@@ -168,9 +174,14 @@ describe('useInspectorState', () => {
           screenWidth: 'enormous',
           sidebarWidth: 'wide',
           rightSidebarWidth: 120,
+          containerHeight: 'huge',
+          containerWidth: 'wide',
           containerMaxHeight: 'tall',
           hover: 'yes',
           safeAreaInsets: { top: 10 },
+          timeZone: 42,
+          modelProvider: 'openai\nforged',
+          modelId: 'gpt-test\u0000forged',
         })
       );
 
@@ -183,9 +194,19 @@ describe('useInspectorState', () => {
       expect(result.current.screenWidth).toBe('full');
       expect(result.current.sidebarWidth).toBe(260);
       expect(result.current.rightSidebarWidth).toBe(260);
+      expect(result.current.containerHeight).toBeUndefined();
+      expect(result.current.containerWidth).toBeUndefined();
       expect(result.current.containerMaxHeight).toBeUndefined();
       expect(result.current.hover).toBe(true);
       expect(result.current.safeAreaInsets).toEqual({ top: 0, bottom: 0, left: 0, right: 0 });
+
+      act(() => {
+        result.current.setLocale('en-GB');
+      });
+
+      const prefs = JSON.parse(localStorage.getItem(PREFS_KEY) ?? '{}') as Record<string, unknown>;
+      expect(prefs.modelProvider).toBeUndefined();
+      expect(prefs.modelId).toBeUndefined();
     });
 
     it('falls back to defaults when stored JSON is corrupt', () => {
@@ -234,6 +255,28 @@ describe('useInspectorState', () => {
       const prefs = JSON.parse(localStorage.getItem(PREFS_KEY) ?? '{}') as Record<string, unknown>;
       expect(prefs.sidebarWidth).toBe(360);
       expect(prefs.rightSidebarWidth).toBe(390);
+    });
+
+    it('persists the rest of the configured host-context values without dropping inspector prefs', () => {
+      localStorage.setItem(
+        PREFS_KEY,
+        JSON.stringify({ modelProvider: 'openai', modelId: 'gpt-test', prodResources: true })
+      );
+      const { result } = renderHook(() => useInspectorState({ simulations }));
+
+      act(() => {
+        result.current.setContainerHeight(512);
+        result.current.setContainerWidth(768);
+        result.current.setTimeZone('Europe/London');
+      });
+
+      const prefs = JSON.parse(localStorage.getItem(PREFS_KEY) ?? '{}') as Record<string, unknown>;
+      expect(prefs.containerHeight).toBe(512);
+      expect(prefs.containerWidth).toBe(768);
+      expect(prefs.timeZone).toBe('Europe/London');
+      expect(prefs.modelProvider).toBe('openai');
+      expect(prefs.modelId).toBe('gpt-test');
+      expect(prefs.prodResources).toBe(true);
     });
   });
 });

--- a/packages/sunpeak/src/inspector/use-inspector-state.ts
+++ b/packages/sunpeak/src/inspector/use-inspector-state.ts
@@ -282,10 +282,12 @@ function parseUrlParams(): {
 
 const PREFS_KEY = 'sunpeak-inspector-prefs';
 
-interface StoredPrefs {
+export interface StoredPrefs {
   theme?: McpUiTheme;
   locale?: string;
   displayMode?: McpUiDisplayMode;
+  containerHeight?: number;
+  containerWidth?: number;
   containerMaxHeight?: number;
   containerMaxWidth?: number;
   safeAreaInsets?: { top: number; bottom: number; left: number; right: number };
@@ -296,6 +298,10 @@ interface StoredPrefs {
   screenWidth?: ScreenWidth;
   sidebarWidth?: number;
   rightSidebarWidth?: number;
+  timeZone?: string;
+  prodResources?: boolean;
+  modelProvider?: string;
+  modelId?: string;
 }
 
 const VALID_THEMES: ReadonlySet<McpUiTheme> = new Set(['light', 'dark']);
@@ -307,6 +313,10 @@ const VALID_SCREEN_WIDTHS: ReadonlySet<ScreenWidth> = new Set([
   'tablet',
   'full',
 ]);
+
+function isSafeStoredString(value: unknown): value is string {
+  return typeof value === 'string' && value.length <= 200 && !/[\u0000-\u001f\u007f]/.test(value);
+}
 
 // Validate the parsed JSON one field at a time so a corrupt or stale entry
 // (older sunpeak version, manual edit) can't seed bad values into state.
@@ -326,6 +336,12 @@ function sanitizeStoredPrefs(raw: unknown): StoredPrefs {
     VALID_DISPLAY_MODES.has(obj.displayMode as McpUiDisplayMode)
   ) {
     prefs.displayMode = obj.displayMode as McpUiDisplayMode;
+  }
+  if (typeof obj.containerHeight === 'number' && Number.isFinite(obj.containerHeight)) {
+    prefs.containerHeight = obj.containerHeight;
+  }
+  if (typeof obj.containerWidth === 'number' && Number.isFinite(obj.containerWidth)) {
+    prefs.containerWidth = obj.containerWidth;
   }
   if (typeof obj.containerMaxHeight === 'number' && Number.isFinite(obj.containerMaxHeight)) {
     prefs.containerMaxHeight = obj.containerMaxHeight;
@@ -369,11 +385,23 @@ function sanitizeStoredPrefs(raw: unknown): StoredPrefs {
   if (typeof obj.rightSidebarWidth === 'number' && Number.isFinite(obj.rightSidebarWidth)) {
     prefs.rightSidebarWidth = Math.max(DEFAULT_SIDEBAR_WIDTH, Math.round(obj.rightSidebarWidth));
   }
+  if (typeof obj.timeZone === 'string') {
+    prefs.timeZone = obj.timeZone;
+  }
+  if (typeof obj.prodResources === 'boolean') {
+    prefs.prodResources = obj.prodResources;
+  }
+  if (isSafeStoredString(obj.modelProvider)) {
+    prefs.modelProvider = obj.modelProvider;
+  }
+  if (isSafeStoredString(obj.modelId)) {
+    prefs.modelId = obj.modelId;
+  }
 
   return prefs;
 }
 
-function readStoredPrefs(): StoredPrefs {
+export function readStoredPrefs(): StoredPrefs {
   if (typeof window === 'undefined') return {};
   try {
     const raw = localStorage.getItem(PREFS_KEY);
@@ -381,6 +409,15 @@ function readStoredPrefs(): StoredPrefs {
     return sanitizeStoredPrefs(JSON.parse(raw));
   } catch {
     return {};
+  }
+}
+
+export function writeStoredPrefs(prefs: StoredPrefs): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(PREFS_KEY, JSON.stringify(prefs));
+  } catch {
+    // localStorage may be unavailable (private browsing, storage quota) — ignore
   }
 }
 
@@ -497,8 +534,12 @@ export function useInspectorState({
     urlParams.displayMode ?? storedPrefs.displayMode ?? DEFAULT_DISPLAY_MODE
   );
   const [locale, setLocale] = useState(urlParams.locale ?? storedPrefs.locale ?? 'en-US');
-  const [containerHeight, setContainerHeight] = useState<number | undefined>(undefined);
-  const [containerWidth, setContainerWidth] = useState<number | undefined>(undefined);
+  const [containerHeight, setContainerHeight] = useState<number | undefined>(
+    storedPrefs.containerHeight
+  );
+  const [containerWidth, setContainerWidth] = useState<number | undefined>(
+    storedPrefs.containerWidth
+  );
   const [containerMaxHeight, setContainerMaxHeight] = useState<number | undefined>(
     urlParams.containerMaxHeight ?? storedPrefs.containerMaxHeight
   );
@@ -518,7 +559,9 @@ export function useInspectorState({
     urlParams.safeAreaInsets ??
       storedPrefs.safeAreaInsets ?? { top: 0, bottom: 0, left: 0, right: 0 }
   );
-  const [timeZone, setTimeZone] = useState(() => Intl.DateTimeFormat().resolvedOptions().timeZone);
+  const [timeZone, setTimeZone] = useState(
+    () => storedPrefs.timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone
+  );
 
   // Skip persisting on the first render — only write when the user actually changes something.
   const isFirstRender = useRef(true);
@@ -528,31 +571,32 @@ export function useInspectorState({
       return;
     }
     if (autoRun) return;
-    try {
-      const prefs: StoredPrefs = {
-        theme,
-        locale,
-        displayMode,
-        containerMaxHeight,
-        containerMaxWidth,
-        safeAreaInsets,
-        activeHost,
-        platform,
-        hover,
-        touch,
-        screenWidth,
-        sidebarWidth,
-        rightSidebarWidth,
-      };
-      localStorage.setItem(PREFS_KEY, JSON.stringify(prefs));
-    } catch {
-      // localStorage may be unavailable (private browsing, storage quota) — ignore
-    }
+    writeStoredPrefs({
+      ...readStoredPrefs(),
+      theme,
+      locale,
+      displayMode,
+      containerHeight,
+      containerWidth,
+      containerMaxHeight,
+      containerMaxWidth,
+      safeAreaInsets,
+      activeHost,
+      platform,
+      hover,
+      touch,
+      screenWidth,
+      sidebarWidth,
+      rightSidebarWidth,
+      timeZone,
+    });
   }, [
     autoRun,
     theme,
     locale,
     displayMode,
+    containerHeight,
+    containerWidth,
     containerMaxHeight,
     containerMaxWidth,
     safeAreaInsets,
@@ -563,6 +607,7 @@ export function useInspectorState({
     screenWidth,
     sidebarWidth,
     rightSidebarWidth,
+    timeZone,
   ]);
 
   // Content width measured from the conversation component's ResizeObserver.

--- a/packages/sunpeak/tests/e2e/inspector-modes.spec.ts
+++ b/packages/sunpeak/tests/e2e/inspector-modes.spec.ts
@@ -415,7 +415,7 @@ for (const host of hosts) {
 
       expect(requestBody).toMatchObject({
         provider: 'openai',
-        modelId: 'gpt-4o',
+        modelId: 'gpt-5.5',
         messages: [{ role: 'user', content: prompt }],
       });
 
@@ -729,7 +729,7 @@ test.describe('Model Chat API Keys', () => {
     await expect(page.locator('input[name="userInput"]').last()).toBeDisabled();
     await expect(page.locator('input[name="userInput"]').last()).toHaveAttribute(
       'placeholder',
-      'Add an API key to chat with gpt-4o'
+      'Add an API key to chat with gpt-5.5'
     );
 
     expect(keyRequests).toEqual([


### PR DESCRIPTION
## Summary
- Persist Model Chat provider/model plus related inspector sidebar preferences in local storage
- Keep preference writes merged so host context and Model Chat settings do not erase each other
- Update the default OpenAI Model Chat model to gpt-5.5 and cover persistence/default behavior in unit and E2E tests

## Validation
- pnpm --filter sunpeak validate