### PR TITLE
Fix model chat schemas and reset control

### DIFF
--- a/packages/sunpeak/bin/commands/inspect.mjs
+++ b/packages/sunpeak/bin/commands/inspect.mjs
@@ -1363,9 +1363,43 @@ function toolRendersApp(tool) {
   return !!(tool?._meta?.ui?.resourceUri ?? tool?._meta?.['ui/resourceUri']);
 }
 
-function sanitizeAiSdkSchema(schema) {
-  const clean = { ...(schema || { type: 'object', properties: {} }) };
+function sanitizeAiSdkSchemaNode(schema) {
+  if (Array.isArray(schema)) {
+    return schema.map((item) => sanitizeAiSdkSchemaNode(item));
+  }
+  if (!schema || typeof schema !== 'object') return schema;
+
+  const clean = { ...schema };
   delete clean.$schema;
+  if (
+    clean.properties &&
+    typeof clean.properties === 'object' &&
+    !Array.isArray(clean.properties)
+  ) {
+    clean.properties = Object.fromEntries(
+      Object.entries(clean.properties).map(([key, value]) => [
+        key,
+        sanitizeAiSdkSchemaNode(value),
+      ])
+    );
+  }
+  if (clean.items !== undefined) {
+    clean.items = sanitizeAiSdkSchemaNode(clean.items);
+  }
+  for (const key of ['anyOf', 'allOf', 'oneOf']) {
+    if (Array.isArray(clean[key])) {
+      clean[key] = clean[key].map((item) => sanitizeAiSdkSchemaNode(item));
+    }
+  }
+
+  const isObjectSchema = clean.type === 'object' || clean.properties != null;
+  if (isObjectSchema) {
+    if (!clean.type) clean.type = 'object';
+    if (!clean.properties) clean.properties = {};
+    clean.additionalProperties = false;
+    return clean;
+  }
+
   if (
     clean.additionalProperties != null &&
     typeof clean.additionalProperties === 'object' &&
@@ -1373,8 +1407,14 @@ function sanitizeAiSdkSchema(schema) {
   ) {
     delete clean.additionalProperties;
   }
+  return clean;
+}
+
+export function sanitizeAiSdkSchema(schema) {
+  const clean = sanitizeAiSdkSchemaNode(schema || { type: 'object', properties: {} });
   if (!clean.type) clean.type = 'object';
   if (!clean.properties) clean.properties = {};
+  clean.additionalProperties = false;
   return clean;
 }
 
@@ -1421,9 +1461,10 @@ async function createModelInstance(provider, modelId, apiKey) {
   if (provider === 'openai') {
     const { createOpenAI } = await import('@ai-sdk/openai');
     const openai = createOpenAI({ apiKey });
+    const settings = { structuredOutputs: false };
     return typeof openai.chat === 'function'
-      ? openai.chat(normalizedModelId)
-      : openai(normalizedModelId);
+      ? openai.chat(normalizedModelId, settings)
+      : openai(normalizedModelId, settings);
   }
   const { createAnthropic } = await import('@ai-sdk/anthropic');
   return createAnthropic({ apiKey })(normalizedModelId);

--- a/packages/sunpeak/bin/lib/eval/model-registry.mjs
+++ b/packages/sunpeak/bin/lib/eval/model-registry.mjs
@@ -47,9 +47,12 @@ export async function resolveModel(modelId) {
     // @ai-sdk/openai v3 defaults to the Responses API, which requires strict
     // JSON Schema (additionalProperties: false at every level, all properties
     // required) — incompatible with arbitrary MCP server schemas. Use .chat()
-    // (Chat Completions API) when available. v1/v2 default to Chat Completions
-    // already and may not have .chat(), so fall back to the default.
-    return typeof openai.chat === 'function' ? openai.chat(modelId) : openai(modelId);
+    // (Chat Completions API) when available and disable structured outputs,
+    // because reasoning models also enable strict function schemas by default.
+    const settings = { structuredOutputs: false };
+    return typeof openai.chat === 'function'
+      ? openai.chat(modelId, settings)
+      : openai(modelId, settings);
   }
   if (pkg === '@ai-sdk/anthropic') {
     const { anthropic } = provider;

--- a/packages/sunpeak/src/cli/inspect.test.ts
+++ b/packages/sunpeak/src/cli/inspect.test.ts
@@ -905,6 +905,62 @@ describe('resolveMcpResourceMetadataUrl', () => {
 });
 
 describe('inspect CLI', () => {
+  describe('sanitizeAiSdkSchema', () => {
+    it('closes object schemas for OpenAI function tool compatibility', async () => {
+      const { sanitizeAiSdkSchema } = await import('../../bin/commands/inspect.mjs');
+
+      expect(
+        sanitizeAiSdkSchema({
+          $schema: 'https://json-schema.org/draft/2020-12/schema',
+          type: 'object',
+          required: ['title'],
+          properties: {
+            title: { type: 'string' },
+            metadata: {
+              type: 'object',
+              properties: {
+                owner: { type: 'string' },
+              },
+            },
+            files: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  path: { type: 'string' },
+                },
+              },
+            },
+          },
+        })
+      ).toEqual({
+        type: 'object',
+        required: ['title'],
+        additionalProperties: false,
+        properties: {
+          title: { type: 'string' },
+          metadata: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              owner: { type: 'string' },
+            },
+          },
+          files: {
+            type: 'array',
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                path: { type: 'string' },
+              },
+            },
+          },
+        },
+      });
+    });
+  });
+
   describe('parseArgs (tested via inspect function behavior)', () => {
     it('should parse --server flag', async () => {
       // We'll test parseArgs logic by checking the inspect function rejects

--- a/packages/sunpeak/src/eval/eval.test.ts
+++ b/packages/sunpeak/src/eval/eval.test.ts
@@ -435,6 +435,17 @@ describe('model registry', () => {
     }
   });
 
+  it('disables OpenAI structured outputs for reasoning model tool schemas', async () => {
+    const mod = await importRegistry();
+    const result = await mod.resolveModel('gpt-5.5').catch((e: Error) => e);
+    if (result instanceof Error) {
+      expect(result.message).toContain('@ai-sdk/openai');
+    } else {
+      expect(result).toHaveProperty('modelId', 'gpt-5.5');
+      expect(result.settings).toMatchObject({ structuredOutputs: false });
+    }
+  });
+
   it('routes claude- models to anthropic', async () => {
     const mod = await importRegistry();
     const result = await mod.resolveModel('claude-sonnet-4-20250514').catch((e: Error) => e);

--- a/packages/sunpeak/src/inspector/inspector.test.tsx
+++ b/packages/sunpeak/src/inspector/inspector.test.tsx
@@ -1499,6 +1499,9 @@ describe('Inspector', () => {
       );
 
       const resetButton = screen.getByRole('button', { name: 'Reset model conversation' });
+      expect(resetButton).toHaveAttribute('title', 'Reset conversation');
+      expect(resetButton).toHaveClass('cursor-pointer');
+      expect(screen.getByRole('tooltip')).toHaveTextContent('Reset conversation');
       expect(resetButton).toBeDisabled();
 
       const composer = document.querySelector<HTMLInputElement>('input[name="userInput"]')!;

--- a/packages/sunpeak/src/inspector/inspector.tsx
+++ b/packages/sunpeak/src/inspector/inspector.tsx
@@ -2051,40 +2051,41 @@ export function Inspector({
                         />
                       )}
                     </SidebarControl>
-                    <div className="space-y-1">
-                      <span
-                        className="block text-[10px] font-medium leading-tight opacity-0"
-                        aria-hidden="true"
-                      >
-                        Reset
-                      </span>
+                    <div className="group relative flex h-7 items-center self-end">
                       <button
                         type="button"
                         onClick={handleResetModelConversation}
                         disabled={chatMessages.length === 0 && !isChatting && !chatStatus}
                         aria-label="Reset model conversation"
-                        title="Reset model conversation"
-                        className="flex h-7 w-7 items-center justify-center rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+                        aria-describedby="reset-model-conversation-tooltip"
+                        title="Reset conversation"
+                        className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-40"
                         style={{
                           backgroundColor: 'var(--color-background-primary)',
                           color: 'var(--color-text-primary)',
                         }}
                       >
                         <svg
-                          width="14"
-                          height="14"
+                          width="18"
+                          height="18"
                           viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
+                          fill="currentColor"
                           aria-hidden="true"
                         >
-                          <path d="M21 12a9 9 0 1 1-2.64-6.36" />
-                          <path d="M21 3v7h-7" />
+                          <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-8 3.58-8 8s3.58 8 8 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h8V3z" />
                         </svg>
                       </button>
+                      <span
+                        id="reset-model-conversation-tooltip"
+                        role="tooltip"
+                        className="pointer-events-none absolute right-0 top-full z-[1000] mt-1 hidden whitespace-nowrap rounded px-2 py-1 text-[11px] font-normal leading-tight group-focus-within:block group-hover:block"
+                        style={{
+                          backgroundColor: 'var(--color-text-primary)',
+                          color: 'var(--color-background-primary)',
+                        }}
+                      >
+                        Reset conversation
+                      </span>
                     </div>
                   </div>
                   {usesApiKeyUi && (


### PR DESCRIPTION
## Summary
- Fix Model Chat tool schema handling for OpenAI reasoning models and nested object schemas.
- Update the Model Chat reset button tooltip, cursor, alignment, and icon.
- Add regression tests for schema sanitization, OpenAI model settings, and the reset tooltip.

## Tests
- pnpm --filter sunpeak test -- src/cli/inspect.test.ts
- pnpm --filter sunpeak test -- src/eval/eval.test.ts
- pnpm --filter sunpeak test -- src/inspector/inspector.test.tsx
- pnpm --filter sunpeak lint
- pnpm --filter sunpeak typecheck