### PR TITLE
Advertise the MCP Apps UI client capability in the inspector

### DIFF
--- a/packages/sunpeak/bin/commands/inspect.mjs
+++ b/packages/sunpeak/bin/commands/inspect.mjs
@@ -824,7 +824,16 @@ async function resolveHttpRedirectsForMcp(
  */
 async function createMcpConnection(serverArg, authConfig) {
   const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
-  const client = new Client({ name: 'sunpeak-inspector', version: '1.0.0' });
+  const client = new Client(
+    { name: 'sunpeak-inspector', version: '1.0.0' },
+    {
+      capabilities: {
+        extensions: {
+          'io.modelcontextprotocol/ui': { mimeTypes: ['text/html;profile=mcp-app'] },
+        },
+      },
+    },
+  );
 
   if (serverArg.startsWith('http://') || serverArg.startsWith('https://')) {
     if (authConfig?.enforcePublicHttpUrl) {


### PR DESCRIPTION
The inspector connects to MCP servers without declaring capabilities.extensions["io.modelcontextprotocol/ui"]. Per the MCP Apps spec, the host advertises which UI resource MIME types it can render, and servers may gate inline UI rendering on that advertisement (returning a text or URL fallback to hosts that don't advertise). Since the inspector renders these resources, it should advertise that it can, otherwise such servers never return the ui:// resource and nothing renders.