### PR TITLE
Fix main CI version tagging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           cd packages/sunpeak
-          NEW_VERSION=$(pnpm version patch --no-git-tag-version | tail -n 1)
-          NEW_VERSION=${NEW_VERSION#v}
+          pnpm version patch --no-git-tag-version
+          NEW_VERSION=$(node -p "require('./package.json').version")
           cd ../..
           git add packages/sunpeak/package.json
           git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
-          git tag v$NEW_VERSION
+          git tag "v$NEW_VERSION"
           git push origin main
-          git push origin v$NEW_VERSION
+          git push origin "v$NEW_VERSION"


### PR DESCRIPTION
## Summary
- Read the bumped package version from package.json instead of parsing pnpm version output
- Quote the generated tag ref when creating and pushing it

## Testing
- Confirmed the version command writes a bare semver to package.json in a temp package
- Full validate was started and passed format, lint, build, typecheck, unit tests, package e2e, docs validation, and example generation before being stopped during generated-project validation