### PR TITLE
Trigger CI for workflow config changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,16 @@ on:
   push:
     branches: [main]
     paths:
+      - '.github/workflows/**'
+      - 'package.json'
       - 'packages/sunpeak/**'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
   pull_request:
     branches: [main]
     paths:
+      - '.github/workflows/**'
+      - 'package.json'
       - 'packages/sunpeak/**'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
       - name: Run validation
         run: pnpm validate
@@ -45,7 +45,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
       - name: Bump version and tag
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup pnpm


### PR DESCRIPTION
## Summary
- Add workflow files to the CI path filters so CI config fixes start new runs.
- Add root package.json to the path filters because it defines the pnpm packageManager version.
- Run pnpm workflows on Node 22 so pnpm 11.7.0 has a supported runtime.

## Testing
- Parsed .github/workflows/ci.yml and .github/workflows/publish.yml with Ruby YAML.
- Ran git diff --check.
- Ran pnpm validate; package install, format, lint, build, typecheck, unit tests, docs validation, package e2e, and example generation passed before the validation wrapper stopped emitting output during generated example tests.