### PR TITLE
Pre-register useToolData handlers before connect()

### DIFF
--- a/packages/sunpeak/src/hooks/app-context.tsx
+++ b/packages/sunpeak/src/hooks/app-context.tsx
@@ -15,6 +15,7 @@
  */
 import { createContext, useState, useEffect, type ReactNode } from 'react';
 import { App, PostMessageTransport } from '@modelcontextprotocol/ext-apps';
+import { initToolDataStore } from './tool-data-store';
 
 export interface AppProviderProps {
   appInfo: { name: string; version: string };
@@ -89,6 +90,12 @@ async function connectWithRetry(
     try {
       transport = new PostMessageTransport(window.parent, window.parent);
       const newApp = new App(appInfo, capabilities);
+      // Pre-register useToolData's notification handlers BEFORE connect()
+      // runs the ui/initialize handshake. Hosts that fire
+      // `ui/notifications/tool-result` immediately after the initialize
+      // response (ChatGPT on production Safari) would otherwise race the
+      // first React commit and drop the result. See tool-data-store.ts.
+      initToolDataStore(newApp);
       onAppCreated?.(newApp);
       await withTimeout(newApp.connect(transport), CONNECT_TIMEOUT_MS);
       return newApp;

--- a/packages/sunpeak/src/hooks/tool-data-store.test.ts
+++ b/packages/sunpeak/src/hooks/tool-data-store.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import type { App } from '@modelcontextprotocol/ext-apps';
+import { initToolDataStore } from './tool-data-store';
+
+// Minimal fake App: only the four setter properties initToolDataStore touches
+// plus the `__toolDataStore` slot the module augmentation declares.
+function fakeApp(): App {
+  const obj: Record<string, unknown> = {};
+  return obj as unknown as App;
+}
+
+describe('initToolDataStore', () => {
+  it('attaches a store with the loading initial state', () => {
+    const app = fakeApp();
+    const store = initToolDataStore(app);
+
+    expect(store).toBe(app.__toolDataStore);
+    expect(store.data).toEqual({
+      input: null,
+      inputPartial: null,
+      output: null,
+      isError: false,
+      isLoading: true,
+      isCancelled: false,
+      cancelReason: null,
+    });
+  });
+
+  it('is idempotent — second call returns the same store and does not rewire handlers', () => {
+    const app = fakeApp();
+    const first = initToolDataStore(app);
+    const originalOnToolResult = app.ontoolresult;
+    const second = initToolDataStore(app);
+
+    expect(second).toBe(first);
+    expect(app.ontoolresult).toBe(originalOnToolResult);
+  });
+
+  it('updates the store and notifies listeners when ontoolresult fires before any consumer renders', () => {
+    // Reproduces the production race: handler is invoked between the
+    // ui/initialize response and the first React commit. useToolData never
+    // got a chance to wire its listener yet — but when it eventually
+    // subscribes, the store should already hold the result.
+    const app = fakeApp();
+    const store = initToolDataStore(app);
+
+    app.ontoolresult!({
+      structuredContent: { items: [1, 2, 3] },
+      content: [],
+      isError: false,
+    });
+
+    expect(store.data.output).toEqual({ items: [1, 2, 3] });
+    expect(store.data.isLoading).toBe(false);
+    expect(store.data.isError).toBe(false);
+  });
+
+  it('notifies subscribers when a notification updates the store', () => {
+    const app = fakeApp();
+    const store = initToolDataStore(app);
+    let calls = 0;
+    store.listeners.add(() => {
+      calls++;
+    });
+
+    app.ontoolinput!({ arguments: { q: 'hi' } });
+    app.ontoolresult!({ structuredContent: { ok: true }, content: [], isError: false });
+
+    expect(calls).toBe(2);
+    expect(store.data.input).toEqual({ q: 'hi' });
+    expect(store.data.output).toEqual({ ok: true });
+  });
+
+  it('marks the store as cancelled with the reason from ontoolcancelled', () => {
+    const app = fakeApp();
+    const store = initToolDataStore(app);
+
+    app.ontoolcancelled!({ reason: 'user_aborted' });
+
+    expect(store.data.isCancelled).toBe(true);
+    expect(store.data.cancelReason).toBe('user_aborted');
+    expect(store.data.isLoading).toBe(false);
+  });
+
+  it('tracks streaming partials via ontoolinputpartial without clobbering input', () => {
+    const app = fakeApp();
+    const store = initToolDataStore(app);
+
+    app.ontoolinputpartial!({ arguments: { q: 'he' } });
+    expect(store.data.inputPartial).toEqual({ q: 'he' });
+    expect(store.data.input).toBeNull();
+
+    app.ontoolinput!({ arguments: { q: 'hello' } });
+    expect(store.data.input).toEqual({ q: 'hello' });
+    expect(store.data.inputPartial).toBeNull();
+  });
+});

--- a/packages/sunpeak/src/hooks/tool-data-store.ts
+++ b/packages/sunpeak/src/hooks/tool-data-store.ts
@@ -1,0 +1,107 @@
+/**
+ * Tool-data store shared between AppProvider and the useToolData hook.
+ *
+ * AppProvider eagerly creates the store and wires the App's tool-event
+ * handlers BEFORE running the ui/initialize handshake. Without that, hosts
+ * that fire `ui/notifications/tool-result` immediately after the initialize
+ * response (ChatGPT in production Safari is the known offender) race the
+ * React commit that lets <AppProvider> children render and call
+ * `useToolData()` — the lazy registration runs after the host has already
+ * dispatched the notification, the result is dropped, and the widget is
+ * stranded on its loading skeleton forever. sunpeak's own console warning
+ * flagged exactly this:
+ *   "toolresult handler registered after connect() completed the
+ *    ui/initialize handshake".
+ *
+ * `useToolData` still falls back to a lazy WeakMap registration for App
+ * instances created outside `AppProvider` (tests, direct SDK usage).
+ */
+import type { App } from '@modelcontextprotocol/ext-apps';
+
+export interface ToolData<TInput = unknown, TOutput = unknown> {
+  input: TInput | null;
+  inputPartial: TInput | null;
+  output: TOutput | null;
+  isError: boolean;
+  isLoading: boolean;
+  isCancelled: boolean;
+  cancelReason: string | null;
+}
+
+export interface ToolDataStore<TInput = unknown, TOutput = unknown> {
+  data: ToolData<TInput, TOutput>;
+  listeners: Set<() => void>;
+}
+
+declare module '@modelcontextprotocol/ext-apps' {
+  interface App {
+    /** @internal Eager store attached by AppProvider before connect(). */
+    __toolDataStore?: ToolDataStore;
+  }
+}
+
+/**
+ * Initialize the tool-data store on an App instance and wire its
+ * `on*` event handlers. Idempotent — returns the existing store if one is
+ * already attached.
+ */
+export function initToolDataStore(app: App): ToolDataStore {
+  if (app.__toolDataStore) return app.__toolDataStore;
+
+  const store: ToolDataStore = {
+    data: {
+      input: null,
+      inputPartial: null,
+      output: null,
+      isError: false,
+      isLoading: true,
+      isCancelled: false,
+      cancelReason: null,
+    },
+    listeners: new Set(),
+  };
+  app.__toolDataStore = store;
+
+  const notify = () => {
+    for (const fn of store.listeners) fn();
+  };
+
+  app.ontoolinput = (_params) => {
+    store.data = {
+      ...store.data,
+      input: _params.arguments,
+      inputPartial: null,
+    };
+    notify();
+  };
+
+  app.ontoolinputpartial = (_params) => {
+    store.data = {
+      ...store.data,
+      inputPartial: _params.arguments,
+    };
+    notify();
+  };
+
+  app.ontoolresult = (_params) => {
+    store.data = {
+      ...store.data,
+      output: _params.structuredContent ?? _params.content,
+      isError: _params.isError ?? false,
+      isLoading: false,
+    };
+    notify();
+  };
+
+  app.ontoolcancelled = (_params) => {
+    store.data = {
+      ...store.data,
+      isCancelled: true,
+      cancelReason: _params.reason ?? null,
+      isLoading: false,
+    };
+    notify();
+  };
+
+  return store;
+}

--- a/packages/sunpeak/src/hooks/use-tool-data.test.tsx
+++ b/packages/sunpeak/src/hooks/use-tool-data.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { App } from '@modelcontextprotocol/ext-apps';
+import { AppContext } from './app-context';
+import { useToolData } from './use-tool-data';
+import { initToolDataStore } from './tool-data-store';
+import type { ReactNode } from 'react';
+
+function fakeApp(): App {
+  return {} as unknown as App;
+}
+
+function wrapper(app: App | null) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <AppContext.Provider value={{ app, isConnected: !!app, error: null }}>
+        {children}
+      </AppContext.Provider>
+    );
+  };
+}
+
+describe('useToolData eager-store integration', () => {
+  it('picks up a tool result that arrived before the component mounted', () => {
+    const app = fakeApp();
+    initToolDataStore(app);
+    // Host fires the result before any React commit — the bug this PR fixes.
+    app.ontoolresult!({
+      structuredContent: { greeting: 'hello' },
+      content: [],
+      isError: false,
+    });
+
+    const { result } = renderHook(() => useToolData(), {
+      wrapper: wrapper(app),
+    });
+
+    expect(result.current.output).toEqual({ greeting: 'hello' });
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('re-renders when a notification arrives after the component mounted', () => {
+    const app = fakeApp();
+    initToolDataStore(app);
+
+    const { result } = renderHook(() => useToolData(), {
+      wrapper: wrapper(app),
+    });
+
+    expect(result.current.output).toBeNull();
+    expect(result.current.isLoading).toBe(true);
+
+    act(() => {
+      app.ontoolresult!({
+        structuredContent: { greeting: 'late' },
+        content: [],
+        isError: false,
+      });
+    });
+
+    expect(result.current.output).toEqual({ greeting: 'late' });
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('falls back to a lazy WeakMap store when no eager store is attached', () => {
+    // App created outside AppProvider — e.g. in tests or direct SDK usage.
+    const app = fakeApp();
+    expect(app.__toolDataStore).toBeUndefined();
+
+    const { result } = renderHook(() => useToolData(), {
+      wrapper: wrapper(app),
+    });
+
+    expect(result.current.output).toBeNull();
+    expect(result.current.isLoading).toBe(true);
+
+    act(() => {
+      app.ontoolresult!({
+        structuredContent: { lazy: true },
+        content: [],
+        isError: false,
+      });
+    });
+
+    expect(result.current.output).toEqual({ lazy: true });
+  });
+
+  it('applies useToolData defaults to an empty eager store', () => {
+    const app = fakeApp();
+    initToolDataStore(app);
+
+    const { result } = renderHook(
+      () => useToolData<{ q: string }, { items: string[] }>({ q: 'seed' }, { items: ['a'] }),
+      { wrapper: wrapper(app) }
+    );
+
+    expect(result.current.input).toEqual({ q: 'seed' });
+    expect(result.current.output).toEqual({ items: ['a'] });
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/packages/sunpeak/src/hooks/use-tool-data.ts
+++ b/packages/sunpeak/src/hooks/use-tool-data.ts
@@ -1,32 +1,37 @@
 import { useCallback, useMemo, useRef, useSyncExternalStore } from 'react';
 import type { App } from '@modelcontextprotocol/ext-apps';
 import { useApp } from './use-app';
+import { initToolDataStore, type ToolData, type ToolDataStore } from './tool-data-store';
 
-export interface ToolData<TInput = unknown, TOutput = unknown> {
-  input: TInput | null;
-  inputPartial: TInput | null;
-  output: TOutput | null;
-  isError: boolean;
-  isLoading: boolean;
-  isCancelled: boolean;
-  cancelReason: string | null;
-}
+export type { ToolData };
 
-interface ToolDataStore<TInput, TOutput> {
-  data: ToolData<TInput, TOutput>;
-  listeners: Set<() => void>;
-}
-
-const stores = new WeakMap<App, ToolDataStore<unknown, unknown>>();
+const stores = new WeakMap<App, ToolDataStore>();
 
 function getStore<TInput, TOutput>(
   app: App,
   defaultInput?: TInput,
   defaultOutput?: TOutput
 ): ToolDataStore<TInput, TOutput> {
+  // Prefer the eager store created by AppProvider before connect(). Doing so
+  // avoids a race where a host fires `ui/notifications/tool-result` between
+  // the initialize response and the first React commit — see the comment in
+  // tool-data-store.ts for the full background.
+  const eager = app.__toolDataStore as ToolDataStore<TInput, TOutput> | undefined;
+  if (eager) {
+    if (defaultInput !== undefined && eager.data.input === null) {
+      eager.data = { ...eager.data, input: defaultInput };
+    }
+    if (defaultOutput !== undefined && eager.data.output === null) {
+      eager.data = { ...eager.data, output: defaultOutput, isLoading: false };
+    }
+    return eager;
+  }
+
+  // Lazy path for App instances created outside <AppProvider> (tests, direct
+  // SDK usage). Same shape as the eager store, just attached via WeakMap.
   let store = stores.get(app) as ToolDataStore<TInput, TOutput> | undefined;
   if (!store) {
-    store = {
+    const lazy: ToolDataStore<TInput, TOutput> = {
       data: {
         input: defaultInput ?? null,
         inputPartial: null,
@@ -38,15 +43,16 @@ function getStore<TInput, TOutput>(
       },
       listeners: new Set(),
     };
-    stores.set(app, store as ToolDataStore<unknown, unknown>);
+    stores.set(app, lazy as ToolDataStore);
+    store = lazy;
 
     const notify = () => {
-      for (const fn of store!.listeners) fn();
+      for (const fn of lazy.listeners) fn();
     };
 
     app.ontoolinput = (_params) => {
-      store!.data = {
-        ...store!.data,
+      lazy.data = {
+        ...lazy.data,
         input: _params.arguments as TInput,
         inputPartial: null,
       };
@@ -54,16 +60,16 @@ function getStore<TInput, TOutput>(
     };
 
     app.ontoolinputpartial = (_params) => {
-      store!.data = {
-        ...store!.data,
+      lazy.data = {
+        ...lazy.data,
         inputPartial: _params.arguments as TInput,
       };
       notify();
     };
 
     app.ontoolresult = (_params) => {
-      store!.data = {
-        ...store!.data,
+      lazy.data = {
+        ...lazy.data,
         output: (_params.structuredContent ?? _params.content) as TOutput,
         isError: _params.isError ?? false,
         isLoading: false,
@@ -72,8 +78,8 @@ function getStore<TInput, TOutput>(
     };
 
     app.ontoolcancelled = (_params) => {
-      store!.data = {
-        ...store!.data,
+      lazy.data = {
+        ...lazy.data,
         isCancelled: true,
         cancelReason: _params.reason ?? null,
         isLoading: false,
@@ -83,6 +89,10 @@ function getStore<TInput, TOutput>(
   }
   return store;
 }
+
+// Re-export the eager initializer so callers (AppProvider) and tests can
+// pre-register handlers on an App before connect().
+export { initToolDataStore };
 
 /**
  * Reactive access to tool input and output data from the MCP Apps host.


### PR DESCRIPTION
Hosts can fire `ui/notifications/tool-result` between the `ui/initialize` response and the first React commit. The lazy handler registration inside `useToolData`'s `getStore` only runs once `<AppProvider>` children render — so a notification that lands first is dropped and the widget is stranded on its loading skeleton. 

ChatGPT in production Safari hits this consistently; sunpeak's own console warning already flagged it (`"toolresult handler registered after connect() completed the ui/initialize handshake"`).

- `AppProvider` calls `initToolDataStore(newApp)` before `newApp.connect(transport)` so the four `on*` handlers are wired before the handshake.
- Shared store + init logic moves to `hooks/tool-data-store.ts`. `useToolData` prefers the eager store and falls back to its previous lazy WeakMap path for `App` instances created outside `AppProvider` (tests, direct SDK usage).
- `useToolData` defaults still seed the store when it hasn't been populated yet.
