### PR TITLE
Fix pnpm setup version conflict in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
       - uses: actions/setup-node@v6
         with:
           node-version: '20'
@@ -41,8 +39,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
       - uses: actions/setup-node@v6
         with:
           node-version: '20'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Update npm
         run: npm install -g npm@latest


### PR DESCRIPTION
## Summary
- Remove explicit pnpm version pins from CI and publish workflows.
- Let pnpm/action-setup use the root packageManager value, pnpm@11.7.0, to avoid duplicate-version failures.

## Verification
- git diff --check
- workflow YAML parsed with Ruby YAML
- pnpm --filter sunpeak typecheck