### PR TITLE
Add auth headers for sunpeak inspect

### DIFF
--- a/docs/testing/cli/inspect.mdx
+++ b/docs/testing/cli/inspect.mdx
@@ -22,12 +22,16 @@ sunpeak inspect --server <url-or-command>
 | `--name <string>` | | App name displayed in inspector chrome |
 | `--env <KEY=VALUE>` | | Environment variable for stdio servers (repeatable) |
 | `--cwd <path>` | | Working directory for stdio servers |
+| `--header <Name: value>` | `-H` | HTTP header for HTTP MCP servers (repeatable) |
 
 ## Examples
 
 ```bash
 # Connect to an HTTP MCP server
 sunpeak inspect --server http://localhost:8000/mcp
+
+# Pass an Authorization header to an HTTP MCP server
+sunpeak inspect --server http://localhost:8000/mcp -H "Authorization: Bearer $TOKEN"
 
 # Connect to a stdio MCP server
 sunpeak inspect --server "python my_server.py"
@@ -51,6 +55,16 @@ sunpeak inspect --server http://localhost:8000/mcp --simulations tests/simulatio
 
 - **HTTP/SSE**: URLs starting with `http://` or `https://` connect via Streamable HTTP transport
 - **Stdio**: Any other string is parsed as a shell command and connects via stdio transport (e.g., `"python my_server.py"`, `"node server.js"`)
+
+## Authentication
+
+sunpeak auto-negotiates MCP OAuth when the server returns 401 Unauthorized and publishes standard MCP OAuth metadata. If you already have a token, pass it as an HTTP header:
+
+```bash
+sunpeak inspect --server http://localhost:8000/mcp -H "Authorization: Bearer $TOKEN"
+```
+
+You can repeat `--header` for other HTTP auth schemes or tenant headers.
 
 ## Combining with Simulations
 

--- a/docs/testing/inspector.mdx
+++ b/docs/testing/inspector.mdx
@@ -33,12 +33,16 @@ sunpeak inspect --server <url-or-command>
 | `--server <url>` | HTTP URL or stdio command for the MCP server |
 | `--env KEY=VALUE` | Set an environment variable for stdio server processes. Repeatable. |
 | `--cwd <path>` | Working directory for stdio server processes |
+| `--header "Name: value"` | Set an HTTP header for HTTP MCP server requests. Repeatable. |
 
 Examples:
 
 ```bash
 # HTTP server
 sunpeak inspect --server http://localhost:8000/mcp
+
+# HTTP server with a bearer token
+sunpeak inspect --server http://localhost:8000/mcp -H "Authorization: Bearer $TOKEN"
 
 # Python stdio server with env vars
 sunpeak inspect --server "python server.py" --env DATABASE_URL=sqlite:///test.db --env DEBUG=1
@@ -52,6 +56,12 @@ sunpeak inspect --server "python server.py" --cwd ./my-server
 sunpeak auto-negotiates MCP OAuth when connecting to servers that return 401 Unauthorized. For servers with auto-approved (anonymous) OAuth, this happens without user interaction. For servers requiring interactive login, sunpeak opens the authorization URL in your browser and waits for the callback.
 
 No configuration is needed. sunpeak follows the [MCP OAuth specification](https://spec.modelcontextprotocol.io), discovering metadata from `/.well-known/oauth-protected-resource` and registering a client dynamically.
+
+If you already have a token, pass it directly:
+
+```bash
+sunpeak inspect --server http://localhost:8000/mcp -H "Authorization: Bearer $TOKEN"
+```
 
 ## Import
 

--- a/packages/sunpeak/bin/commands/inspect.mjs
+++ b/packages/sunpeak/bin/commands/inspect.mjs
@@ -44,6 +44,7 @@ function parseArgs(args) {
     name: undefined,
     env: undefined,
     cwd: undefined,
+    headers: undefined,
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -66,6 +67,10 @@ function parseArgs(args) {
       }
     } else if (arg === '--cwd' && i + 1 < args.length) {
       opts.cwd = args[++i];
+    } else if ((arg === '--header' || arg === '-H') && i + 1 < args.length) {
+      opts.headers = opts.headers || {};
+      const [name, value] = parseHttpHeader(args[++i]);
+      setHttpHeader(opts.headers, name, value);
     } else if (arg === '--help' || arg === '-h') {
       printHelp();
       process.exit(0);
@@ -89,14 +94,50 @@ Options:
   --name <string>            App name in inspector chrome
   --env <KEY=VALUE>          Environment variable for stdio servers (repeatable)
   --cwd <path>               Working directory for stdio servers
+  --header, -H <Name: value> HTTP header for HTTP MCP servers (repeatable)
   --help, -h                 Show this help
 
 Examples:
   sunpeak inspect --server http://localhost:8000/mcp
+  sunpeak inspect --server http://localhost:8000/mcp -H "Authorization: Bearer $TOKEN"
   sunpeak inspect --server "python my_server.py"
   sunpeak inspect --server "python server.py" --env API_KEY=sk-123 --cwd ./backend
   sunpeak inspect --server http://localhost:8000/mcp --simulations tests/simulations
 `);
