### PR TITLE
Support multiple simulations per tool

### DIFF
--- a/packages/sunpeak/bin/commands/inspect.mjs
+++ b/packages/sunpeak/bin/commands/inspect.mjs
@@ -906,43 +906,66 @@ async function discoverSimulations(client) {
 
 /**
  * Load simulation JSON fixtures from a directory and merge into discovered simulations.
+ *
+ * Each fixture becomes a simulation keyed by its filename, so a tool can have
+ * multiple fixtures (e.g. `show-albums.json` and `show-albums-empty.json`
+ * both targeting tool `show-albums`). Auto-discovered slots are kept only for
+ * tools that have no fixture file.
+ *
  * @param {string} dir - Simulation directory path
  * @param {Record<string, object>} simulations - Discovered simulations to merge into
  */
-function mergeSimulationFixtures(dir, simulations) {
+export function mergeSimulationFixtures(dir, simulations) {
   if (!existsSync(dir)) return;
 
   const files = readdirSync(dir).filter((f) => f.endsWith('.json'));
+
+  // Load every fixture first so we can group by tool name. We need the grouping
+  // to decide whether to keep the auto-discovered slot (no fixtures) or replace
+  // it with one entry per fixture file (one or more fixtures).
+  const fixtures = [];
   for (const file of files) {
     try {
       const fixture = JSON.parse(readFileSync(join(dir, file), 'utf-8'));
-      const toolName = fixture.tool;
-      if (!toolName) continue;
-
-      // Find matching simulation by tool name
-      const sim = simulations[toolName];
-      if (sim) {
-        // Merge fixture data into discovered simulation
-        if (fixture.toolInput !== undefined) sim.toolInput = fixture.toolInput;
-        if (fixture.toolResult !== undefined) sim.toolResult = fixture.toolResult;
-        if (fixture.serverTools !== undefined) sim.serverTools = fixture.serverTools;
-        if (fixture.userMessage !== undefined) sim.userMessage = fixture.userMessage;
-        if (fixture.hostContext !== undefined) sim.hostContext = fixture.hostContext;
-      } else {
-        // Create a new simulation from the fixture (tool not on server, but user wants to mock it)
-        const simName = file.replace(/\.json$/, '');
-        simulations[simName] = {
-          name: simName,
-          tool: { name: toolName, inputSchema: { type: 'object' } },
-          toolInput: fixture.toolInput,
-          toolResult: fixture.toolResult,
-          serverTools: fixture.serverTools,
-          userMessage: fixture.userMessage,
-          hostContext: fixture.hostContext,
-        };
-      }
+      if (!fixture.tool) continue;
+      fixtures.push({ file, fixture });
     } catch (err) {
       console.warn(`Warning: Failed to parse simulation fixture ${file}:`, err.message);
+    }
+  }
+
+  const byTool = new Map();
+  for (const item of fixtures) {
+    const tool = item.fixture.tool;
+    if (!byTool.has(tool)) byTool.set(tool, []);
+    byTool.get(tool).push(item);
+  }
+
+  for (const [toolName, items] of byTool) {
+    const discovered = simulations[toolName];
+
+    // Drop the auto-discovered slot if none of the fixtures will reuse its
+    // key (filename === tool name). Otherwise the named fixture overwrites
+    // it in place below.
+    const reusesSlot = items.some(({ file }) => file.replace(/\.json$/, '') === toolName);
+    if (discovered && !reusesSlot) {
+      delete simulations[toolName];
+    }
+
+    for (const { file, fixture } of items) {
+      const simName = file.replace(/\.json$/, '');
+      const sim = discovered
+        ? { ...discovered, name: simName }
+        : {
+            name: simName,
+            tool: { name: toolName, inputSchema: { type: 'object' } },
+          };
+      if (fixture.toolInput !== undefined) sim.toolInput = fixture.toolInput;
+      if (fixture.toolResult !== undefined) sim.toolResult = fixture.toolResult;
+      if (fixture.serverTools !== undefined) sim.serverTools = fixture.serverTools;
+      if (fixture.userMessage !== undefined) sim.userMessage = fixture.userMessage;
+      if (fixture.hostContext !== undefined) sim.hostContext = fixture.hostContext;
+      simulations[simName] = sim;
     }
   }
 }

--- a/packages/sunpeak/src/cli/inspect.test.ts
+++ b/packages/sunpeak/src/cli/inspect.test.ts
@@ -977,6 +977,11 @@ describe('inspect CLI', () => {
   describe('mergeSimulationFixtures', () => {
     const tmpDir = path.join(process.cwd(), '.test-simulations-' + Date.now());
 
+    const loadMerge = async () => {
+      const mod = await import('../../bin/commands/inspect.mjs');
+      return mod.mergeSimulationFixtures;
+    };
+
     beforeEach(() => {
       fs.mkdirSync(tmpDir, { recursive: true });
     });
@@ -985,8 +990,7 @@ describe('inspect CLI', () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     });
 
-    it('should merge fixture toolInput into existing simulation', () => {
-      // Write a fixture
+    it('merges fixture toolInput into the discovered simulation', async () => {
       fs.writeFileSync(
         path.join(tmpDir, 'search.json'),
         JSON.stringify({
@@ -996,7 +1000,6 @@ describe('inspect CLI', () => {
         })
       );
 
-      // Simulate discovered simulations
       const simulations = {
         search: {
           name: 'search',
@@ -1004,23 +1007,14 @@ describe('inspect CLI', () => {
         },
       };
 
-      // Manually run merge logic (same as inspect.mjs mergeSimulationFixtures)
-      const files = fs.readdirSync(tmpDir).filter((f) => f.endsWith('.json'));
-      for (const file of files) {
-        const fixture = JSON.parse(fs.readFileSync(path.join(tmpDir, file), 'utf-8'));
-        const sim = simulations[fixture.tool];
-        if (sim) {
-          if (fixture.toolInput !== undefined) sim.toolInput = fixture.toolInput;
-          if (fixture.toolResult !== undefined) sim.toolResult = fixture.toolResult;
-          if (fixture.userMessage !== undefined) sim.userMessage = fixture.userMessage;
-        }
-      }
+      const mergeSimulationFixtures = await loadMerge();
+      mergeSimulationFixtures(tmpDir, simulations);
 
       expect(simulations.search.toolInput).toEqual({ query: 'headphones' });
       expect(simulations.search.userMessage).toBe('Find headphones');
     });
 
-    it('should create new simulation from fixture when tool not on server', () => {
+    it('creates a simulation from a fixture when the tool is not on the server', async () => {
       fs.writeFileSync(
         path.join(tmpDir, 'mock-tool.json'),
         JSON.stringify({
@@ -1031,22 +1025,8 @@ describe('inspect CLI', () => {
       );
 
       const simulations = {};
-
-      const files = fs.readdirSync(tmpDir).filter((f) => f.endsWith('.json'));
-      for (const file of files) {
-        const fixture = JSON.parse(fs.readFileSync(path.join(tmpDir, file), 'utf-8'));
-        const toolName = fixture.tool;
-        const sim = simulations[toolName];
-        if (!sim) {
-          const simName = file.replace(/\.json$/, '');
-          simulations[simName] = {
-            name: simName,
-            tool: { name: toolName, inputSchema: { type: 'object' } },
-            toolInput: fixture.toolInput,
-            toolResult: fixture.toolResult,
-          };
-        }
-      }
+      const mergeSimulationFixtures = await loadMerge();
+      mergeSimulationFixtures(tmpDir, simulations);
 
       expect(simulations['mock-tool']).toBeDefined();
       expect(simulations['mock-tool'].tool.name).toBe('mock-tool');
@@ -1056,32 +1036,91 @@ describe('inspect CLI', () => {
       });
     });
 
-    it('should skip non-JSON files', () => {
-      fs.writeFileSync(path.join(tmpDir, 'readme.md'), '# Test');
-      fs.writeFileSync(
-        path.join(tmpDir, 'valid.json'),
-        JSON.stringify({ tool: 'valid', toolInput: { x: 1 } })
-      );
-
-      const files = fs.readdirSync(tmpDir).filter((f) => f.endsWith('.json'));
-      expect(files).toHaveLength(1);
-      expect(files[0]).toBe('valid.json');
-    });
-
-    it('should skip fixtures without tool field', () => {
+    it('skips fixtures without a tool field', async () => {
       fs.writeFileSync(path.join(tmpDir, 'no-tool.json'), JSON.stringify({ toolInput: { x: 1 } }));
 
       const simulations = {};
-
-      const files = fs.readdirSync(tmpDir).filter((f) => f.endsWith('.json'));
-      for (const file of files) {
-        const fixture = JSON.parse(fs.readFileSync(path.join(tmpDir, file), 'utf-8'));
-        const toolName = fixture.tool;
-        if (!toolName) continue;
-        simulations[toolName] = { name: toolName };
-      }
+      const mergeSimulationFixtures = await loadMerge();
+      mergeSimulationFixtures(tmpDir, simulations);
 
       expect(Object.keys(simulations)).toHaveLength(0);
+    });
+
+    it('keeps every fixture when multiple files target the same tool', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'show-albums.json'),
+        JSON.stringify({
+          tool: 'show-albums',
+          toolResult: { structuredContent: { albums: ['a', 'b'] } },
+        })
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, 'show-albums-empty.json'),
+        JSON.stringify({
+          tool: 'show-albums',
+          toolResult: { structuredContent: { albums: [] } },
+        })
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, 'show-albums-error.json'),
+        JSON.stringify({
+          tool: 'show-albums',
+          toolResult: { isError: true, content: [{ type: 'text', text: 'boom' }] },
+        })
+      );
+
+      const simulations = {
+        'show-albums': {
+          name: 'show-albums',
+          tool: { name: 'show-albums', inputSchema: { type: 'object' } },
+          resource: { uri: 'ui://albums', name: 'albums' },
+        },
+      };
+
+      const mergeSimulationFixtures = await loadMerge();
+      mergeSimulationFixtures(tmpDir, simulations);
+
+      expect(Object.keys(simulations).sort()).toEqual([
+        'show-albums',
+        'show-albums-empty',
+        'show-albums-error',
+      ]);
+      expect(simulations['show-albums'].toolResult).toEqual({
+        structuredContent: { albums: ['a', 'b'] },
+      });
+      expect(simulations['show-albums-empty'].toolResult).toEqual({
+        structuredContent: { albums: [] },
+      });
+      expect(simulations['show-albums-error'].toolResult.isError).toBe(true);
+      // Each derived sim inherits the discovered tool + resource metadata.
+      for (const name of ['show-albums', 'show-albums-empty', 'show-albums-error']) {
+        expect(simulations[name].tool.name).toBe('show-albums');
+        expect(simulations[name].resource).toEqual({ uri: 'ui://albums', name: 'albums' });
+      }
+    });
+
+    it('drops the auto-discovered slot when no fixture file reuses its name', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'show-albums-empty.json'),
+        JSON.stringify({
+          tool: 'show-albums',
+          toolResult: { structuredContent: { albums: [] } },
+        })
+      );
+
+      const simulations = {
+        'show-albums': {
+          name: 'show-albums',
+          tool: { name: 'show-albums', inputSchema: { type: 'object' } },
+        },
+      };
+
+      const mergeSimulationFixtures = await loadMerge();
+      mergeSimulationFixtures(tmpDir, simulations);
+
+      // The lone fixture takes over; no empty `show-albums` slot is left behind.
+      expect(Object.keys(simulations)).toEqual(['show-albums-empty']);
+      expect(simulations['show-albums-empty'].tool.name).toBe('show-albums');
     });
   });
 });

--- a/packages/sunpeak/src/mcp/server.test.ts
+++ b/packages/sunpeak/src/mcp/server.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import path from 'node:path';
 import fs from 'node:fs';
+import { createAppServer } from './server.js';
+import type { SimulationWithDist } from './types.js';
 
 describe('MCP Server Module', () => {
   it('validates that readToolHtml would need an existing file', () => {
@@ -85,5 +87,40 @@ describe('Dev overlay format contract', () => {
     expect('0.3ms').toMatch(/^\d+(\.\d)?ms$/);
     expect('143ms').toMatch(/^\d+(\.\d)?ms$/);
     expect('12.5ms').toMatch(/^\d+(\.\d)?ms$/);
+  });
+});
+
+describe('createAppServer', () => {
+  function makeUiSim(name: string, toolResult: unknown): SimulationWithDist {
+    return {
+      name,
+      distPath: '/tmp/sunpeak-test-not-read-at-registration.html',
+      tool: { name: 'show-albums', inputSchema: { type: 'object' } },
+      resource: {
+        name: 'albums',
+        uri: 'ui://albums',
+        mimeType: 'text/html',
+      },
+      toolResult: toolResult as SimulationWithDist['toolResult'],
+    };
+  }
+
+  it('registers a UI tool once even when multiple simulations target it', () => {
+    const simulations: SimulationWithDist[] = [
+      makeUiSim('show-albums', { structuredContent: { albums: ['a'] } }),
+      makeUiSim('show-albums-empty', { structuredContent: { albums: [] } }),
+      makeUiSim('show-albums-error', {
+        isError: true,
+        content: [{ type: 'text', text: 'boom' }],
+      }),
+    ];
+
+    // Before the dedup fix this threw because the MCP SDK rejects duplicate
+    // tool registrations.
+    const result = createAppServer({ simulations }, simulations, false);
+
+    expect(result.toolHandles).toHaveLength(1);
+    expect(result.toolHandles[0].resourceName).toBe('albums');
+    expect(result.resourceHandles.has('albums')).toBe(true);
   });
 });

--- a/packages/sunpeak/src/mcp/server.ts
+++ b/packages/sunpeak/src/mcp/server.ts
@@ -268,7 +268,7 @@ function makeSchemaOptional(shape: Record<string, unknown>): Record<string, unkn
   return optional;
 }
 
-function createAppServer(
+export function createAppServer(
   config: MCPServerConfig,
   simulations: SimulationWithDist[],
   viteMode: boolean
@@ -393,6 +393,16 @@ function createAppServer(
         );
         resourceHandles.set(resourceName, handle);
       }
+
+      // Multiple simulations can share a UI tool (e.g. show-albums + show-albums-empty
+      // exercise different fixture states). The MCP SDK rejects duplicate tool
+      // registrations, so register each tool name once — later sims still share
+      // the same resource (deduped above) and the inspector renders their
+      // fixture data from the simulation JSON, not from the registered handler.
+      if (registeredToolNames.has(tool.name as string)) {
+        continue;
+      }
+      registeredToolNames.add(tool.name as string);
 
       // Register the tool using ext-apps helper (normalizes ui/resourceUri metadata).
       // Capture the returned RegisteredTool handle for metadata updates on rebuild.
@@ -555,10 +565,10 @@ function createAppServer(
     }
   }
 
-  const uiToolCount = simulations.filter((s) => s.resource).length;
-  const plainToolCount = simulations.length - uiToolCount;
+  const uiToolCount = toolHandles.length;
+  const plainToolCount = registeredToolNames.size - uiToolCount;
   console.log(
-    `[MCP] Registered ${simulations.length} tool(s) (${uiToolCount} UI, ${plainToolCount} plain), ${registeredUriSet.size} resource(s)`
+    `[MCP] Registered ${registeredToolNames.size} tool(s) (${uiToolCount} UI, ${plainToolCount} plain), ${registeredUriSet.size} resource(s)`
   );
 
   return { server: mcpServer, resourceHandles, toolHandles };


### PR DESCRIPTION
The docs already advertise multiple `.json` fixtures targeting the same tool (e.g. `show-albums.json` + `show-albums-empty.json`), but in practice only the last one survived: `mergeSimulationFixtures` looked sims up by `tool` name and overwrote, and the dev MCP server registered the same UI tool twice and only showed the last registry.

- `mergeSimulationFixtures`: group fixtures by tool. When a tool has multiple fixtures, drop the auto-discovered slot (unless one fixture's filename matches the tool) and key each entry by its filename. Single-fixture flow is unchanged.
- `createAppServer`: skip duplicate UI tool registrations the same way plain tools already do. First simulation's `toolResult` is used for the fallback mock.
- Tests: covered both via the existing inspect + mcp test files; `mergeSimulationFixtures` is now exported so tests call the real function instead of inlining the logic.