### PR TITLE
Fix useToolData event handler composition

### DIFF
--- a/packages/sunpeak/src/hooks/tool-data-store.test.ts
+++ b/packages/sunpeak/src/hooks/tool-data-store.test.ts
@@ -2,11 +2,33 @@ import { describe, it, expect } from 'vitest';
 import type { App } from '@modelcontextprotocol/ext-apps';
 import { initToolDataStore } from './tool-data-store';
 
-// Minimal fake App: only the four setter properties initToolDataStore touches
-// plus the `__toolDataStore` slot the module augmentation declares.
-function fakeApp(): App {
-  const obj: Record<string, unknown> = {};
-  return obj as unknown as App;
+type ToolEvent = 'toolinput' | 'toolinputpartial' | 'toolresult' | 'toolcancelled';
+type FakeApp = App & {
+  emit: (type: ToolEvent, params: Record<string, unknown>) => void;
+  listenerCount: (type: ToolEvent) => number;
+};
+
+function fakeApp(): FakeApp {
+  const listeners = new Map<ToolEvent, Set<(params: Record<string, unknown>) => void>>();
+  const obj: Record<string, unknown> = {
+    addEventListener(type: ToolEvent, fn: (params: Record<string, unknown>) => void) {
+      const set = listeners.get(type) ?? new Set();
+      set.add(fn);
+      listeners.set(type, set);
+    },
+    removeEventListener(type: ToolEvent, fn: (params: Record<string, unknown>) => void) {
+      listeners.get(type)?.delete(fn);
+    },
+    emit(type: ToolEvent, params: Record<string, unknown>) {
+      for (const fn of listeners.get(type) ?? []) fn(params);
+      const handler = obj[`on${type}`];
+      if (typeof handler === 'function') handler(params);
+    },
+    listenerCount(type: ToolEvent) {
+      return listeners.get(type)?.size ?? 0;
+    },
+  };
+  return obj as unknown as FakeApp;
 }
 
 describe('initToolDataStore', () => {
@@ -26,17 +48,18 @@ describe('initToolDataStore', () => {
     });
   });
 
-  it('is idempotent — second call returns the same store and does not rewire handlers', () => {
+  it('is idempotent - second call returns the same store and does not rewire listeners', () => {
     const app = fakeApp();
     const first = initToolDataStore(app);
-    const originalOnToolResult = app.ontoolresult;
+    expect(app.listenerCount('toolresult')).toBe(1);
+
     const second = initToolDataStore(app);
 
     expect(second).toBe(first);
-    expect(app.ontoolresult).toBe(originalOnToolResult);
+    expect(app.listenerCount('toolresult')).toBe(1);
   });
 
-  it('updates the store and notifies listeners when ontoolresult fires before any consumer renders', () => {
+  it('updates the store and notifies listeners when toolresult fires before any consumer renders', () => {
     // Reproduces the production race: handler is invoked between the
     // ui/initialize response and the first React commit. useToolData never
     // got a chance to wire its listener yet — but when it eventually
@@ -44,7 +67,7 @@ describe('initToolDataStore', () => {
     const app = fakeApp();
     const store = initToolDataStore(app);
 
-    app.ontoolresult!({
+    app.emit('toolresult', {
       structuredContent: { items: [1, 2, 3] },
       content: [],
       isError: false,
@@ -63,8 +86,8 @@ describe('initToolDataStore', () => {
       calls++;
     });
 
-    app.ontoolinput!({ arguments: { q: 'hi' } });
-    app.ontoolresult!({ structuredContent: { ok: true }, content: [], isError: false });
+    app.emit('toolinput', { arguments: { q: 'hi' } });
+    app.emit('toolresult', { structuredContent: { ok: true }, content: [], isError: false });
 
     expect(calls).toBe(2);
     expect(store.data.input).toEqual({ q: 'hi' });
@@ -75,7 +98,7 @@ describe('initToolDataStore', () => {
     const app = fakeApp();
     const store = initToolDataStore(app);
 
-    app.ontoolcancelled!({ reason: 'user_aborted' });
+    app.emit('toolcancelled', { reason: 'user_aborted' });
 
     expect(store.data.isCancelled).toBe(true);
     expect(store.data.cancelReason).toBe('user_aborted');
@@ -86,12 +109,29 @@ describe('initToolDataStore', () => {
     const app = fakeApp();
     const store = initToolDataStore(app);
 
-    app.ontoolinputpartial!({ arguments: { q: 'he' } });
+    app.emit('toolinputpartial', { arguments: { q: 'he' } });
     expect(store.data.inputPartial).toEqual({ q: 'he' });
     expect(store.data.input).toBeNull();
 
-    app.ontoolinput!({ arguments: { q: 'hello' } });
+    app.emit('toolinput', { arguments: { q: 'hello' } });
     expect(store.data.input).toEqual({ q: 'hello' });
     expect(store.data.inputPartial).toBeNull();
+  });
+
+  it('keeps receiving events when a user assigns an ontoolresult handler', () => {
+    const app = fakeApp();
+    const store = initToolDataStore(app);
+    let userResult: Record<string, unknown> | undefined;
+
+    app.ontoolresult = (params) => {
+      userResult = params as Record<string, unknown>;
+    };
+
+    const payload = { structuredContent: { ok: true }, content: [], isError: false };
+    app.emit('toolresult', payload);
+
+    expect(userResult).toBe(payload);
+    expect(store.data.output).toEqual({ ok: true });
+    expect(store.data.isLoading).toBe(false);
   });
 });

--- a/packages/sunpeak/src/hooks/tool-data-store.ts
+++ b/packages/sunpeak/src/hooks/tool-data-store.ts
@@ -2,7 +2,7 @@
  * Tool-data store shared between AppProvider and the useToolData hook.
  *
  * AppProvider eagerly creates the store and wires the App's tool-event
- * handlers BEFORE running the ui/initialize handshake. Without that, hosts
+ * listeners BEFORE running the ui/initialize handshake. Without that, hosts
  * that fire `ui/notifications/tool-result` immediately after the initialize
  * response (ChatGPT in production Safari is the known offender) race the
  * React commit that lets <AppProvider> children render and call
@@ -41,9 +41,9 @@ declare module '@modelcontextprotocol/ext-apps' {
 }
 
 /**
- * Initialize the tool-data store on an App instance and wire its
- * `on*` event handlers. Idempotent — returns the existing store if one is
- * already attached.
+ * Initialize the tool-data store on an App instance and wire its event
+ * listeners. Idempotent - returns the existing store if one is already
+ * attached.
  */
 export function initToolDataStore(app: App): ToolDataStore {
   if (app.__toolDataStore) return app.__toolDataStore;
@@ -66,24 +66,24 @@ export function initToolDataStore(app: App): ToolDataStore {
     for (const fn of store.listeners) fn();
   };
 
-  app.ontoolinput = (_params) => {
+  app.addEventListener('toolinput', (_params) => {
     store.data = {
       ...store.data,
       input: _params.arguments,
       inputPartial: null,
     };
     notify();
-  };
+  });
 
-  app.ontoolinputpartial = (_params) => {
+  app.addEventListener('toolinputpartial', (_params) => {
     store.data = {
       ...store.data,
       inputPartial: _params.arguments,
     };
     notify();
-  };
+  });
 
-  app.ontoolresult = (_params) => {
+  app.addEventListener('toolresult', (_params) => {
     store.data = {
       ...store.data,
       output: _params.structuredContent ?? _params.content,
@@ -91,9 +91,9 @@ export function initToolDataStore(app: App): ToolDataStore {
       isLoading: false,
     };
     notify();
-  };
+  });
 
-  app.ontoolcancelled = (_params) => {
+  app.addEventListener('toolcancelled', (_params) => {
     store.data = {
       ...store.data,
       isCancelled: true,
@@ -101,7 +101,7 @@ export function initToolDataStore(app: App): ToolDataStore {
       isLoading: false,
     };
     notify();
-  };
+  });
 
   return store;
 }

--- a/packages/sunpeak/src/hooks/use-tool-data.test.tsx
+++ b/packages/sunpeak/src/hooks/use-tool-data.test.tsx
@@ -6,8 +6,29 @@ import { useToolData } from './use-tool-data';
 import { initToolDataStore } from './tool-data-store';
 import type { ReactNode } from 'react';
 
-function fakeApp(): App {
-  return {} as unknown as App;
+type ToolEvent = 'toolinput' | 'toolinputpartial' | 'toolresult' | 'toolcancelled';
+type FakeApp = App & {
+  emit: (type: ToolEvent, params: Record<string, unknown>) => void;
+};
+
+function fakeApp(): FakeApp {
+  const listeners = new Map<ToolEvent, Set<(params: Record<string, unknown>) => void>>();
+  const obj: Record<string, unknown> = {
+    addEventListener(type: ToolEvent, fn: (params: Record<string, unknown>) => void) {
+      const set = listeners.get(type) ?? new Set();
+      set.add(fn);
+      listeners.set(type, set);
+    },
+    removeEventListener(type: ToolEvent, fn: (params: Record<string, unknown>) => void) {
+      listeners.get(type)?.delete(fn);
+    },
+    emit(type: ToolEvent, params: Record<string, unknown>) {
+      for (const fn of listeners.get(type) ?? []) fn(params);
+      const handler = obj[`on${type}`];
+      if (typeof handler === 'function') handler(params);
+    },
+  };
+  return obj as unknown as FakeApp;
 }
 
 function wrapper(app: App | null) {
@@ -25,7 +46,7 @@ describe('useToolData eager-store integration', () => {
     const app = fakeApp();
     initToolDataStore(app);
     // Host fires the result before any React commit — the bug this PR fixes.
-    app.ontoolresult!({
+    app.emit('toolresult', {
       structuredContent: { greeting: 'hello' },
       content: [],
       isError: false,
@@ -51,7 +72,7 @@ describe('useToolData eager-store integration', () => {
     expect(result.current.isLoading).toBe(true);
 
     act(() => {
-      app.ontoolresult!({
+      app.emit('toolresult', {
         structuredContent: { greeting: 'late' },
         content: [],
         isError: false,
@@ -75,7 +96,7 @@ describe('useToolData eager-store integration', () => {
     expect(result.current.isLoading).toBe(true);
 
     act(() => {
-      app.ontoolresult!({
+      app.emit('toolresult', {
         structuredContent: { lazy: true },
         content: [],
         isError: false,
@@ -96,6 +117,32 @@ describe('useToolData eager-store integration', () => {
 
     expect(result.current.input).toEqual({ q: 'seed' });
     expect(result.current.output).toEqual({ items: ['a'] });
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('keeps useToolData subscribed when a user also assigns ontoolresult', () => {
+    const app = fakeApp();
+    initToolDataStore(app);
+    let userResult: Record<string, unknown> | undefined;
+    app.ontoolresult = (params) => {
+      userResult = params as Record<string, unknown>;
+    };
+
+    const { result } = renderHook(() => useToolData(), {
+      wrapper: wrapper(app),
+    });
+
+    const payload = {
+      structuredContent: { composed: true },
+      content: [],
+      isError: false,
+    };
+    act(() => {
+      app.emit('toolresult', payload);
+    });
+
+    expect(userResult).toBe(payload);
+    expect(result.current.output).toEqual({ composed: true });
     expect(result.current.isLoading).toBe(false);
   });
 });

--- a/packages/sunpeak/src/hooks/use-tool-data.ts
+++ b/packages/sunpeak/src/hooks/use-tool-data.ts
@@ -50,24 +50,24 @@ function getStore<TInput, TOutput>(
       for (const fn of lazy.listeners) fn();
     };
 
-    app.ontoolinput = (_params) => {
+    app.addEventListener('toolinput', (_params) => {
       lazy.data = {
         ...lazy.data,
         input: _params.arguments as TInput,
         inputPartial: null,
       };
       notify();
-    };
+    });
 
-    app.ontoolinputpartial = (_params) => {
+    app.addEventListener('toolinputpartial', (_params) => {
       lazy.data = {
         ...lazy.data,
         inputPartial: _params.arguments as TInput,
       };
       notify();
-    };
+    });
 
-    app.ontoolresult = (_params) => {
+    app.addEventListener('toolresult', (_params) => {
       lazy.data = {
         ...lazy.data,
         output: (_params.structuredContent ?? _params.content) as TOutput,
@@ -75,9 +75,9 @@ function getStore<TInput, TOutput>(
         isLoading: false,
       };
       notify();
-    };
+    });
 
-    app.ontoolcancelled = (_params) => {
+    app.addEventListener('toolcancelled', (_params) => {
       lazy.data = {
         ...lazy.data,
         isCancelled: true,
@@ -85,7 +85,7 @@ function getStore<TInput, TOutput>(
         isLoading: false,
       };
       notify();
-    };
+    });
   }
   return store;
 }


### PR DESCRIPTION
Updates useToolData's eager and lazy tool-data stores to subscribe with composable App event listeners instead of replacing single ontool handlers. This preserves user handlers registered through onAppCreated while still catching early tool notifications before React consumers mount. Adds regression coverage for user-assigned ontoolresult handlers coexisting with useToolData.\n\nTests: pnpm -C packages/sunpeak typecheck; pnpm -C packages/sunpeak exec vitest run src/hooks; pnpm -C packages/sunpeak lint