+}
+
+function setHttpHeader(headers, name, value) {
+  const lowerName = name.toLowerCase();
+  for (const existingName of Object.keys(headers)) {
+    if (existingName.toLowerCase() === lowerName) {
+      delete headers[existingName];
+    }
+  }
+  headers[name] = value;
+}
+
+function parseHttpHeader(raw) {
+  if (typeof raw !== 'string') {
+    throw new Error('Invalid --header value. Expected "Name: value".');
+  }
+  const separator = raw.indexOf(':');
+  if (separator <= 0) {
+    throw new Error('Invalid --header value. Expected "Name: value".');
+  }
+
+  const name = raw.slice(0, separator).trim();
+  const value = raw.slice(separator + 1).trim();
+  if (!/^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/.test(name)) {
+    throw new Error(`Invalid HTTP header name: ${name || '(empty)'}`);
+  }
+  if (/[\u0000-\u001f\u007f]/.test(value)) {
+    throw new Error(`Invalid HTTP header value for ${name}: control characters are not allowed`);
+  }
+  return [name, value];
+}
+
+function hasAuthorizationHeader(headers) {
+  return Object.keys(headers || {}).some((name) => name.toLowerCase() === 'authorization');
 }
 
 /**
@@ -503,6 +544,9 @@ function isAuthError(err) {
   // StreamableHTTPError includes a status code in its message.
   // Check for the specific "401" HTTP status pattern, not substring matches.
   const msg = err.message || '';
+  if (/"statusCode"\s*:\s*401\b/.test(msg)) return true;
+  if (/\bstatus(?:Code)?\s*[:=]\s*401\b/i.test(msg)) return true;
+  if (/\bHTTP\s+401\b/i.test(msg)) return true;
   if (msg.includes('invalid_token')) return true;
 
   // Connection errors (ECONNREFUSED, ETIMEDOUT, etc.) are never auth errors.
@@ -693,11 +737,15 @@ async function assertHttpServerUrlAllowed(
 
 async function resolveHttpRedirectsForMcp(
   serverArg,
-  { enforcePublicHttpUrl = false, fetchFn = fetch, lookupFn = dnsLookup } = {}
+  { enforcePublicHttpUrl = false, fetchFn = fetch, lookupFn = dnsLookup, requestInit } = {}
 ) {
   if (!enforcePublicHttpUrl) {
     try {
-      const probeResponse = await fetchFn(serverArg, { method: 'HEAD', redirect: 'follow' });
+      const probeResponse = await fetchFn(serverArg, {
+        ...(requestInit ?? {}),
+        method: 'HEAD',
+        redirect: 'follow',
+      });
       await probeResponse.body?.cancel?.();
       return probeResponse.url && probeResponse.url !== serverArg ? probeResponse.url : serverArg;
     } catch {
@@ -710,7 +758,11 @@ async function resolveHttpRedirectsForMcp(
   for (let i = 0; i < maxRedirects; i++) {
     let probeResponse;
     try {
-      probeResponse = await fetchFn(currentUrl, { method: 'HEAD', redirect: 'manual' });
+      probeResponse = await fetchFn(currentUrl, {
+        ...(requestInit ?? {}),
+        method: 'HEAD',
+        redirect: 'manual',
+      });
     } catch {
       return currentUrl;
     }
@@ -733,7 +785,7 @@ async function resolveHttpRedirectsForMcp(
 /**
  * Create an MCP client connection.
  * @param {string} serverArg - URL or command string
- * @param {{ type?: 'none' | 'bearer' | 'oauth', bearerToken?: string, authProvider?: import('@modelcontextprotocol/sdk/client/auth.js').OAuthClientProvider, env?: Record<string, string>, cwd?: string, enforcePublicHttpUrl?: boolean }} [authConfig]
+ * @param {{ type?: 'none' | 'bearer' | 'oauth', bearerToken?: string, authProvider?: import('@modelcontextprotocol/sdk/client/auth.js').OAuthClientProvider, headers?: Record<string, string>, env?: Record<string, string>, cwd?: string, enforcePublicHttpUrl?: boolean }} [authConfig]
  * @returns {Promise<{ client: import('@modelcontextprotocol/sdk/client/index.js').Client, transport: import('@modelcontextprotocol/sdk/types.js').Transport, serverUrl?: string, stderrOutput?: string[] }>}
  */
 async function createMcpConnection(serverArg, authConfig) {
@@ -749,10 +801,18 @@ async function createMcpConnection(serverArg, authConfig) {
     const { StreamableHTTPClientTransport } =
       await import('@modelcontextprotocol/sdk/client/streamableHttp.js');
 
+    const requestHeaders = { ...(authConfig?.headers ?? {}) };
+    if (authConfig?.type === 'bearer' && authConfig.bearerToken) {
+      requestHeaders.Authorization = `Bearer ${authConfig.bearerToken}`;
+    }
+
     // Follow redirects (e.g. /mcp → /mcp/) before creating the transport.
     // The MCP SDK transport doesn't follow redirects on its own.
     const finalUrl = await resolveHttpRedirectsForMcp(serverArg, {
       enforcePublicHttpUrl: !!authConfig?.enforcePublicHttpUrl,
+      ...(Object.keys(requestHeaders).length > 0
+        ? { requestInit: { headers: requestHeaders } }
+        : {}),
     });
 
     if (authConfig?.enforcePublicHttpUrl) {
@@ -762,11 +822,6 @@ async function createMcpConnection(serverArg, authConfig) {
     const transportOpts = {};
     if (authConfig?.enforcePublicHttpUrl) {
       transportOpts.requestInit = { redirect: 'manual' };
-    }
-
-    const requestHeaders = {};
-    if (authConfig?.type === 'bearer' && authConfig.bearerToken) {
-      requestHeaders.Authorization = `Bearer ${authConfig.bearerToken}`;
     }
     if (Object.keys(requestHeaders).length > 0) {
       transportOpts.requestInit = {
@@ -2907,6 +2962,9 @@ export const _securityTestExports = {
   normalizeModelId,
   normalizeModelProviderModelId,
   quoteSecurityInteractiveArg,
+  parseHttpHeader,
+  hasAuthorizationHeader,
+  isAuthError,
   readRequestBody,
   resolveHttpRedirectsForMcp,
   shouldAllowPrivateServerUrls,
@@ -2970,6 +3028,7 @@ function readRequestBody(req, { maxBytes = Infinity } = {}) {
  * @param {object} [opts.viteCssConfig] - Vite css config override (e.g., lightningcss customAtRules)
  * @param {Record<string, string>} [opts.env] - Extra environment variables for stdio server processes
  * @param {string} [opts.cwd] - Working directory for stdio server processes
+ * @param {Record<string, string>} [opts.headers] - Extra HTTP headers for HTTP MCP server requests
  */
 export async function inspectServer(opts) {
   const {
@@ -2990,6 +3049,7 @@ export async function inspectServer(opts) {
     viteCssConfig,
     env: serverEnv,
     cwd: serverCwd,
+    headers: serverHeaders,
   } = opts;
 
   // Load favicon from sunpeak package for the inspector UI.
@@ -3017,6 +3077,7 @@ export async function inspectServer(opts) {
   const connectionOpts = {};
   if (serverEnv) connectionOpts.env = serverEnv;
   if (serverCwd) connectionOpts.cwd = serverCwd;
+  if (serverHeaders) connectionOpts.headers = serverHeaders;
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
       mcpConnection = await createMcpConnection(resolvedServerUrl, connectionOpts);
@@ -3029,7 +3090,11 @@ export async function inspectServer(opts) {
       }
 
       // If the server requires OAuth, negotiate it and retry once.
-      if (isAuthError(err) && resolvedServerUrl.startsWith('http')) {
+      if (
+        isAuthError(err) &&
+        resolvedServerUrl.startsWith('http') &&
+        !hasAuthorizationHeader(connectionOpts.headers)
+      ) {
         console.log('Server requires authentication. Negotiating OAuth...');
         try {
           const authProvider = await negotiateOAuth(resolvedServerUrl);
@@ -3416,5 +3481,6 @@ export async function inspect(args) {
     name: opts.name,
     env: opts.env,
     cwd: opts.cwd,
+    headers: opts.headers,
   });
 }

--- a/packages/sunpeak/bin/lib/inspect/inspect-config.d.mts
+++ b/packages/sunpeak/bin/lib/inspect/inspect-config.d.mts
@@ -15,6 +15,14 @@ export interface InspectConfigOptions {
   use?: Record<string, unknown>;
   /** Visual regression testing configuration */
   visual?: VisualConfig;
+  /** HTTP headers for HTTP MCP server requests */
+  headers?: Record<string, string>;
+  /** Server startup timeout in ms */
+  timeout?: number;
+  /** Environment variables for stdio servers */
+  env?: Record<string, string>;
+  /** Working directory for stdio servers */
+  cwd?: string;
 }
 
 /**

--- a/packages/sunpeak/bin/lib/inspect/inspect-config.mjs
+++ b/packages/sunpeak/bin/lib/inspect/inspect-config.mjs
@@ -30,6 +30,7 @@ import { resolveSunpeakBin } from '../resolve-bin.mjs';
  * @param {number} [options.timeout] - Server startup timeout in ms (default: 60000)
  * @param {Record<string, string>} [options.env] - Environment variables for stdio servers
  * @param {string} [options.cwd] - Working directory for stdio servers
+ * @param {Record<string, string>} [options.headers] - HTTP headers for HTTP MCP server requests
  * @returns {import('@playwright/test').PlaywrightTestConfig}
  */
 export function defineInspectConfig(options) {
@@ -44,6 +45,7 @@ export function defineInspectConfig(options) {
     timeout,
     env,
     cwd,
+    headers,
   } = options;
 
   if (!server) {
@@ -65,6 +67,9 @@ export function defineInspectConfig(options) {
         })
       : []),
     ...(cwd ? [cwd.includes(' ') ? `--cwd "${cwd}"` : `--cwd ${cwd}`] : []),
+    ...(headers
+      ? Object.entries(headers).map(([k, v]) => `--header ${shellQuote(`${k}: ${v}`)}`)
+      : []),
     ...(simulationsDir ? [`--simulations ${simulationsDir}`] : []),
     `--port ${port}`,
     ...(name ? [`--name "${name}"`] : []),
@@ -82,4 +87,8 @@ export function defineInspectConfig(options) {
       healthUrl: `http://127.0.0.1:${port}/health`,
     },
   });
+}
+
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
 }

--- a/packages/sunpeak/bin/lib/inspect/inspect-server.d.mts
+++ b/packages/sunpeak/bin/lib/inspect/inspect-server.d.mts
@@ -29,4 +29,6 @@ export function inspectServer(opts: {
   env?: Record<string, string>;
   /** Working directory for stdio server processes. */
   cwd?: string;
+  /** HTTP headers for HTTP MCP server requests. */
+  headers?: Record<string, string>;
 }): Promise<void>;

--- a/packages/sunpeak/bin/lib/test/test-config.d.mts
+++ b/packages/sunpeak/bin/lib/test/test-config.d.mts
@@ -12,6 +12,10 @@ export interface ServerConfig {
   url?: string;
   /** Environment variables for the server process. */
   env?: Record<string, string>;
+  /** Working directory for the server process. */
+  cwd?: string;
+  /** HTTP headers for HTTP MCP server requests. */
+  headers?: Record<string, string>;
 }
 
 /**
@@ -55,6 +59,8 @@ export interface TestConfigOptions {
   use?: Record<string, unknown>;
   /** Visual regression testing configuration. */
   visual?: VisualConfig;
+  /** Server startup timeout in ms. */
+  timeout?: number;
 }
 
 /**

--- a/packages/sunpeak/bin/lib/test/test-config.mjs
+++ b/packages/sunpeak/bin/lib/test/test-config.mjs
@@ -28,6 +28,7 @@ import { resolveSunpeakBin } from '../resolve-bin.mjs';
  * @param {string} [options.server.url] - HTTP server URL (alternative to command)
  * @param {Record<string, string>} [options.server.env] - Environment variables
  * @param {string} [options.server.cwd] - Working directory for the server process
+ * @param {Record<string, string>} [options.server.headers] - HTTP headers for HTTP MCP server requests
  * @param {string[]} [options.hosts] - Host shells to test (default: ['chatgpt', 'claude'])
  * @param {string} [options.testDir] - Test directory
  * @param {string} [options.simulationsDir] - Simulations directory for mock data
@@ -126,6 +127,12 @@ function buildInspectCommand({ server, port, sandboxPort, simulationsDir }) {
     parts.push(server.cwd.includes(' ') ? `--cwd "${server.cwd}"` : `--cwd ${server.cwd}`);
   }
 
+  if (server.headers) {
+    for (const [key, value] of Object.entries(server.headers)) {
+      parts.push(`--header ${shellQuote(`${key}: ${value}`)}`);
+    }
+  }
+
   if (simulationsDir) {
     parts.push(`--simulations ${simulationsDir}`);
   }
@@ -133,4 +140,8 @@ function buildInspectCommand({ server, port, sandboxPort, simulationsDir }) {
   parts.push(`--port ${port}`);
 
   return parts.join(' ');
+}
+
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
 }

--- a/packages/sunpeak/bin/sunpeak.js
+++ b/packages/sunpeak/bin/sunpeak.js
@@ -131,6 +131,7 @@ Inspector (works with any MCP server):
   sunpeak inspect          Inspect any MCP server in the inspector
     --server, -s <url|cmd> MCP server URL or stdio command (required)
     --simulations <dir>    Simulation JSON directory
+    --header, -H <header>  HTTP header for HTTP MCP servers (repeatable)
 
   sunpeak --version        Show version number
   Resources: ${resources.join(', ')} (comma/space separated)

--- a/packages/sunpeak/src/cli/inspect.test.ts
+++ b/packages/sunpeak/src/cli/inspect.test.ts
@@ -50,6 +50,18 @@ describe('defineConfig (external server)', () => {
     expect(config.webServer.command).toContain('--cwd ./backend');
   });
 
+  it('passes HTTP headers as --header flags', async () => {
+    const { defineConfig } = await importTestConfig();
+    const config = defineConfig({
+      server: {
+        url: 'http://localhost:8000/mcp',
+        headers: { Authorization: 'Bearer test-token' },
+      },
+    });
+
+    expect(config.webServer.command).toContain("--header 'Authorization: Bearer test-token'");
+  });
+
   it('uses custom timeout', async () => {
     const { defineConfig } = await importTestConfig();
     const config = defineConfig({
@@ -178,6 +190,16 @@ describe('defineInspectConfig', () => {
     expect(config.webServer.command).toContain('--cwd ./backend');
   });
 
+  it('passes HTTP headers as --header flags', async () => {
+    const { defineInspectConfig } = await importInspectConfig();
+    const config = defineInspectConfig({
+      server: 'http://localhost:8000/mcp',
+      headers: { Authorization: 'Bearer test-token' },
+    });
+
+    expect(config.webServer.command).toContain("--header 'Authorization: Bearer test-token'");
+  });
+
   it('quotes cwd paths that contain spaces', async () => {
     const { defineInspectConfig } = await importInspectConfig();
     const config = defineInspectConfig({
@@ -239,26 +261,21 @@ describe('defineInspectConfig', () => {
 });
 
 describe('isAuthError', () => {
-  // isAuthError is not exported, so we re-implement the same logic to verify
-  // the detection patterns are correct. Keep this in sync with inspect.mjs.
-  const isAuthError = (err: Error) => {
-    if (err.constructor?.name === 'UnauthorizedError') return true;
-    const msg = err.message || '';
-    if (msg.includes('invalid_token')) return true;
-    if (msg.includes('ECONNREFUSED') || msg.includes('ETIMEDOUT') || msg.includes('ENOTFOUND')) {
-      return false;
-    }
-    return false;
+  const loadIsAuthError = async () => {
+    const { _securityTestExports } = await import('../../bin/commands/inspect.mjs');
+    return _securityTestExports.isAuthError;
   };
 
-  it('detects invalid_token error', () => {
+  it('detects invalid_token error', async () => {
+    const isAuthError = await loadIsAuthError();
     const err = new Error(
       'Streamable HTTP error: Error POSTing to endpoint: {"error":"invalid_token"}'
     );
     expect(isAuthError(err)).toBe(true);
   });
 
-  it('detects UnauthorizedError by class name', () => {
+  it('detects UnauthorizedError by class name', async () => {
+    const isAuthError = await loadIsAuthError();
     class UnauthorizedError extends Error {
       constructor() {
         super('Unauthorized');
@@ -267,22 +284,40 @@ describe('isAuthError', () => {
     expect(isAuthError(new UnauthorizedError())).toBe(true);
   });
 
-  it('does not match ECONNREFUSED', () => {
+  it('detects Streamable HTTP 401 JSON status messages', async () => {
+    const isAuthError = await loadIsAuthError();
+    const err = new Error(
+      'Streamable HTTP error: Error POSTing to endpoint: {"statusCode":401,"message":"Authentication is required"}'
+    );
+    expect(isAuthError(err)).toBe(true);
+  });
+
+  it('detects HTTP 401 text messages', async () => {
+    const isAuthError = await loadIsAuthError();
+    expect(isAuthError(new Error('HTTP 401 Unauthorized'))).toBe(true);
+    expect(isAuthError(new Error('status=401'))).toBe(true);
+  });
+
+  it('does not match ECONNREFUSED', async () => {
+    const isAuthError = await loadIsAuthError();
     const err = new Error('connect ECONNREFUSED 127.0.0.1:8000');
     expect(isAuthError(err)).toBe(false);
   });
 
-  it('does not match ETIMEDOUT', () => {
+  it('does not match ETIMEDOUT', async () => {
+    const isAuthError = await loadIsAuthError();
     const err = new Error('connect ETIMEDOUT 10.0.0.1:443');
     expect(isAuthError(err)).toBe(false);
   });
 
-  it('does not match generic errors', () => {
+  it('does not match generic errors', async () => {
+    const isAuthError = await loadIsAuthError();
     const err = new Error('Something went wrong');
     expect(isAuthError(err)).toBe(false);
   });
 
-  it('does not false-positive on URLs containing 401', () => {
+  it('does not false-positive on URLs containing 401', async () => {
+    const isAuthError = await loadIsAuthError();
     const err = new Error('Failed to fetch http://example.com/path/4014');
     expect(isAuthError(err)).toBe(false);
   });
@@ -439,6 +474,27 @@ describe('inspect endpoint security helpers', () => {
     expect(fetchFn).toHaveBeenCalledTimes(2);
   });
 
+  it('passes configured headers to MCP redirect probes', async () => {
+    const { _securityTestExports } = await importInspectCommand();
+    const fetchFn = vi.fn(async () => new Response(null, { status: 200 }));
+
+    await expect(
+      _securityTestExports.resolveHttpRedirectsForMcp('https://mcp.example.com/mcp', {
+        fetchFn,
+        requestInit: { headers: { Authorization: 'Bearer test-token' } },
+      })
+    ).resolves.toBe('https://mcp.example.com/mcp');
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      'https://mcp.example.com/mcp',
+      expect.objectContaining({
+        method: 'HEAD',
+        redirect: 'follow',
+        headers: { Authorization: 'Bearer test-token' },
+      })
+    );
+  });
+
   it('accepts anonymous OAuth redirects only when state matches', async () => {
     const { _securityTestExports } = await importInspectCommand();
     const fetchFn = vi.fn(async () => {
@@ -502,6 +558,31 @@ describe('inspect endpoint security helpers', () => {
     expect(_securityTestExports.quoteSecurityInteractiveArg("abc' def")).toBe("'abc'\\'' def'");
     expect(_securityTestExports.quoteSecurityInteractiveArg('$(security dump-keychain)')).toBe(
       "'$(security dump-keychain)'"
+    );
+  });
+
+  it('parses HTTP header CLI values', async () => {
+    const { _securityTestExports } = await importInspectCommand();
+
+    expect(_securityTestExports.parseHttpHeader('Authorization: Bearer test-token')).toEqual([
+      'Authorization',
+      'Bearer test-token',
+    ]);
+    expect(_securityTestExports.parseHttpHeader('X-Api-Key: secret')).toEqual([
+      'X-Api-Key',
+      'secret',
+    ]);
+    expect(
+      _securityTestExports.hasAuthorizationHeader({ authorization: 'Bearer test-token' })
+    ).toBe(true);
+    expect(() => _securityTestExports.parseHttpHeader('Authorization Bearer test-token')).toThrow(
+      'Expected "Name: value"'
+    );
+    expect(() => _securityTestExports.parseHttpHeader('Bad Header: value')).toThrow(
+      'Invalid HTTP header name'
+    );
+    expect(() => _securityTestExports.parseHttpHeader('Authorization: bad\nvalue')).toThrow(
+      'control characters'
     );
   });
 


### PR DESCRIPTION
Adds repeatable `--header` / `-H` support for `sunpeak inspect` and forwards those headers through the CLI, programmatic inspect server, and external-server test config helpers. Updates auth detection so 401 status payloads trigger the existing OAuth flow when no manual Authorization header is supplied, and sends configured headers during MCP redirect probes before the transport connects. Documents the new Authorization header usage in the inspect docs and CLI help. Validation: `pnpm --filter sunpeak validate`, then focused reruns of `pnpm --filter sunpeak test -- src/cli/inspect.test.ts --run`, `pnpm --filter sunpeak typecheck`, `pnpm --filter sunpeak lint`, and `git diff --check` after the review fix.